### PR TITLE
Fix category duplication and image sizes

### DIFF
--- a/templates/catalog/_partials/category-header.tpl
+++ b/templates/catalog/_partials/category-header.tpl
@@ -11,13 +11,18 @@
             {/if}
             {if !empty($category.image.large.url)}
               <div class="category-cover mb-4">
-                <img src="{$category.image.large.url}" alt="{if !empty($category.image.legend)}{$category.image.legend}{else}{$category.name}{/if}" loading="lazy" width="141" height="180">
+                <img src="{$category.image.large.url}" 
+                  alt="{if !empty($category.image.legend)}{$category.image.legend}{else}{$category.name}{/if}" 
+                  loading="lazy" 
+                  width="{$category.image.large.width}" 
+                  height="{$category.image.large.height}">
               </div>
             {/if}
         </div>
     {/if}
+    {if isset($subcategories) && $subcategories|@count> 0}
+      {include file='catalog/_partials/subcategories.tpl' subcategories=$subcategories}
+    {/if}
 </div>
 
-{if isset($subcategories) && $subcategories|@count> 0}
-  {include file='catalog/_partials/subcategories.tpl' subcategories=$subcategories}
-{/if}
+

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -17,9 +17,9 @@
                 src="{$product.cover.bySize.home_default.url}"
                 alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name}{/if}"
                 loading="lazy"
-                data-full-size-image-url="{$product.cover.large.url}"
-                width="{$product.cover.large.width}"
-                height="{$product.cover.large.height}"
+                data-full-size-image-url="{$product.cover.home_default.url}"
+                width="{$product.cover.home_default.width}"
+                height="{$product.cover.home_default.height}"
                 class="{$componentName}__image card-img-top"
               />
             {else}

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -18,16 +18,16 @@
                 alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name}{/if}"
                 loading="lazy"
                 data-full-size-image-url="{$product.cover.large.url}"
-                width="250"
-                height="250"
+                width="{$product.cover.large.width}"
+                height="{$product.cover.large.height}"
                 class="{$componentName}__image card-img-top"
               />
             {else}
               <img
                 src="{$urls.no_picture_image.bySize.home_default.url}"
                 loading="lazy"
-                width="250"
-                height="250"
+                width="{$urls.no_picture_image.bySize.home_default.width}"
+                height="{$urls.no_picture_image.bySize.home_default.height}"
                 class="{$componentName}__image card-img-top"
               />
             {/if}
@@ -99,6 +99,7 @@
                 {/if}
               {/block}
             </div>
+
           </div>
         </div>
       {/block}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When filtering, top categories are duplicated, and images sizes were wrong
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
