### PR TITLE
Fix dropdown menu for RTL

### DIFF
--- a/modules/ps_brandlist/views/templates/_partials/brand_form.tpl
+++ b/modules/ps_brandlist/views/templates/_partials/brand_form.tpl
@@ -27,6 +27,7 @@
   <button
     class="btn-unstyle select-title"
     rel="nofollow"
+    data-bs-display="static"
     data-bs-toggle="dropdown"
     aria-haspopup="true"
     aria-expanded="false">

--- a/modules/ps_customersignin/ps_customersignin.tpl
+++ b/modules/ps_customersignin/ps_customersignin.tpl
@@ -27,39 +27,67 @@
   <div class="user-info">
     {if $customer.is_logged}
       <div class="dropdown">
-        <button class="dropdown-toggle btn btn-link btn-with-icon" type="button" id="userMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <i class="material-icons">person</i>
+        <button class="dropdown-toggle btn btn-link btn-with-icon" type="button" id="userMenuButton" data-bs-display="static" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <i class="material-icons">&#xE7FD;</i>
           <span class="user-info__name">{$customerName|truncate:22:"..":true}</span>
         </button>
 
         <div class="dropdown-menu" aria-labelledby="userMenuButton">
-          <a class="dropdown-item" href="{$urls.pages.my_account}">{l s='Your account' d='Shop.Theme.Customeraccount'}</a>
+          <a class="dropdown-item" href="{$urls.pages.my_account}">
+            <i class="material-icons me-2">&#xF02E;</i>
+            {l s='Your account' d='Shop.Theme.Customeraccount'}
+          </a>
           <div class="dropdown-divider"></div>
-          <a href="{$urls.pages.identity}" title="{l s='Information' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">{l s='Information' d='Shop.Theme.Customeraccount'}</a>
+          <a href="{$urls.pages.identity}" title="{l s='Information' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
+            <i class="material-icons me-2">&#xE853;</i>
+            {l s='Information' d='Shop.Theme.Customeraccount'}
+          </a>
           {if $customer.addresses|count}
-            <a href="{$urls.pages.addresses}" title="{l s='Addresses' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">{l s='Addresses' d='Shop.Theme.Customeraccount'}</a>
+            <a href="{$urls.pages.addresses}" title="{l s='Addresses' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
+              <i class="material-icons me-2">&#xE56A;</i>
+              {l s='Addresses' d='Shop.Theme.Customeraccount'}
+            </a>
           {else}
-            <a href="{$urls.pages.address}" title="{l s='Add first address' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">{l s='Add first address' d='Shop.Theme.Customeraccount'}</a>
+            <a href="{$urls.pages.address}" title="{l s='Add first address' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
+              <i class="material-icons me-2">&#xE567;</i>
+              {l s='Add first address' d='Shop.Theme.Customeraccount'}
+            </a>
           {/if}
           {if !$configuration.is_catalog}
-            <a href="{$urls.pages.history}" title="{l s='Orders' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">{l s='Orders' d='Shop.Theme.Customeraccount'}</a>
+            <a href="{$urls.pages.history}" title="{l s='Orders' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
+              <i class="material-icons me-2">&#xE916;</i>
+              {l s='Orders' d='Shop.Theme.Customeraccount'}
+            </a>
           {/if}
           {if !$configuration.is_catalog}
-            <a href="{$urls.pages.order_slip}" title="{l s='Credit slips' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">{l s='Credit slips' d='Shop.Theme.Customeraccount'}</a>
+            <a href="{$urls.pages.order_slip}" title="{l s='Credit slips' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
+              <i class="material-icons me-2">&#xE8B0;</i>
+              {l s='Credit slips' d='Shop.Theme.Customeraccount'}
+            </a>
           {/if}
           {if $configuration.voucher_enabled && !$configuration.is_catalog}
-            <a href="{$urls.pages.discount}" title="{l s='Vouchers' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">{l s='Vouchers' d='Shop.Theme.Customeraccount'}</a>
+            <a href="{$urls.pages.discount}" title="{l s='Vouchers' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
+            <i class="material-icons me-2">&#xE54E;</i>
+            {l s='Vouchers' d='Shop.Theme.Customeraccount'}
+            </a>
           {/if}
           {if $configuration.return_enabled && !$configuration.is_catalog}
-            <a href="{$urls.pages.order_follow}" title="{l s='Merchandise returns' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">{l s='Merchandise returns' d='Shop.Theme.Customeraccount'}</a>
+            <a href="{$urls.pages.order_follow}" title="{l s='Merchandise returns' d='Shop.Theme.Customeraccount'}" class="dropdown-item" rel="nofollow">
+              <i class="material-icons me-2">&#xE860;</i>
+              {l s='Merchandise returns' d='Shop.Theme.Customeraccount'}
+            </a>
           {/if}
           <div class="dropdown-divider"></div>
