### PR TITLE
Change PrestaShop URL in footer

### DIFF
--- a/templates/_partials/footer.tpl
+++ b/templates/_partials/footer.tpl
@@ -22,7 +22,7 @@
     </div>
     <p class="copyright">
       {block name='copyright_link'}
-        <a href="https://www.prestashop.com" target="_blank" rel="noopener noreferrer nofollow">
+        <a href="https://www.prestashop-project.org/" target="_blank" rel="noopener noreferrer nofollow">
           {l s='%copyright% %year% - Ecommerce software by %prestashop%' sprintf=['%prestashop%' => 'PrestaShop™', '%year%' => 'Y'|date, '%copyright%' => '©'] d='Shop.Theme.Global'}
         </a>
       {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | According to Company/OS Project clarification, link in footer should point to https://www.prestashop-project.org/ instead of https://www.prestashop.com/.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/22311.
| How to test?      | -
| Possible impacts? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
