### PR TITLE
Fix typographic base for BS

### DIFF
--- a/src/scss/partials/_commons.scss
+++ b/src/scss/partials/_commons.scss
@@ -10,7 +10,6 @@ html {
 
 body {
   font-family: $font-family-base;
-  line-height: 1.25em;
   color: $body-color;
   direction: ltr;
   -webkit-font-smoothing: antialiased;

--- a/src/scss/partials/variables/bootstrap/_fonts.scss
+++ b/src/scss/partials/variables/bootstrap/_fonts.scss
@@ -1,1 +1,3 @@
 $font-family-base: inter, sans-serif;
+$font-size-base: 1;
+$line-height-base: 1.25;


### PR DESCRIPTION
Some components use `$line-height-base` for alignment, so it must be defined.
Using `line-height` in body definition leads to some bugs in components (e.g. label):

| Current | Fixed |
| :---:        |     :---:      |
| <img src="https://user-images.githubusercontent.com/85633460/165747851-0ba950b5-9dc3-4709-9ad1-454708a3919d.png" width=350>   | <img src="https://user-images.githubusercontent.com/85633460/165747974-f11bcf44-786e-4bdf-add2-a9072289c112.png" width=350>  |