-          <a class="dropdown-item" href="{$logout_url}">{l s='Sign out' d='Shop.Theme.Actions'}</a>
+          <a class="dropdown-item" href="{$logout_url}">
+            <i class="material-icons me-2">&#xE879;</i>
+            {l s='Sign out' d='Shop.Theme.Actions'}
+          </a>
         </div>
       </div>
     {else}
       <a href="{$urls.pages.my_account}" title="{l s='Log in to your customer account' d='Shop.Theme.Customeraccount'}" class="btn" rel="nofollow" role="button">
-        <i class="material-icons">person</i><span class="d-none d-md-inline">{l s='Sign in' d='Shop.Theme.Actions'}</span>
+        <i class="material-icons me-2">&#xE7FD;</i>
+        <span class="d-none d-md-inline">{l s='Sign in' d='Shop.Theme.Actions'}</span>
       </a>
     {/if}
   </div>

--- a/modules/ps_facetedsearch/views/templates/front/catalog/facets.tpl
+++ b/modules/ps_facetedsearch/views/templates/front/catalog/facets.tpl
@@ -123,7 +123,7 @@
                 <ul class="accordion-body">
                   <li>
                     <div class="facet-dropdown dropdown">
-                      <a class="select-title" rel="nofollow" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                      <a class="select-title" rel="nofollow" data-bs-display="static" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         {$active_found = false}
                         <span>
                           {foreach from=$facet.filters item="filter"}

--- a/modules/ps_supplierlist/views/templates/_partials/supplier_form.tpl
+++ b/modules/ps_supplierlist/views/templates/_partials/supplier_form.tpl
@@ -27,6 +27,7 @@
   <button
     class="btn-unstyle select-title"
     rel="nofollow"
+    data-bs-display="static"
     data-bs-toggle="dropdown"
     aria-haspopup="true"
     aria-expanded="false">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "prestashop-classic-dev-tools",
+  "name": "prestashop-hummingbird-dev-tools",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -12851,11 +12851,6 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
       "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q=="
     },
-    "bootstrap-input-spinner": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/bootstrap-input-spinner/-/bootstrap-input-spinner-3.1.7.tgz",
-      "integrity": "sha512-Ck0d/DmC9c9d6GywSPiQR8OtBuoXDCW+surQeiKgl89Lw2qpqw5x1BRx+WBhXWnxzI4c1uJhTF128OKSj9qWPA=="
-    },
     "bootstrap-touchspin": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/bootstrap-touchspin/-/bootstrap-touchspin-4.3.0.tgz",
@@ -20631,9 +20626,9 @@
       "dev": true
     },
     "material-design-icons-iconfont": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-5.0.1.tgz",
-      "integrity": "sha512-Xg6rIdGrfySTqiTZ6d+nQbcFepS6R4uKbJP0oAqyeZXJY/bX6mZDnOmmUJusqLXfhIwirs0c++a6JpqVa8RFvA=="
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-6.7.0.tgz",
+      "integrity": "sha512-lSj71DgVv20kO0kGbs42icDzbRot61gEDBLQACzkUuznRQBUYmbxzEkGU6dNBb5fRWHMaScYlAXX96HQ4/cJWA=="
     },
     "mathml-tag-names": {
       "version": "2.1.3",
@@ -27300,9 +27295,9 @@
       "dev": true
     },
     "vazirmatn": {
-      "version": "32.101.0",
-      "resolved": "https://registry.npmjs.org/vazirmatn/-/vazirmatn-32.101.0.tgz",
-      "integrity": "sha512-pYgbu8S9qvYLMJv24g2KEAt4Lgo9j/mHE0oMdbe8rlfJ4VkUVYAq99/djiRJc96wPjm/T/n5uTqtAffbVWaZwA=="
+      "version": "32.102.0",
+      "resolved": "https://registry.npmjs.org/vazirmatn/-/vazirmatn-32.102.0.tgz",
+      "integrity": "sha512-Fkvs0Hp5x9zjHTuwog3KEcARhMLxjXd3o3MyD/vBywxYt2LG+4THEHpu6AW8ojfHJAutrxFnDTPB/5hvkX80ww=="
     },
     "vendors": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -83,15 +83,14 @@
     "@popperjs/core": "^2.9.2",
     "@types/jquery": "^3.5.6",
     "bootstrap": "5.1.3",
-    "bootstrap-input-spinner": "^3.1.7",
     "events": "^3.3.0",
     "jquery": "^3.5.1",
     "jquery-touchswipe": "^1.6",
     "jquery.browser": "^0.1.0",
-    "material-design-icons-iconfont": "^5.0.1",
+    "material-design-icons-iconfont": "^6.7.0",
     "nouislider": "^15.5.0",
     "swiper": "^7.4.1",
-    "vazirmatn": "^32.1.0",
+    "vazirmatn": "^32.102.0",
     "wnumb": "^1.2.0"
   }
 }

