### PR TITLE
Add modules to config.yml hook

### DIFF
--- a/config/theme.yml
+++ b/config/theme.yml
@@ -67,9 +67,11 @@ global_settings:
         - ps_searchbar
       displayHome:
         - ps_imageslider
+        - ps_customtext
         - ps_featuredproducts
         - ps_banner
-        - ps_customtext
+        - ps_newproducts
+        - ps_bestsellers
       displayFooterBefore:
         - ps_emailsubscription
         - ps_socialfollow
@@ -77,6 +79,7 @@ global_settings:
         - ps_linklist
         - ps_customeraccountlinks
         - ps_contactinfo
+        - ~
       displayLeftColumn:
         - ps_categorytree
         - ps_facetedsearch


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/hummingbird/issues/296
| How to test?      | Reinstall theme and check if module is hooked to that hook
| Possible impacts? | Noooope


I chose a `~` for displayFooter because I think many devs will use this hook to add some modals, scripts...., so we must keep as store admin wants, with all modules working
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
