### PR TITLE
Add customization modal for product line

### DIFF
--- a/templates/catalog/_partials/product-customization-modal.tpl
+++ b/templates/catalog/_partials/product-customization-modal.tpl
@@ -20,32 +20,30 @@
     <div class="modal-dialog modal-dialog-scrollable modal-fullscreen-md-down">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title">{l s='Product customization' d='Shop.Theme.Checkout'}</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          <h4 class="modal-title">{l s='Product customization' d='Shop.Theme.Checkout'}</h4>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{l s='Close' d='Shop.Theme.Global'}"></button>
         </div>
         <div class="modal-body">
-          <div class="container-fluid">
-            {foreach from=$product.customizations item="customization"}
-              <div class="row row-cols-1">
-                {foreach from=$customization.fields item="field"}
-                <div class="d-flex flex-column mb-3">
-                  <span class="mb-1 text-dark">{$field.label}</span>
-                  {if $field.type == 'text'}
-                    <p class="mb-0">
-                      {if (int)$field.id_module}
-                        {$field.text nofilter}
-                      {else}
-                        {$field.text}
-                      {/if}
-                    </p>
-                  {elseif $field.type == 'image'}
-                    <img class="align-self-start rounded-3" src="{$field.image.small.url}">
-                  {/if}
-                </div>
-                {/foreach}
+          {foreach from=$product.customizations item="customization"}
+            {foreach from=$customization.fields item="field"}
+              <div class="{$componentName}__line{if !$field@last} mb-3{/if}">
+                <p class="mb-1 text-dark">{$field.label}</p>
+                {if $field.type == 'text'}
+                  <p class="mb-0">
+                    {if $field.id_module|intval}
+                      {$field.text nofilter}
+                    {else}
+                      {$field.text}
+                    {/if}
+                  </p>
+                {elseif $field.type == 'image'}
+                  <a href="{$field.image.large.url}">
+                    <img class="rounded-3" src="{$field.image.small.url}">
+                  </a>
+                {/if}
               </div>
             {/foreach}
-          </div>
+          {/foreach}
         </div>
       </div>
     </div>

--- a/templates/catalog/_partials/product-customization-modal.tpl
+++ b/templates/catalog/_partials/product-customization-modal.tpl
@@ -1,0 +1,53 @@
+{**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *}
+{$componentName = 'product-customization-modal'}
+
+<div class="{$componentName}__wrapper">
+  <button class="btn btn-sm btn-outline-primary mb-2"
+    data-bs-toggle="modal"
+    data-bs-target="#{$componentName}--{$product.id_customization|intval}"
+  >
+    {l s='Customized' d='Shop.Theme.Checkout'}
+  </button>
+
+  <div class="modal fade"
+    id="{$componentName}--{$product.id_customization|intval}"
+    tabindex="-1"
+    aria-hidden="true"
+  >
+    <div class="modal-dialog modal-dialog-scrollable modal-fullscreen-md-down">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">{l s='Product customization' d='Shop.Theme.Checkout'}</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="container-fluid">
+            {foreach from=$product.customizations item="customization"}
+              <div class="row row-cols-1">
+                {foreach from=$customization.fields item="field"}
+                <div class="d-flex flex-column mb-3">
+                  <span class="mb-1 text-dark">{$field.label}</span>
+                  {if $field.type == 'text'}
+                    <p class="mb-0">
+                      {if (int)$field.id_module}
+                        {$field.text nofilter}
+                      {else}
+                        {$field.text}
+                      {/if}
+                    </p>
+                  {elseif $field.type == 'image'}
+                    <img class="align-self-start rounded-3" src="{$field.image.small.url}">
+                  {/if}
+                </div>
+                {/foreach}
+              </div>
+            {/foreach}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/catalog/_partials/product-customization-modal.tpl
+++ b/templates/catalog/_partials/product-customization-modal.tpl
@@ -17,7 +17,7 @@
     tabindex="-1"
     aria-hidden="true"
   >
-    <div class="modal-dialog modal-dialog-scrollable modal-fullscreen-md-down">
+    <div class="modal-dialog modal-dialog-scrollable modal-fullscreen-sm-down">
       <div class="modal-content">
         <div class="modal-header">
           <h4 class="modal-title">{l s='Product customization' d='Shop.Theme.Checkout'}</h4>

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -43,6 +43,10 @@
       {$product.name}
     </a>
 
+    {if is_array($product.customizations) && $product.customizations|count}
+      {include file="catalog/_partials/product-customization-modal.tpl" product=$product}
+    {/if}
+
     {foreach from=$product.attributes key="attribute" item="value"}
       <div class="product-line__info product-line__item {$attribute|lower}">
         <span class="label">{$attribute}:</span>

--- a/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/templates/checkout/_partials/order-confirmation-table.tpl
@@ -27,41 +27,7 @@
         {/if}
 
         {if is_array($product.customizations) && $product.customizations|count}
-          {foreach from=$product.customizations item="customization"}
-            <div class="customizations">
-              <a href="#" data-bs-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
-            </div>
-            <div class="modal fade customization-modal" id="product-customizations-modal-{$customization.id_customization}" tabindex="-1" role="dialog" aria-hidden="true">
-              <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                  <div class="modal-header">
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{l s='Close' d='Shop.Theme.Global'}"></button>
-                    <h4 class="modal-title">{l s='Product customization' d='Shop.Theme.Catalog'}</h4>
-                  </div>
-                  <div class="modal-body">
-                    {foreach from=$customization.fields item="field"}
-                      <div class="product-customization-line row">
-                        <div class="col-sm-3 col-4 label">
-                          {$field.label}
-                        </div>
-                        <div class="col-sm-9 col-8 value">
-                          {if $field.type == 'text'}
-                            {if (int)$field.id_module}
-                              {$field.text nofilter}
-                            {else}
-                              {$field.text}
-                            {/if}
-                          {elseif $field.type == 'image'}
-                            <img src="{$field.image.small.url}" loading="lazy">
-                          {/if}
-                        </div>
-                      </div>
-                    {/foreach}
-                  </div>
-                </div>
-              </div>
-            </div>
-          {/foreach}
+          {include file="catalog/_partials/product-customization-modal.tpl" product=$product}
         {/if}
         
         {hook h='displayProductPriceBlock' product=$product type="unit_price"}


### PR DESCRIPTION
It's confusing for users to see multiple lines for same product in Cart or Order details, without showing the difference between them (Customization data).

https://user-images.githubusercontent.com/85633460/169803231-e265cdf8-6cf7-4243-98fe-916eb2d418e8.mp4



