### PR TITLE
Add products reviews to schema.org

### DIFF
--- a/templates/_partials/microdata/product-jsonld.tpl
+++ b/templates/_partials/microdata/product-jsonld.tpl
@@ -35,14 +35,33 @@
     "brand": {
       "@type": "Thing",
       "name": "{if $product_manufacturer->name}{$product_manufacturer->name|escape:'html':'UTF-8'}{else}{$shop.name}{/if}"
-    }
+    },{/if}
+    {if !empty($product.productComments.comments)}
+      "review": [
+        {foreach from=$product.productComments.comments item=comment}
+          {
+            "@type": "Review",
+            "reviewRating": {
+              "@type": "Rating",
+              "ratingValue": "{$comment.grade}",
+              "datePublished": "{$comment.date_add}"
+            },
+            "name": "{$comment.title}",
+            "author": {
+              "@type": "Person",
+              "name": "{$comment.customer_name}"
+            },
+            "reviewBody": "{$comment.content}"
+          }
+        {/foreach}
+      ],
     {/if}
     {if $hasAggregateRating},
-    "aggregateRating": {
-      "@type": "AggregateRating",
-      "ratingValue": "{$ratingValue|round:1|escape:'html':'UTF-8'}",
-      "reviewCount": "{$ratingReviewCount|escape:'html':'UTF-8'}"
-    }
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "{$ratingValue|round:1|escape:'html':'UTF-8'}",
+        "reviewCount": "{$ratingReviewCount|escape:'html':'UTF-8'}"
+      }
     {/if}
     {if $hasWeight},
     "weight": {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add customer reviews to product json+ld
| Type?             | improvement
| BC breaks?        |  no
| Deprecations?     |  no


This change depends on this pull request, as we have the data from somewhere:
https://github.com/PrestaShop/productcomments/pull/140

But for now i add the code to print the reviews
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
