### PR TITLE
Fix markup validity for header

### DIFF
--- a/templates/_partials/header.tpl
+++ b/templates/_partials/header.tpl
@@ -60,17 +60,11 @@
 {block name='header_top'}
   <div class="{$headerBottomName} navbar navbar-expand-lg">
     <div class="container">
-      {if $page.page_name == 'index'}
-        <a class="navbar-brand" href="{$urls.pages.index}">
-          <h1>
-              <img class="logo img-responsive" src="{$shop.logo.src}" alt="{$shop.name}" loading="lazy" width="{$shop.logo.width}" height="{$shop.logo.height}">
-          </h1>
-        </a>
-      {else}
-        <a class="navbar-brand" href="{$urls.pages.index}">
-          <img class="logo img-responsive" src="{$shop.logo.src}" alt="{$shop.name}" loading="lazy" width="{$shop.logo.width}" height="{$shop.logo.height}">
-        </a>
-      {/if}
+      {if $page.page_name == 'index'}<h1>{/if}
+      <a class="navbar-brand" href="{$urls.pages.index}">
+        <img class="logo img-responsive" src="{$shop.logo.src}" alt="{$shop.name}" loading="lazy" width="{$shop.logo.width}" height="{$shop.logo.height}">
+      </a>
+      {if $page.page_name == 'index'}</h1>{/if}
 
       {hook h='displayTop'}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | `<a><h1></h1></a>` is not W3C valid... Basically, we can't put block elements inside inline elements.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | -
| Possible impacts? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
