### PR TITLE
Fix bugs for icon mirroring in RTL

### DIFF
--- a/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl
+++ b/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl
@@ -28,7 +28,7 @@
         {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-6 col-lg-4 col-xl-3"}
         <div class="best-sellers-products-footer text-center">
             <a class="all-product-link btn btn-outline-primary" href="{$allBestSellers}">
-                {l s='All best sellers' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
+                {l s='All best sellers' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip">&#xE315;</i>
             </a>
         </div>
     </div>

--- a/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
+++ b/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
@@ -30,7 +30,7 @@
 
   <div class="featured-products-footer text-center">
     <a class="all-product-link btn btn-outline-primary" href="{$allProductsLink}">
-      {l s='All products' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
+      {l s='All products' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip">&#xE315;</i>
     </a>
   </div>
 </section>

--- a/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
+++ b/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
@@ -29,7 +29,7 @@
         {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-6 col-lg-4 col-xl-3"}
         <div class="new-products-footer text-center">
             <a class="all-product-link btn btn-outline-primary" href="{$allNewProductsLink}">
-                {l s='All new products' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
+                {l s='All new products' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip">&#xE315;</i>
             </a>
         </div>
     </div>

--- a/modules/ps_specials/views/templates/hook/ps_specials.tpl
+++ b/modules/ps_specials/views/templates/hook/ps_specials.tpl
@@ -29,7 +29,7 @@
         {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-6 col-lg-4 col-xl-3"}
         <div class="sale-products-footer text-center">
             <a class="all-product-link btn btn-outline-primary" href="{$allSpecialProductsLink}">
-                {l s='All sale products' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
+                {l s='All sale products' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip">&#xE315;</i>
             </a>
         </div>
     </div>

--- a/src/scss/partials/_commons.scss
+++ b/src/scss/partials/_commons.scss
@@ -33,7 +33,6 @@ a:not(.alert-link) {
   transition: 0.25s ease-out;
 
   .material-icons {
-    color: $default-icon-color;
     transition: 0.25s ease-out;
   }
 }

--- a/src/scss/partials/_fonts.scss
+++ b/src/scss/partials/_fonts.scss
@@ -1,19 +1,12 @@
-/* stylelint-disable */
 @import "~@fontsource/inter/index.css";
 
 @font-face {
   font-family: "Material Icons";
   font-style: normal;
   font-weight: 400;
+  src: url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.woff2") format("woff2"), url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.woff") format("woff");
   font-display: swap;
-  src: url(~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.eot); /* For IE6-8 */
-  src:
-    local("Material Icons"), local("MaterialIcons-Regular"), url(~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.woff2)
-    format("woff2"), url(~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.woff)
-    format("woff"), url(~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.ttf)
-    format("truetype");
 }
-/* stylelint-enable */
 
 .material-icons {
   display: inline-block;
@@ -33,6 +26,8 @@
   word-wrap: normal;
   white-space: nowrap;
   vertical-align: middle;
+
+  /*! /* @noflip */
   direction: ltr;
 
   /* Support for all WebKit browsers. */
@@ -44,5 +39,4 @@
 
   /* Support for Firefox. */
   -moz-osx-font-smoothing: grayscale;
-
 }

--- a/src/scss/rtl.scss
+++ b/src/scss/rtl.scss
@@ -28,3 +28,8 @@ body {
     transform: scaleX(-1);
   }
 }
+
+.carousel-control-next-icon,
+.carousel-control-prev-icon {
+  transform: scaleX(-1);
+}

--- a/templates/checkout/_partials/steps/addresses.tpl
+++ b/templates/checkout/_partials/steps/addresses.tpl
@@ -114,14 +114,14 @@
 
       <div class="mt-4 d-flex flex-wrap justify-content-between">
         <button class="btn btn-outline-primary btn-with-icon d-block d-md-inline-block me-2 w-full w-md-auto mb-3 mb-md-0 js-back" data-step="checkout-personal-information-step">
-          <div class="material-icons">arrow_backward</div>
+          <div class="material-icons rtl-flip">arrow_backward</div>
           {l s='Continue to Personal Information' d='Shop.Theme.Actions'}
         </button>
 
         {if !$form_has_continue_button}
             <button type="submit" class="btn btn-primary btn-with-icon d-block d-md-inline-block w-full w-md-auto continue" name="confirm-addresses" value="1">
               {l s='Continue to Shipping' d='Shop.Theme.Actions'}
-              <div class="material-icons">arrow_forward</div>
+              <div class="material-icons rtl-flip">arrow_forward</div>
             </button>
             <input type="hidden" id="not-valid-addresses" class="js-not-valid-addresses" value="{$not_valid_addresses}">
         {/if}

--- a/templates/checkout/_partials/steps/payment.tpl
+++ b/templates/checkout/_partials/steps/payment.tpl
@@ -131,7 +131,7 @@
 
   <div class="payment__actions d-block d-md-flex d-flex flex-wrap justify-content-between">
     <button class="btn btn-outline-primary btn-with-icon d-block d-md-inline-block me-2 w-full w-md-auto mb-3 mb-md-0 js-back" data-step="checkout-delivery-step">
-      <div class="material-icons">arrow_backward</div>
+      <div class="material-icons rtl-flip">arrow_backward</div>
       {l s='Back to Shipping method' d='Shop.Theme.Actions'}
     </button>
 
@@ -140,7 +140,7 @@
         <div class="payment__actions">
           <button type="submit" class="btn btn-primary btn-with-icon center-block d-block d-md-inline-block w-full w-md-auto{if !$selected_payment_option} disabled{/if}">
             {l s='Place order' d='Shop.Theme.Checkout'}
-            <div class="material-icons">arrow_forward</div>
+            <div class="material-icons rtl-flip">arrow_forward</div>
           </button>
         </div>
       </div>

--- a/templates/checkout/_partials/steps/personal-information.tpl
+++ b/templates/checkout/_partials/steps/personal-information.tpl
@@ -44,7 +44,7 @@
           value="order"
        > 
           {l s='Continue to Addresses' d='Shop.Theme.Actions'}
-          <div class="material-icons">arrow_forward</div>
+          <div class="material-icons rtl-flip">arrow_forward</div>
         </button>
       </form>
     </div>

--- a/templates/checkout/_partials/steps/shipping.tpl
+++ b/templates/checkout/_partials/steps/shipping.tpl
@@ -117,13 +117,13 @@
 
         <div class="shipping__actions d-flex flex-wrap justify-content-between">
           <button class="btn btn-outline-primary btn-with-icon d-block d-md-inline-block me-2 w-full w-md-auto mb-3 mb-md-0 js-back" data-step="checkout-addresses-step">
-            <div class="material-icons">arrow_backward</div>
+            <div class="material-icons rtl-flip">arrow_backward</div>
             {l s='Back to Addresses' d='Shop.Theme.Actions'}
           </button>
 
           <button type="submit" class="btn btn-primary btn-with-icon d-block d-md-inline-block w-full w-md-auto" name="confirmDeliveryOption" value="1">
             {l s='Continue to Payment' d='Shop.Theme.Actions'}
-            <div class="material-icons">arrow_forward</div>
+            <div class="material-icons rtl-flip">arrow_forward</div>
           </button>
         </div>
       </form>

--- a/templates/checkout/cart-empty.tpl
+++ b/templates/checkout/cart-empty.tpl
@@ -26,7 +26,7 @@
 
 {block name='continue_shopping' append}
   <a class="label" href="{$urls.pages.index}">
-    <i class="material-icons">chevron_left</i>{l s='Continue shopping' d='Shop.Theme.Actions'}
+    <i class="material-icons rtl-flip">chevron_left</i>{l s='Continue shopping' d='Shop.Theme.Actions'}
   </a>
 {/block}
 

--- a/templates/checkout/cart.tpl
+++ b/templates/checkout/cart.tpl
@@ -38,7 +38,7 @@
 
         {block name='continue_shopping'}
           <a class="btn btn-outline-primary" href="{$urls.pages.index}">
-            <i class="material-icons">chevron_left</i>{l s='Continue shopping' d='Shop.Theme.Actions'}
+            <i class="material-icons rtl-flip">chevron_left</i>{l s='Continue shopping' d='Shop.Theme.Actions'}
           </a>
         {/block}
 


### PR DESCRIPTION
1. Some icons need to be flipped for RTL languages (arrow_backward, arrow_forward).

2. There is bugs for some icons when Material Icons direction is RTL
So need to prevent transforming the direction by CSSjanus with `/*! /* @noflip */` comment.
<img src="https://user-images.githubusercontent.com/85633460/164684087-9e04504f-a0e1-4be3-8336-0f0b1db11085.png" width=500>

3. The material icon color inside buttons must be as same as text color
<img src="https://user-images.githubusercontent.com/85633460/164684942-b29e1c33-e274-42a8-b212-4ec2c6f0aeca.png" width=500>


## RTL fixed:
<img src="https://user-images.githubusercontent.com/85633460/164687293-51ae574b-d71b-44eb-a11c-e774b212d5e1.png" width=700>