### PR TITLE
Improve useQuantityInput and fix minor bug

### DIFF
--- a/src/js/components/useQuantityInput.test.ts
+++ b/src/js/components/useQuantityInput.test.ts
@@ -4,7 +4,7 @@
  */
 
 import initEmitter from '@js/prestashop';
-import selectorsMap from '@constants/selectors-map';
+import {quantityInput as quantityInputMap} from '@constants/selectors-map';
 import resetHTMLBodyContent from '@helpers/resetBody';
 import * as Quantify from '@constants/mocks/useQuantityInput-data';
 import useQuantityInput from './useQuantityInput';
@@ -15,15 +15,15 @@ describe('useQuantityInput', () => {
       resetHTMLBodyContent(Quantify.ProductLineTemplate);
       window.prestashop = {};
       initEmitter();
-      useQuantityInput(selectorsMap.qtyInput.default, Quantify.delay);
+      useQuantityInput(quantityInputMap.default, Quantify.delay);
     });
 
     it('should display error with NOK response', async () => {
       const mockedIncrementFetch = mockedResponse(false);
-      const incrementButton = getHTMLElement<HTMLButtonElement>(selectorsMap.qtyInput.increment);
+      const incrementButton = getHTMLElement<HTMLButtonElement>(quantityInputMap.increment);
       incrementButton.click();
       await debounceTimeout();
-      const productLineAlert = getHTMLElement<HTMLDivElement>(selectorsMap.qtyInput.alert(Quantify.ProductId));
+      const productLineAlert = getHTMLElement<HTMLDivElement>(quantityInputMap.alert(Quantify.AlertId));
       mockedIncrementFetch.mockReset();
 
       expect(productLineAlert.innerHTML).not.toBe('');
@@ -39,7 +39,7 @@ describe('useQuantityInput', () => {
       resetQtyInputValueInDOM(qtyInput, qtyMin, qtyValue);
 
       const mockedIncrementFetch = mockedResponse(true, false, incrementExpectedValue);
-      const incrementButton = getHTMLElement<HTMLButtonElement>(selectorsMap.qtyInput.increment);
+      const incrementButton = getHTMLElement<HTMLButtonElement>(quantityInputMap.increment);
 
       for (let i = 0; i < spamClicks; i += 1) {
         incrementButton.click();
@@ -50,7 +50,7 @@ describe('useQuantityInput', () => {
       mockedIncrementFetch.mockReset();
 
       const mockedDecrementFetch = mockedResponse(true, false, decrementExpectedValue);
-      const decrementButton = getHTMLElement<HTMLButtonElement>(selectorsMap.qtyInput.decrement);
+      const decrementButton = getHTMLElement<HTMLButtonElement>(quantityInputMap.decrement);
       decrementButton.click();
       await debounceTimeout();
       const decreasedValue = qtyInput.value;
@@ -67,7 +67,7 @@ describe('useQuantityInput', () => {
       resetQtyInputValueInDOM(qtyInput, qtyMin, qtyValue);
 
       const mockedDecrementFetch = mockedResponse(true, true, qtyMin);
-      const decrementButton = getHTMLElement<HTMLButtonElement>(selectorsMap.qtyInput.decrement);
+      const decrementButton = getHTMLElement<HTMLButtonElement>(quantityInputMap.decrement);
       decrementButton.click();
       await debounceTimeout();
       const decreasedValue = qtyInput.value;
@@ -81,11 +81,11 @@ describe('useQuantityInput', () => {
       qtyInput.dispatchEvent(new Event('keyup'));
       qtyInput.value = '1';
 
-      const decrementButton = getHTMLElement<HTMLButtonElement>(selectorsMap.qtyInput.decrement);
-      const cancelIcon = getHTMLElement<HTMLElement>(selectorsMap.qtyInput.confirm, decrementButton);
+      const decrementButton = getHTMLElement<HTMLButtonElement>(quantityInputMap.decrement);
+      const cancelIcon = getHTMLElement<HTMLElement>(quantityInputMap.confirm, decrementButton);
 
-      const incrementButton = getHTMLElement<HTMLButtonElement>(selectorsMap.qtyInput.increment);
-      const submitIcon = getHTMLElement<HTMLElement>(selectorsMap.qtyInput.confirm, incrementButton);
+      const incrementButton = getHTMLElement<HTMLButtonElement>(quantityInputMap.increment);
+      const submitIcon = getHTMLElement<HTMLElement>(quantityInputMap.confirm, incrementButton);
 
       expect(cancelIcon.classList.toString()).toEqual(expect.not.stringContaining('d-none'));
       expect(submitIcon.classList.toString()).toEqual(expect.not.stringContaining('d-none'));
@@ -95,10 +95,10 @@ describe('useQuantityInput', () => {
       const qtyInput = getHTMLElement<HTMLInputElement>('input');
       qtyInput.dispatchEvent(new Event('keyup'));
 
-      const decrementButton = getHTMLElement<HTMLButtonElement>(selectorsMap.qtyInput.decrement);
+      const decrementButton = getHTMLElement<HTMLButtonElement>(quantityInputMap.decrement);
       decrementButton.click();
       await debounceTimeout();
-      const cancelIcon = getHTMLElement<HTMLElement>(selectorsMap.qtyInput.confirm, decrementButton);
+      const cancelIcon = getHTMLElement<HTMLElement>(quantityInputMap.confirm, decrementButton);
 
       expect(cancelIcon.classList.toString()).toEqual(expect.stringContaining('d-none'));
     });
@@ -112,7 +112,7 @@ describe('useQuantityInput', () => {
       qtyInput.dispatchEvent(new Event('keyup'));
 
       const mockedIncrementFetch = mockedResponse(true, false, confirmedExpectedValue);
-      const incrementButton = getHTMLElement<HTMLButtonElement>(selectorsMap.qtyInput.increment);
+      const incrementButton = getHTMLElement<HTMLButtonElement>(quantityInputMap.increment);
       incrementButton.click();
       await debounceTimeout();
       const increasedValue = qtyInput.value;
@@ -125,7 +125,7 @@ describe('useQuantityInput', () => {
       const qtyInput = getHTMLElement<HTMLInputElement>('input');
       qtyInput.value = 'dummy';
 
-      const decrementButton = getHTMLElement<HTMLButtonElement>(selectorsMap.qtyInput.decrement);
+      const decrementButton = getHTMLElement<HTMLButtonElement>(quantityInputMap.decrement);
       decrementButton.click();
       await debounceTimeout();
 
@@ -139,7 +139,7 @@ describe('useQuantityInput', () => {
       resetHTMLBodyContent(Quantify.ProductTemplate);
       window.prestashop = {};
       initEmitter();
-      useQuantityInput(selectorsMap.qtyInput.modal, Quantify.delay);
+      useQuantityInput(quantityInputMap.modal, Quantify.delay);
     });
 
     it('should update value on increment/decrement without POST request', () => {
@@ -150,11 +150,11 @@ describe('useQuantityInput', () => {
       const decrementExpectedValue = '1';
       resetQtyInputValueInDOM(qtyInput, qtyMin, qtyValue);
 
-      const incrementButton = getHTMLElement<HTMLButtonElement>(selectorsMap.qtyInput.increment);
+      const incrementButton = getHTMLElement<HTMLButtonElement>(quantityInputMap.increment);
       incrementButton.click();
       const increasedValue = qtyInput.value;
 
-      const decrementButton = getHTMLElement<HTMLButtonElement>(selectorsMap.qtyInput.decrement);
+      const decrementButton = getHTMLElement<HTMLButtonElement>(quantityInputMap.decrement);
       decrementButton.click();
       const decreasedValue = qtyInput.value;
 

--- a/src/js/constants/mocks/useQuantityInput-data.ts
+++ b/src/js/constants/mocks/useQuantityInput-data.ts
@@ -4,11 +4,12 @@
  */
 
 export const delay = 5;
-export const ProductId = 1;
+export const ProductId = '1';
+export const AlertId = '99999';
 
 export const ProductLineTemplate = `
   <div class="product-line">
-    <div id="js-product-line-alert--${ProductId}"></div>
+    <div id="js-product-line-alert--${AlertId}"></div>
     <div class="product-line__informations">
       <div class="row">
         <div class="quantity-button js-quantity-button">
@@ -21,6 +22,7 @@ export const ProductLineTemplate = `
             <input
               data-update-url="#"
               data-product-id="${ProductId}"
+              data-alert-id="${AlertId}"
               value="1"
               min="1"
               type="text"

--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -96,17 +96,18 @@ export const desktopMenu = {
   dropdownItemAnchor: (depth: number) => `.js-menu-desktop a[data-depth="${depth}"]`,
 };
 
+export const quantityInput = {
+  default: '.js-quantity-button',
+  modal: '.modal-dialog .js-quantity-button',
+  increment: '.js-increment-button',
+  decrement: '.js-decrement-button',
+  confirm: '.confirmation',
+  icon: '.material-icons',
+  spinner: '.spinner-border',
+  alert: (param: string): string => `#js-product-line-alert--${param}`,
+};
+
 const selectorsMap = {
-  qtyInput: {
-    default: '.js-quantity-button',
-    modal: '.modal-dialog .js-quantity-button',
-    increment: '.js-increment-button',
-    decrement: '.js-decrement-button',
-    confirm: '.confirmation',
-    icon: '.material-icons',
-    spinner: '.spinner-border',
-    alert: (id: number): string => `#js-product-line-alert--${id}`,
-  },
   alert: {
     selector: '#notifications .container',
     alert: '.alert',
@@ -144,6 +145,7 @@ const selectorsMap = {
   mobileMenu,
   visiblePassword,
   desktopMenu,
+  quantityInput,
 };
 
 export default selectorsMap;

--- a/src/js/quickview.ts
+++ b/src/js/quickview.ts
@@ -2,7 +2,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-import useQuantityInput from './components/useQuantityInput';
+
 import selectorsMap from './constants/selectors-map';
 
 const {prestashop} = window;
@@ -21,7 +21,7 @@ export default function initQuickviews() {
           `#quickview-modal-${resp.product.id}-${resp.product.id_product_attribute}`,
         );
         productModal.modal('show');
-        useQuantityInput(selectorsMap.qtyInput.modal);
+
         productModal.on('hidden.bs.modal', () => {
           productModal.remove();
         });

--- a/src/js/theme.ts
+++ b/src/js/theme.ts
@@ -46,8 +46,6 @@ $(() => {
     initCurrencySelector();
     initDesktopMenu();
   });
-
-  prestashop.on('updatedCart', () => useQuantityInput());
 });
 
 export const components = {

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -24,7 +24,8 @@
   *}
 
 <div class="product-line row">
-  <div id="js-product-line-alert--{$product.id_product}"></div>
+  {assign var=product_line_alert_id value=10|mt_rand:100000}
+  <div id="js-product-line-alert--{$product_line_alert_id}"></div>
   <div class="product-line__image col-4 col-sm-2">
     <a class="product-line__title product-line__item" href="{$product.url}"
       data-id_customization="{$product.id_customization|intval}">
@@ -90,6 +91,7 @@
               "name"=>"product-quantity-spin",
               "data-update-url"=>"{$product.update_quantity_url}",
               "data-product-id"=>"{$product.id_product}",
+              "data-alert-id"=>"{$product_line_alert_id}",
               "value"=>"{$product.quantity}",
               "min"=>"{$product.minimal_quantity}"
             ]


### PR DESCRIPTION
Bug:

If we have multiple product lines for one product, then corresponding alert container can not be found by useQuantityInput.
It's possible to have one product with customizations, so we need to define correct ID for each one.

Improvements:

1. Removed event handling from` theme.ts` and `quickview.ts`
2. Added the update listener only if quantity input has update URL.

## Bug:

https://user-images.githubusercontent.com/85633460/169544498-fc912c16-493a-4b29-a6f1-0c4c2b21fb96.mp4

## Fixed:


https://user-images.githubusercontent.com/85633460/169544521-c05aca1a-62d7-4c83-9f5f-86dbff4fccbc.mp4

