### PR TITLE
hiding the quick view after adding a product to the cart

### DIFF
--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -138,6 +138,7 @@ const selectorsMap = {
   modalBody: '.modal-body',
   pageCms: '.page-cms',
   quickview: '.js-quickview',
+  quickviewModal: '.quickview',
   facetedsearch,
   pageLoader,
   listing,

--- a/src/js/quickview.ts
+++ b/src/js/quickview.ts
@@ -42,5 +42,8 @@ export default function initQuickviews() {
       });
       event.preventDefault();
     });
+    prestashop.on('updateCart', () => {
+      $(selectorsMap.quickviewModal).modal('hide');
+    });
   });
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | I have fixed quick view not closing after adding product to the cart
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes NA.
| How to test?      | Add the product to the cart from the quick view. See screenshots below
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

## Before
![image](https://user-images.githubusercontent.com/48727835/177780356-a351b6c8-e3b6-40a6-9d6c-3436390ecfcc.png)

## After 
![image](https://user-images.githubusercontent.com/48727835/177780399-9e73ab0e-3457-4dd4-95f5-3551040ee949.png)


