### PR TITLE
Fix import overrides scss file order according to boostrap doc

### DIFF
--- a/src/scss/abstract/variables/_index.scss
+++ b/src/scss/abstract/variables/_index.scss
@@ -1,6 +1,7 @@
+@import "~bootstrap/scss/functions";
+
 @import "overrides";
 
-@import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins";
 @import "~bootstrap/scss/utilities";


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Change import order of `overrides.scss` according to [bootstrap documentation](https://getbootstrap.com/docs/5.1/customize/sass/#importing).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | No ticket.
| How to test?      | Check the diff.
| Possible impacts? | Possibility to use manipulation colors, SVGs, calc, etc in overrides.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
