### PR TITLE
Fix search-bar icon for RTL

### DIFF
--- a/src/scss/core/components/_search.scss
+++ b/src/scss/core/components/_search.scss
@@ -103,11 +103,13 @@ $component-name: search;
 
 .header__bottom,
 .#{$component-name}__offcanvas {
-  // stylelint-disable-next-line
+  // stylelint-disable-next-line, selector-id-pattern
   #search_widget {
+    min-width: 20rem;
     overflow: visible;
 
     input {
+      height: 2.5rem;
       padding-right: 2.5rem;
       padding-left: 1.5rem;
       background: $gray-100;

--- a/src/scss/core/components/_search.scss
+++ b/src/scss/core/components/_search.scss
@@ -108,15 +108,18 @@ $component-name: search;
     min-width: 20rem;
     overflow: visible;
 
+    @include media-breakpoint-down(md) {
+      min-width: inherit;
+    }
+
     input {
       height: 2.5rem;
-      padding-right: 2.5rem;
+      padding-right: 3.5rem;
       padding-left: 1.5rem;
       background: $gray-100;
       border-radius: 100rem;
 
       @include media-breakpoint-down(md) {
-        padding-right: 4.5rem;
         font-size: 0.9rem;
       }
     }

--- a/src/scss/rtl.scss
+++ b/src/scss/rtl.scss
@@ -37,3 +37,10 @@ body {
 .dropdown-menu-start {
   --bs-position: end;
 }
+
+// stylelint-disable-next-line, selector-id-pattern
+#search_widget {
+  .search {
+    transform: translateX(-1rem);
+  }
+}


### PR DESCRIPTION
Fix search icon position in search-bar for RTL.
Unifies the search-bar display between LTR and RTL (height and width).

| Current | Fixed |
| :---:        |     :---:      |
| <img src="https://user-images.githubusercontent.com/85633460/165754744-f14685ec-515e-4281-b960-b4ea1e936bb1.png" width=350>   | <img src="https://user-images.githubusercontent.com/85633460/165754648-b41174b7-8b8b-4017-a277-500982e9c481.png" width=350>  |