### PR TITLE
Use accordions as categories with childs on categorytree

### DIFF
--- a/modules/ps_categorytree/views/templates/hook/ps_categorytree.tpl
+++ b/modules/ps_categorytree/views/templates/hook/ps_categorytree.tpl
@@ -8,38 +8,20 @@
 {function name="categories" nodes=[] depth=0}
   {strip}
     {if $nodes|count}
-      <ul class="{$componentName}-list">
+      <ul class="{$componentName}__list" data-depth="{$depth}">
         {foreach from=$nodes item=node name="categories"}
-          <li class="{$componentName}-item" data-depth="{$depth}">
-            {if $depth===0}
+          <li class="{$componentName}__item">
+            <div class="{$componentName}__item__header{if $node.children} {$componentName}__item__header--parent{/if}">
+              <a class="{$componentName}__item__link" href="{$node.link}">{$node.name}</a>
               {if $node.children}
-                <div class="d-flex align-items-center justify-content-space-between">
+                <div class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#exCollapsingNavbar{$node.id}"></div>
               {/if}
-              <a class="{$componentName}-item-link" href="{$node.link}">{$node.name}</a>
-              {if $node.children}
-                  <div class="accordion-button px-0 collapsed" data-bs-toggle="collapse" data-bs-target="#exCollapsingNavbar{$node.id}">
-                  </div>
-                </div>
-                <div class="collapse py-2" id="exCollapsingNavbar{$node.id}">
-                  {categories nodes=$node.children depth=$depth+1}
-                </div>
-              {else}
-              {/if}
-            {else}
-              {if $node.children}
-                <div class="d-flex align-items-center justify-content-space-between">
-              {/if}
-              <a class="{$componentName}-child-link" href="{$node.link}">{$node.name}</a>
-              {if $node.children}
-                  <div class="accordion-button px-0 collapsed" data-bs-toggle="collapse" data-bs-target="#exCollapsingNavbar{$node.id}">
-                  </div>
-                </div>
-                <div class="collapse pt-1 pb-2" id="exCollapsingNavbar{$node.id}">
-                  {categories nodes=$node.children depth=$depth+1}
-                </div>
-              {/if}
+            </div>
+            {if $node.children}
+              <div class="collapse" id="exCollapsingNavbar{$node.id}">
+                {categories nodes=$node.children depth=$depth+1}
+              </div>
             {/if}
-            {if !$smarty.foreach.categories.last}<hr class="my-0">{/if}
           </li>
         {/foreach}
       </ul>
@@ -48,10 +30,10 @@
 {/function}
 
 <div class="{$componentName}">
-  <ul class="{$componentName}-list list-group">
-    <li class="{$componentName}-title list-group-item"><a class="{$componentName}-title-link" href="{$categories.link nofilter}">{$categories.name}</a></li>
+  <ul class="{$componentName}__list list-group">
+    <li class="{$componentName}__title list-group-item"><a class="{$componentName}__title__link" href="{$categories.link nofilter}">{$categories.name}</a></li>
     {if !empty($categories.children)}
-      <li class="{$componentName}-child list-group-item">{categories nodes=$categories.children}</li>
+      <li class="{$componentName}__child list-group-item">{categories nodes=$categories.children}</li>
     {/if}
   </ul>
 </div>

--- a/modules/ps_categorytree/views/templates/hook/ps_categorytree.tpl
+++ b/modules/ps_categorytree/views/templates/hook/ps_categorytree.tpl
@@ -9,32 +9,37 @@
   {strip}
     {if $nodes|count}
       <ul class="{$componentName}-list">
-        {foreach from=$nodes item=node}
+        {foreach from=$nodes item=node name="categories"}
           <li class="{$componentName}-item" data-depth="{$depth}">
             {if $depth===0}
+              {if $node.children}
+                <div class="d-flex align-items-center justify-content-space-between">
+              {/if}
               <a class="{$componentName}-item-link" href="{$node.link}">{$node.name}</a>
               {if $node.children}
-                <div class="navbar-toggler collapse-icons" data-bs-toggle="collapse" data-bs-target="#exCollapsingNavbar{$node.id}">
-                  <i class="material-icons add">&#xE145;</i>
-                  <i class="material-icons remove">&#xE15B;</i>
+                  <div class="accordion-button px-0 collapsed" data-bs-toggle="collapse" data-bs-target="#exCollapsingNavbar{$node.id}">
+                  </div>
                 </div>
-                <div class="collapse" id="exCollapsingNavbar{$node.id}">
+                <div class="collapse py-2" id="exCollapsingNavbar{$node.id}">
                   {categories nodes=$node.children depth=$depth+1}
                 </div>
               {else}
               {/if}
             {else}
+              {if $node.children}
+                <div class="d-flex align-items-center justify-content-space-between">
+              {/if}
               <a class="{$componentName}-child-link" href="{$node.link}">{$node.name}</a>
               {if $node.children}
-                <span class="arrows" data-bs-toggle="collapse" data-bs-target="#exCollapsingNavbar{$node.id}">
-                  <i class="material-icons arrow-right">&#xE315;</i>
-                  <i class="material-icons arrow-down">&#xE313;</i>
-                </span>
-                <div class="collapse" id="exCollapsingNavbar{$node.id}">
+                  <div class="accordion-button px-0 collapsed" data-bs-toggle="collapse" data-bs-target="#exCollapsingNavbar{$node.id}">
+                  </div>
+                </div>
+                <div class="collapse pt-1 pb-2" id="exCollapsingNavbar{$node.id}">
                   {categories nodes=$node.children depth=$depth+1}
                 </div>
               {/if}
             {/if}
+            {if !$smarty.foreach.categories.last}<hr class="my-0">{/if}
           </li>
         {/foreach}
       </ul>

--- a/src/scss/custom/components/category-tree/_category-tree.scss
+++ b/src/scss/custom/components/category-tree/_category-tree.scss
@@ -15,18 +15,18 @@ $component-name: category-tree;
   margin-bottom: 2rem;
   border-bottom: var(--#{$component-name}-border-bottom);
 
-  &-child {
+  &__child {
     padding: 0;
     border: none;
   }
 
-  & &-title {
+  &__title {
     padding: 0;
     margin-bottom: var(--#{$component-name}-title-spacing);
     font-size: var(--#{$component-name}-title-size);
     border: none;
 
-    &-link {
+    &__link {
       display: block;
       font-weight: 600;
       line-height: 2rem;
@@ -34,13 +34,25 @@ $component-name: category-tree;
     }
   }
 
-  & &-item {
-    &-link {
+  &__item {
+    &__link {
       display: block;
       padding: var(--#{$component-name}-subtitle-spacing) 0;
       font-size: var(--#{$component-name}-subtitle-size);
       font-weight: 600;
       color: var(--#{$component-name}-subtitle-color);
+    }
+
+    &__header {
+      &--parent {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+
+        > div {
+          padding: 0;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | On ps_categorytree, we want a cool design, easy to maintain, bootstrap collapse with the accordion style is a perfect fit for it!
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/hummingbird/issues/256.
| How to test?      | Go on category page, see screenshot
| Possible impacts? | categorytree

<img width="291" alt="image" src="https://user-images.githubusercontent.com/14963751/177506779-2c9f0a3c-d21f-4154-bc33-8d85de76cfeb.png">

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
