### PR TITLE
Remove actionProductOutOfStock from product-details

### DIFF
--- a/templates/catalog/_partials/product-details.tpl
+++ b/templates/catalog/_partials/product-details.tpl
@@ -1,11 +1,11 @@
 
-<div 
+<div
   class="info js-product-details accordion-item"
   id="product-details"
   data-product="{$product.embedded_attributes|json_encode}"
 >
   <h5 class="info__title accordion-header" id="product-details-heading">
-    <button class="accordion-button {if $product.description}collapsed{/if}" type="button" data-bs-toggle="collapse" data-bs-target="#product-details-collapse" aria-expanded="{if $product.description}false{else}true{/if}" 
+    <button class="accordion-button {if $product.description}collapsed{/if}" type="button" data-bs-toggle="collapse" data-bs-target="#product-details-collapse" aria-expanded="{if $product.description}false{else}true{/if}"
       aria-controls="product-details-collapse">
       {l s='Product Details' d='Shop.Theme.Catalog'}
     </button>
@@ -69,17 +69,6 @@
           {/if}
         {/block}
 
-        {block name='product_out_of_stock'}
-          <li class="detail">
-            <div class="detail__left">
-              <span class="detail__title">{l s='Out of stock' d='Shop.Theme.Catalog'}</span>
-            </div>
-            <div class="detail__right">
-              {hook h='actionProductOutOfStock' product=$product}
-            </div>
-          </li>
-        {/block}
-
         {* if product have specific references, a table will be added to product details section *}
         {block name='product_condition'}
           {if $product.condition}
@@ -116,7 +105,7 @@
     {if $product.grouped_features}
       <div class="info accordion-item" id="product-features">
         <h5 class="info__title accordion-header" id="product-features-heading">
-          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#product-features-collapse" aria-expanded="false" 
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#product-features-collapse" aria-expanded="false"
             aria-controls="product-features-collapse">
             {l s='Data sheet' d='Shop.Theme.Catalog'}
           </button>

--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -35,7 +35,7 @@
         {include file='catalog/_partials/product-cover-thumbnails.tpl'}
       {/block}
     </div>
-    
+
     <div class="product__col col-lg-6 col-xl-5">
       {block name='product_header'}
         <h1 class="h4 product__name">{block name='page_title'}{$product.name}{/block}</h1>
@@ -82,6 +82,10 @@
 
             {block name='product_additional_info'}
               {include file='catalog/_partials/product-additional-info.tpl'}
+            {/block}
+
+            {block name='product_out_of_stock'}
+              {hook h='actionProductOutOfStock' product=$product}
             {/block}
 
             {* Input to refresh product HTML removed, block kept for compatibility with themes *}
@@ -171,7 +175,7 @@
           </div>
       {/block}
     </div>{* /col *}
-  </div>{* /row *} 
+  </div>{* /row *}
   {* END OF SECOND PART *}
 
   {block name='product_accessories'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Fixed ticket?     | Fixes https://github.com/PrestaShop/hummingbird/issues/305


This hook is action type, so it must not display anything, so it makes no sense to put on product-details.tpl with markup code.
Also, I think this hook is useless. I can't find any hook::exec on PrestaShop code since 1.6 version. Anyway, I keep it just in case...
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
