### PR TITLE
Fix subcategories duplication on facetedsearch event

### DIFF
--- a/templates/catalog/_partials/category-header.tpl
+++ b/templates/catalog/_partials/category-header.tpl
@@ -17,7 +17,3 @@
         </div>
     {/if}
 </div>
-
-{if isset($subcategories) && $subcategories|@count> 0}
-  {include file='catalog/_partials/subcategories.tpl' subcategories=$subcategories}
-{/if}

--- a/templates/catalog/listing/product-list.tpl
+++ b/templates/catalog/listing/product-list.tpl
@@ -13,12 +13,17 @@
     {block name='product_list_header'}
       <h1 id="js-product-list-header" class="h1 mb-4">{$listing.label}</h1>
     {/block}
+
+    {block name='subcategory_list'}
+      {if isset($subcategories) && $subcategories|@count> 0}
+        {include file='catalog/_partials/subcategories.tpl' subcategories=$subcategories}
+      {/if}
+    {/block}
     
     {hook h="displayHeaderCategory"}
 
     <section id="products">
       {if $listing.products|count}
-
         <div>
           {block name='product_list_top'}
             {include file='catalog/_partials/products-top.tpl' listing=$listing}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Subcategories has been moved into the content which is causing a duplication on replace
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/hummingbird/issues/322.
| How to test?      | See issue
| Possible impacts? | Subcategories on category page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
