### PR TITLE
Add row class fallback to productlist.tpl and remove every css override

### DIFF
--- a/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl
+++ b/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl
@@ -5,7 +5,7 @@
 <section class="best-sellers-products mt-3">
     <div class="container">
         {include file="components/section-title.tpl" title={l s="Best Sellers" d="Shop.Theme.Catalog"}}
-        {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-6 col-lg-4 col-xl-3"}
+        {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
         <div class="best-sellers-products-footer text-center">
             <a class="all-product-link btn btn-outline-primary" href="{$allBestSellers}">
                 {l s='All best sellers' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip">&#xE315;</i>

--- a/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
+++ b/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
@@ -9,5 +9,5 @@
     {include file="components/section-title.tpl" title={l s='%s other products in the same category' sprintf=[$products|@count] d='Shop.Theme.Catalog'}}
   {/if}
 
-  {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-6 col-lg-4 col-xl-3"}
+  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
 </section>

--- a/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
+++ b/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
@@ -3,11 +3,13 @@
  * file that was distributed with this source code.
  *}
 <section class="category-products mt-3">
-  {if $products|@count == 1}
-    {include file="components/section-title.tpl" title={l s='%s other product in the same category' sprintf=[$products|@count] d='Shop.Theme.Catalog'}}
-  {else}
-    {include file="components/section-title.tpl" title={l s='%s other products in the same category' sprintf=[$products|@count] d='Shop.Theme.Catalog'}}
-  {/if}
+  <div class="container">
+    {if $products|@count == 1}
+      {include file="components/section-title.tpl" title={l s='%s other product in the same category' sprintf=[$products|@count] d='Shop.Theme.Catalog'}}
+    {else}
+      {include file="components/section-title.tpl" title={l s='%s other products in the same category' sprintf=[$products|@count] d='Shop.Theme.Catalog'}}
+    {/if}
 
-  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+    {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+  </div>
 </section>

--- a/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl
+++ b/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl
@@ -4,6 +4,8 @@
  *}
 
 <section class="featured-products mt-3">
-  {include file="components/section-title.tpl" title={l s='Customers who bought this product also bought:' d='Shop.Theme.Catalog'}}
-  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+  <div class="container">
+    {include file="components/section-title.tpl" title={l s='Customers who bought this product also bought:' d='Shop.Theme.Catalog'}}
+    {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+  </div>
 </section>

--- a/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl
+++ b/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl
@@ -5,5 +5,5 @@
 
 <section class="featured-products mt-3">
   <h2>{l s='Customers who bought this product also bought:' d='Shop.Theme.Catalog'}</h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products}
+  {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row"}
 </section>

--- a/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl
+++ b/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl
@@ -4,6 +4,6 @@
  *}
 
 <section class="featured-products mt-3">
-  <h2>{l s='Customers who bought this product also bought:' d='Shop.Theme.Catalog'}</h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row"}
+  {include file="components/section-title.tpl" title={l s='Customers who bought this product also bought:' d='Shop.Theme.Catalog'}}
+  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
 </section>

--- a/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
+++ b/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
@@ -5,7 +5,7 @@
 <section class="featured-products">
   <div class="container">
     {include file="components/section-title.tpl" title={l s="Popular Products" d="Shop.Theme.Catalog"}}
-    {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-6 col-lg-4 col-xl-3"}
+    {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
   </div>
 
   <div class="featured-products-footer text-center">

--- a/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
+++ b/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
@@ -6,7 +6,7 @@
 <section class="new-products mt-3">
     <div class="container">
         {include file="components/section-title.tpl" title={l s="New products" d="Shop.Theme.Catalog"}}
-        {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-6 col-lg-4 col-xl-3"}
+        {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
         <div class="new-products-footer text-center">
             <a class="all-product-link btn btn-outline-primary" href="{$allNewProductsLink}">
                 {l s='All new products' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip">&#xE315;</i>

--- a/modules/ps_specials/views/templates/hook/ps_specials.tpl
+++ b/modules/ps_specials/views/templates/hook/ps_specials.tpl
@@ -6,7 +6,7 @@
 <section class="sale-products mt-3">
     <div class="container">
         {include file="components/section-title.tpl" title={l s="On sale" d="Shop.Theme.Catalog"}}
-        {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-6 col-lg-4 col-xl-3"}
+        {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
         <div class="sale-products-footer text-center">
             <a class="all-product-link btn btn-outline-primary" href="{$allSpecialProductsLink}">
                 {l s='All sale products' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip">&#xE315;</i>

--- a/modules/ps_viewedproduct/views/templates/hook/ps_viewedproduct.tpl
+++ b/modules/ps_viewedproduct/views/templates/hook/ps_viewedproduct.tpl
@@ -4,5 +4,5 @@
  *}
 <section class="viewed-products mt-3">
   {include file="components/section-title.tpl" title={l s="Viewed products" d="Shop.Theme.Catalog"}}
-  {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-6 col-lg-4 col-xl-3"}
+  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
 </section>

--- a/modules/ps_viewedproduct/views/templates/hook/ps_viewedproduct.tpl
+++ b/modules/ps_viewedproduct/views/templates/hook/ps_viewedproduct.tpl
@@ -3,6 +3,8 @@
  * file that was distributed with this source code.
  *}
 <section class="viewed-products mt-3">
-  {include file="components/section-title.tpl" title={l s="Viewed products" d="Shop.Theme.Catalog"}}
-  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+  <div class="container">
+    {include file="components/section-title.tpl" title={l s="Viewed products" d="Shop.Theme.Catalog"}}
+    {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+  </div>
 </section>

--- a/templates/catalog/_partials/product-accessories.tpl
+++ b/templates/catalog/_partials/product-accessories.tpl
@@ -4,5 +4,5 @@
  *}
  <section class="product-accessories mt-3">
   {include file="components/section-title.tpl" title={l s='You might also like' d='Shop.Theme.Catalog'}}
-  {include file="catalog/_partials/productlist.tpl" products=$accessories cssClass="row" productClass="col-6 col-lg-4 col-xl-3"}
+  {include file="catalog/_partials/productlist.tpl" products=$accessories productClass="col-6 col-lg-4 col-xl-3"}
 </section>

--- a/templates/catalog/_partials/productlist.tpl
+++ b/templates/catalog/_partials/productlist.tpl
@@ -4,7 +4,7 @@
  *}
 {capture assign="productClasses"}{if !empty($productClass)}{$productClass}{else}col-xs-6 col-xl-4{/if}{/capture}
 
-<div class="products{if !empty($cssClass)} {$cssClass}{/if}">
+<div class="products{if !empty($cssClass)} {$cssClass}{else} row{/if}">
   {foreach from=$products item="product" key="position"}
     {include file="catalog/_partials/miniatures/product.tpl" product=$product position=$position productClasses=$productClasses}
   {/foreach}

--- a/templates/catalog/_partials/products.tpl
+++ b/templates/catalog/_partials/products.tpl
@@ -3,7 +3,7 @@
  * file that was distributed with this source code.
  *}
 <div id="js-product-list">
-  {include file="catalog/_partials/productlist.tpl" products=$listing.products cssClass="row"}
+  {include file="catalog/_partials/productlist.tpl" products=$listing.products}
 
   {block name='pagination'}
     {include file='_partials/pagination.tpl' pagination=$listing.pagination}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | .row class is missing so BS wont work
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     | no

Before:
![imagen](https://user-images.githubusercontent.com/10741347/173064563-c9fd5d0d-cc7b-4d2f-9b2c-9eda28c0d286.png)
After:
![imagen](https://user-images.githubusercontent.com/10741347/173064620-8889793b-551d-4e02-9b66-4312c05de97a.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
