### PR TITLE
Change primary color to a more neutral color

### DIFF
--- a/src/scss/custom/layout/_footer.scss
+++ b/src/scss/custom/layout/_footer.scss
@@ -1,5 +1,5 @@
 $component-name: footer;
-$footer-background-color: #011638 !default;
+$footer-background-color: #16181c !default;
 $footer-heading-color: $white !default;
 $footer-text-color: $body-color !default;
 

--- a/src/scss/partials/variables/bootstrap/_variable-overrides.scss
+++ b/src/scss/partials/variables/bootstrap/_variable-overrides.scss
@@ -1,5 +1,5 @@
 // IT IS FORBIDDEN TO USE REFERENCES TO BS5 VARIABLES BECAUSE THEY ARE NOT YET DECLARED.
-$primary: #5434d0;
+$primary: #16181c;
 $secondary: #f39d72;
 $success: #21834d;
 $warning: #ff9a52;

--- a/src/scss/partials/variables/prestashop/_colors.scss
+++ b/src/scss/partials/variables/prestashop/_colors.scss
@@ -2,7 +2,7 @@
 $default-icon-color: #6c868e;
 
 // Footer
-$footer-background-color: #011638;
+$footer-background-color: #16181c;
 $footer-heading-color: $white;
 $footer-text-color: $gray-300;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | As per mockups, we wants to kick the current primary color and replace it by a neutral color, I believe this is a right choice, because it makes the theme as neutral as possible from any stakeholder
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No need

<img width="1398" alt="image" src="https://user-images.githubusercontent.com/14963751/165526164-813fe7cb-5aad-4999-be17-d24809cae4bc.png">
<img width="1336" alt="image" src="https://user-images.githubusercontent.com/14963751/165526190-e8ea985e-b61e-4967-8915-9f5bab872842.png">
<img width="1391" alt="image" src="https://user-images.githubusercontent.com/14963751/165526242-8e765cfe-225a-40a9-a3a2-190fceb9758f.png">
<img width="1349" alt="image" src="https://user-images.githubusercontent.com/14963751/165526342-f18b1b09-2077-41e7-bda5-67e661d69dfc.png">
<img width="1349" alt="image" src="https://user-images.githubusercontent.com/14963751/165526747-7f9905df-b2c3-4135-a033-5ddb1dda0eb2.png">


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
