### PR TITLE
Move window.prestashop.themeSelectors selectors to window.Theme.selectors

### DIFF
--- a/src/js/mobile-menu.ts
+++ b/src/js/mobile-menu.ts
@@ -6,8 +6,8 @@
 import {isHTMLElement} from '@helpers/typeguards';
 
 const initMobileMenu = () => {
-  const {prestashop} = window;
-  const {mobileMenu: MobileMenuMap} = prestashop.themeSelectors;
+  const {Theme} = window;
+  const {mobileMenu: MobileMenuMap} = Theme.selectors;
 
   const openChildsButtons = document.querySelectorAll(MobileMenuMap.openChildsButton);
   const backTitle = document.querySelector(MobileMenuMap.backTitle);

--- a/src/js/modules/blockcart.ts
+++ b/src/js/modules/blockcart.ts
@@ -6,11 +6,11 @@ import {Modal} from 'bootstrap';
 import {isHTMLElement} from '@helpers/typeguards';
 
 const {prestashop} = window;
-const {Theme} = window;
 
 prestashop.blockcart = prestashop.blockcart || {};
 
 prestashop.blockcart.showModal = (html: string) => {
+  const {Theme} = window;
   const {blockcart: BlockcartMap} = Theme.selectors;
 
   function getBlockCartModal() {

--- a/src/js/modules/blockcart.ts
+++ b/src/js/modules/blockcart.ts
@@ -6,11 +6,12 @@ import {Modal} from 'bootstrap';
 import {isHTMLElement} from '@helpers/typeguards';
 
 const {prestashop} = window;
+const {Theme} = window;
 
 prestashop.blockcart = prestashop.blockcart || {};
 
 prestashop.blockcart.showModal = (html: string) => {
-  const {blockcart: BlockcartMap} = prestashop.themeSelectors;
+  const {blockcart: BlockcartMap} = Theme.selectors;
 
   function getBlockCartModal() {
     const blockCartModal = document.querySelector<HTMLElement>(BlockcartMap.modal);

--- a/src/js/modules/facetedsearch/index.ts
+++ b/src/js/modules/facetedsearch/index.ts
@@ -8,10 +8,9 @@ import wNumb from 'wnumb';
 import initFacets from './update';
 import filterHandler from './filter-handler';
 
-const {prestashop} = window;
-const {Theme} = window;
-
 const initSliders = () => {
+  const {Theme} = window;
+
   document.querySelectorAll(Theme.selectors.facetedsearch.filterSlider).forEach((filter: HTMLElement) => {
     const container = <target>filter.querySelector(Theme.selectors.facetedsearch.rangeContainer);
     const options = JSON.parse(<string>container.dataset.sliderSpecifications);
@@ -81,6 +80,7 @@ const initSliders = () => {
 };
 
 const toggleLoader = (toggle: boolean) => {
+  const {Theme} = window;
   const loader = document.querySelector(Theme.selectors.pageLoader);
 
   if (loader) {
@@ -89,6 +89,7 @@ const toggleLoader = (toggle: boolean) => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
+  const {prestashop} = window;
   initFacets();
   prestashop.on('updateProductList', () => {
     toggleLoader(true);

--- a/src/js/modules/facetedsearch/index.ts
+++ b/src/js/modules/facetedsearch/index.ts
@@ -9,10 +9,11 @@ import initFacets from './update';
 import filterHandler from './filter-handler';
 
 const {prestashop} = window;
+const {Theme} = window;
 
 const initSliders = () => {
-  document.querySelectorAll(prestashop.themeSelectors.facetedsearch.filterSlider).forEach((filter: HTMLElement) => {
-    const container = <target>filter.querySelector(prestashop.themeSelectors.facetedsearch.rangeContainer);
+  document.querySelectorAll(Theme.selectors.facetedsearch.filterSlider).forEach((filter: HTMLElement) => {
+    const container = <target>filter.querySelector(Theme.selectors.facetedsearch.rangeContainer);
     const options = JSON.parse(<string>container.dataset.sliderSpecifications);
     const signPosition = options.positivePattern.indexOf('¤') === 0 ? 'prefix' : 'suffix';
     // const sliderType = container.dataset.sliderSpecifications ? 'price' : 'weight';
@@ -80,7 +81,7 @@ const initSliders = () => {
 };
 
 const toggleLoader = (toggle: boolean) => {
-  const loader = document.querySelector(prestashop.themeSelectors.pageLoader);
+  const loader = document.querySelector(Theme.selectors.pageLoader);
 
   if (loader) {
     loader.classList.toggle('d-none', toggle);

--- a/src/js/modules/facetedsearch/update.ts
+++ b/src/js/modules/facetedsearch/update.ts
@@ -3,9 +3,6 @@
  * file that was distributed with this source code.
  */
 
-const {prestashop} = window;
-const {Theme} = window;
-
 // @TODO(NeOMakinG): Refactor this file, it comes from facetedsearch or classic
 export const parseSearchUrl = function (event: {target: HTMLElement}) {
   if (event.target.dataset.searchUrl !== undefined) {
@@ -20,6 +17,8 @@ export const parseSearchUrl = function (event: {target: HTMLElement}) {
 };
 
 export function updateProductListDOM(data: Record<string, never>) {
+  const {Theme} = window;
+
   $(Theme.selectors.listing.searchFilters).replaceWith(
     data.rendered_facets,
   );
@@ -51,6 +50,9 @@ export function updateProductListDOM(data: Record<string, never>) {
 }
 
 export default () => {
+  const {prestashop} = window;
+  const {Theme} = window;
+
   $('body').on(
     'change',
     `${Theme.selectors.listing.searchFilters} input[data-search-url]`,

--- a/src/js/modules/facetedsearch/update.ts
+++ b/src/js/modules/facetedsearch/update.ts
@@ -4,6 +4,7 @@
  */
 
 const {prestashop} = window;
+const {Theme} = window;
 
 // @TODO(NeOMakinG): Refactor this file, it comes from facetedsearch or classic
 export const parseSearchUrl = function (event: {target: HTMLElement}) {
@@ -19,31 +20,31 @@ export const parseSearchUrl = function (event: {target: HTMLElement}) {
 };
 
 export function updateProductListDOM(data: Record<string, never>) {
-  $(prestashop.themeSelectors.listing.searchFilters).replaceWith(
+  $(Theme.selectors.listing.searchFilters).replaceWith(
     data.rendered_facets,
   );
-  $(prestashop.themeSelectors.listing.activeSearchFilters).replaceWith(
+  $(Theme.selectors.listing.activeSearchFilters).replaceWith(
     data.rendered_active_filters,
   );
-  $(prestashop.themeSelectors.listing.listTop).replaceWith(
+  $(Theme.selectors.listing.listTop).replaceWith(
     data.rendered_products_top,
   );
 
   const renderedProducts = $(data.rendered_products);
-  const productSelectors = $(prestashop.themeSelectors.listing.product, renderedProducts);
-  const firstProductClasses = $(prestashop.themeSelectors.listing.product).first().attr('class');
+  const productSelectors = $(Theme.selectors.listing.product, renderedProducts);
+  const firstProductClasses = $(Theme.selectors.listing.product).first().attr('class');
 
   if (productSelectors.length > 0 && firstProductClasses) {
     productSelectors.removeClass().addClass(firstProductClasses);
   }
 
-  $(prestashop.themeSelectors.listing.list).replaceWith(renderedProducts);
+  $(Theme.selectors.listing.list).replaceWith(renderedProducts);
 
-  $(prestashop.themeSelectors.listing.listBottom).replaceWith(
+  $(Theme.selectors.listing.listBottom).replaceWith(
     data.rendered_products_bottom,
   );
   if (data.rendered_products_header) {
-    $(prestashop.themeSelectors.listing.listHeader).replaceWith(
+    $(Theme.selectors.listing.listHeader).replaceWith(
       data.rendered_products_header,
     );
   }
@@ -52,7 +53,7 @@ export function updateProductListDOM(data: Record<string, never>) {
 export default () => {
   $('body').on(
     'change',
-    `${prestashop.themeSelectors.listing.searchFilters} input[data-search-url]`,
+    `${Theme.selectors.listing.searchFilters} input[data-search-url]`,
     (event) => {
       prestashop.emit('updateFacets', parseSearchUrl(event));
     },
@@ -60,13 +61,13 @@ export default () => {
 
   $('body').on(
     'click',
-    prestashop.themeSelectors.listing.searchFiltersClearAll,
+    Theme.selectors.listing.searchFiltersClearAll,
     (event) => {
       prestashop.emit('updateFacets', parseSearchUrl(event));
     },
   );
 
-  $('body').on('click', prestashop.themeSelectors.listing.searchLink, (event) => {
+  $('body').on('click', Theme.selectors.listing.searchLink, (event) => {
     event.preventDefault();
     prestashop.emit(
       'updateFacets',
@@ -74,7 +75,7 @@ export default () => {
     );
   });
 
-  if ($(prestashop.themeSelectors.listing.list).length) {
+  if ($(Theme.selectors.listing.list).length) {
     window.addEventListener('popstate', (e) => {
       const {state} = e;
       window.location.href = state && state.current_url ? state.current_url : history;
@@ -83,7 +84,7 @@ export default () => {
 
   $('body').on(
     'change',
-    `${prestashop.themeSelectors.listing.searchFilters} select`,
+    `${Theme.selectors.listing.searchFilters} select`,
     (event) => {
       const form = $(event.target).closest('form');
       prestashop.emit('updateFacets', `?${form.serialize()}`);

--- a/src/js/modules/ps_currencyselector.ts
+++ b/src/js/modules/ps_currencyselector.ts
@@ -4,8 +4,8 @@
  */
 
 const initCurrencySelector = () => {
-  const {prestashop} = window;
-  const {currencySelector: CurrencySelectorMap} = prestashop.themeSelectors;
+  const {Theme} = window;
+  const {currencySelector: CurrencySelectorMap} = Theme.selectors;
   const languageSelector = document.querySelector<HTMLElement>(CurrencySelectorMap.currencySelector);
 
   languageSelector?.addEventListener('change', (event) => {

--- a/src/js/modules/ps_languageselector.ts
+++ b/src/js/modules/ps_languageselector.ts
@@ -4,8 +4,8 @@
  */
 
 const initLanguageSelector = () => {
-  const {prestashop} = window;
-  const {languageSelector: LanguageSelectorMap} = prestashop.themeSelectors;
+  const {Theme} = window;
+  const {languageSelector: LanguageSelectorMap} = Theme.selectors;
   const languageSelector = document.querySelector<HTMLElement>(LanguageSelectorMap.languageSelector);
 
   languageSelector?.addEventListener('change', (event) => {

--- a/src/js/modules/ps_mainmenu.ts
+++ b/src/js/modules/ps_mainmenu.ts
@@ -12,8 +12,8 @@ const ARROW_LEFT_KEY = 'ArrowLeft';
 const ARROW_RIGHT_KEY = 'ArrowRight';
 
 const initDesktopMenu = () => {
-  const {prestashop} = window;
-  const {desktopMenu: desktopMenuMap} = prestashop.themeSelectors;
+  const {Theme} = window;
+  const {desktopMenu: desktopMenuMap} = Theme.selectors;
 
   /**
    * Handle Mouse and Keyboard events for Submenus.

--- a/src/js/modules/ps_searchbar.ts
+++ b/src/js/modules/ps_searchbar.ts
@@ -7,8 +7,8 @@ import {searchProduct, Result} from '@services/search';
 import debounce from '@helpers/debounce';
 
 const initSearchbar = () => {
-  const {prestashop} = window;
-  const {searchBar: SearchBarMap} = prestashop.themeSelectors;
+  const {Theme} = window;
+  const {searchBar: SearchBarMap} = Theme.selectors;
 
   const searchCanvas = document.querySelector<HTMLElement>(SearchBarMap.searchCanvas);
   const searchWidget = document.querySelector<HTMLElement>(SearchBarMap.searchWidget);

--- a/src/js/pages/cart.ts
+++ b/src/js/pages/cart.ts
@@ -7,8 +7,8 @@ import {Collapse} from 'bootstrap';
 import {isHTMLElement} from '@helpers/typeguards';
 
 export default () => {
-  const {prestashop} = window;
-  const voucherCodes = document.querySelectorAll(prestashop.themeSelectors.cart.discountCode);
+  const {Theme} = window;
+  const voucherCodes = document.querySelectorAll(Theme.selectors.cart.discountCode);
 
   voucherCodes.forEach((voucher) => {
     voucher.addEventListener('click', (event: Event) => {
@@ -16,8 +16,8 @@ export default () => {
 
       if (isHTMLElement(event.currentTarget)) {
         const code = event.currentTarget;
-        const discountInput = document.querySelector(prestashop.themeSelectors.cart.discountName);
-        const formCollapser = new Collapse(document.querySelector(prestashop.themeSelectors.cart.promoCode));
+        const discountInput = document.querySelector(Theme.selectors.cart.discountName);
+        const formCollapser = new Collapse(document.querySelector(Theme.selectors.cart.promoCode));
 
         discountInput.value = code.innerText;
         // Show promo code field

--- a/src/js/pages/checkout.ts
+++ b/src/js/pages/checkout.ts
@@ -7,8 +7,7 @@ import useProgressRing from '@js/components/useProgressRing';
 
 const initCheckout = () => {
   const {prestashop} = window;
-  const {Theme} = window;
-  const {selectors} = Theme;
+  const {Theme: {selectors}} = window;
   const {progressRing: ProgressRingMap, checkout: CheckoutMap} = selectors;
 
   const steps = document.querySelectorAll<HTMLElement>(CheckoutMap.steps.item);

--- a/src/js/pages/checkout.ts
+++ b/src/js/pages/checkout.ts
@@ -7,8 +7,9 @@ import useProgressRing from '@js/components/useProgressRing';
 
 const initCheckout = () => {
   const {prestashop} = window;
-  const {themeSelectors: selectorsMap} = prestashop;
-  const {progressRing: ProgressRingMap, checkout: CheckoutMap} = selectorsMap;
+  const {Theme} = window;
+  const {selectors} = Theme;
+  const {progressRing: ProgressRingMap, checkout: CheckoutMap} = selectors;
 
   const steps = document.querySelectorAll<HTMLElement>(CheckoutMap.steps.item);
   const actionButtons = document.querySelectorAll<HTMLElement>(CheckoutMap.actionsButtons);
@@ -120,8 +121,8 @@ const initCheckout = () => {
             const content = await response.text();
             const contentElement = document.createElement('div');
             contentElement.innerHTML = content;
-            const modalBody = termsModalElement.querySelector(selectorsMap.modalBody);
-            const sanitizedContent = contentElement.querySelector(selectorsMap.pageCms);
+            const modalBody = termsModalElement.querySelector(selectors.modalBody);
+            const sanitizedContent = contentElement.querySelector(selectors.pageCms);
 
             if (sanitizedContent && modalBody) {
               modalBody.innerHTML = sanitizedContent.innerHTML;

--- a/src/js/theme.ts
+++ b/src/js/theme.ts
@@ -2,7 +2,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import selectors from './constants/selectors-map';
+import themeSelectors from './constants/selectors-map';
 import initEmitter from './prestashop';
 import initResponsiveToggler from './responsive-toggler';
 import initQuickview from './quickview';
@@ -57,9 +57,10 @@ export const components = {
   useQuantityInput,
 };
 
+export const selectors = themeSelectors;
+
 export default {
   initResponsiveToggler,
   initQuickview,
   initProductBehavior,
-  selectors,
 };

--- a/src/js/theme.ts
+++ b/src/js/theme.ts
@@ -2,7 +2,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import selectorsMap from './constants/selectors-map';
+import selectors from './constants/selectors-map';
 import initEmitter from './prestashop';
 import initResponsiveToggler from './responsive-toggler';
 import initQuickview from './quickview';
@@ -23,8 +23,6 @@ import './modules/facetedsearch';
 import initDesktopMenu from './modules/ps_mainmenu';
 
 initEmitter();
-
-window.prestashop.themeSelectors = selectorsMap;
 
 $(() => {
   const {prestashop} = window;
@@ -63,4 +61,5 @@ export default {
   initResponsiveToggler,
   initQuickview,
   initProductBehavior,
+  selectors,
 };

--- a/src/js/visible-password.ts
+++ b/src/js/visible-password.ts
@@ -4,8 +4,8 @@
  */
 
 const initVisiblePassword = () => {
-  const {prestashop} = window;
-  const {visiblePassword: visiblePasswordMap} = prestashop.themeSelectors;
+  const {Theme} = window;
+  const {visiblePassword: visiblePasswordMap} = Theme.selectors;
   const visiblePasswordList = document.querySelectorAll(visiblePasswordMap.visiblePassword) as NodeListOf<HTMLElement>;
 
   if (visiblePasswordList.length > 0) {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,5 +1,6 @@
 interface Window { 
   prestashop: any;
+  Theme: any;
   $: JQueryStatic;
   jQuery: JQueryStatic;
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Split Theme and core elements under window variable.
| Type?             | refacto
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #274.
| How to test?      | All the theme should work.
| Possible impacts? | Every selector may be impacted so all the theme could be broken.