--- a/src/scss/core/_core.scss
+++ b/src/scss/core/_core.scss
@@ -1,6 +1,7 @@
 // Components
 @import "./components/buttons";
 @import "./components/inputs";
+@import "./components/dropdown";
 @import "./components/slider";
 @import "./components/breadcrumb";
 @import "./components/product/product-miniature";

--- a/src/scss/core/components/_dropdown.scss
+++ b/src/scss/core/components/_dropdown.scss
@@ -1,0 +1,33 @@
+.dropdown-menu {
+  &[data-bs-popper] {
+    a {
+      display: block;
+      padding: 0.75rem 1rem;
+      color: $gray-800;
+      transition: 0.25s ease-out;
+
+      &:hover {
+        background: none;
+        opacity: 0.6;
+      }
+    }
+  }
+}
+
+.wrapper {
+  &__content {
+    .dropdown-menu {
+      &[data-bs-popper] {
+        left: calc(var(--bs-gutter-x) * 0.5);
+      }
+    }
+  }
+}
+
+.facet-dropdown {
+  a {
+    display: block;
+    padding: 0.5rem 0;
+    cursor: pointer;
+  }
+}

--- a/src/scss/custom/components/category/_product-list.scss
+++ b/src/scss/custom/components/category/_product-list.scss
@@ -32,18 +32,5 @@
     .sort-by-row {
       align-items: center;
     }
-
-    .dropdown-menu {
-      a {
-        display: block;
-        padding: 0.75rem 1rem;
-        color: $gray-800;
-        transition: 0.25s ease-out;
-
-        &:hover {
-          opacity: 0.6;
-        }
-      }
-    }
   }
 }

--- a/src/scss/custom/layout/_header.scss
+++ b/src/scss/custom/layout/_header.scss
@@ -4,7 +4,7 @@ $component-name: header;
   & &__top {
     border-bottom: 1px solid $gray-200;
 
-    a {
+    a:not(.dropdown-item) {
       color: $body-color;
 
       &:hover {

--- a/src/scss/partials/_variables.scss
+++ b/src/scss/partials/_variables.scss
@@ -18,7 +18,7 @@
 @import "variables/bootstrap/forms";
 @import "variables/bootstrap/accordion";
 @import "variables/bootstrap/headings";
-
+@import "variables/bootstrap/dropdown";
 @import "variables/prestashop/carousel";
 
 // Import bootstrap partials

--- a/src/scss/partials/variables/bootstrap/_dropdown.scss
+++ b/src/scss/partials/variables/bootstrap/_dropdown.scss
@@ -1,0 +1,1 @@
+$dropdown-divider-margin-y: $spacer * 0.375;

--- a/templates/catalog/_partials/facets.tpl
+++ b/templates/catalog/_partials/facets.tpl
@@ -123,7 +123,7 @@
             <ul id="facet_{$_expand_id}" class="collapse{if !$_collapse} in{/if}">
               <li>
                 <div class="facet-dropdown dropdown">
-                  <a class="select-title" rel="nofollow" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <a class="select-title" rel="nofollow" data-bs-display="static" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     {$active_found = false}
                     <span>
                       {foreach from=$facet.filters item="filter"}

--- a/templates/catalog/_partials/sort-orders.tpl
+++ b/templates/catalog/_partials/sort-orders.tpl
@@ -28,6 +28,7 @@
   <button
     class="btn-unstyle select-title"
     rel="nofollow"
+    data-bs-display="static"
     data-bs-toggle="dropdown"
     aria-haspopup="true"
     aria-expanded="false">

--- a/templates/customer/my-account.tpl
+++ b/templates/customer/my-account.tpl
@@ -97,7 +97,7 @@
   </div>
 
   <a class="{$componentName}__logout hidden-on-desktop" href="{$urls.actions.logout}">
-    <i class="material-icons me-2">exit_to_app</i>
+    <i class="material-icons me-2">&#xE879;</i>
     {l s='Sign out' d='Shop.Theme.Actions'}
   </a>
 {/block}


### PR DESCRIPTION
Using static display for dropdown menu (popper.js will be disabled so bugs for RTL will be fixed)
The goal of this change is that not to use `!important` for fixing bugs in RTL (popper.js uses inline style for dropdown positioning).

![Screenshot from 2022-04-23 14-06-39](https://user-images.githubusercontent.com/85633460/164890889-9acb3bbe-6d2d-48c3-b637-38fc4c8f281d.png)

![Screenshot from 2022-04-23 14-08-20](https://user-images.githubusercontent.com/85633460/164890894-72793d03-e0cd-44d5-b698-eea38673d4a0.png)

![Screenshot from 2022-04-23 14-16-18](https://user-images.githubusercontent.com/85633460/164890901-ee7ea7cf-cdef-4bb9-a63b-bed426b55f99.png)

## RTL fixed

![Screenshot from 2022-04-23 14-08-36](https://user-images.githubusercontent.com/85633460/164890896-47b29848-8b79-4c77-95e3-ffe74e963204.png)