### PR TITLE
Change contact page widget to hooks

### DIFF
--- a/config/theme.yml
+++ b/config/theme.yml
@@ -83,6 +83,12 @@ global_settings:
       displayLeftColumn:
         - ps_categorytree
         - ps_facetedsearch
+      displayContactLeftColumn:
+        - ps_contactinfo
+      displayContactRightColumn:
+        - ps_contactinfo
+      displayContactContent:
+        - ps_contactinfo
       displaySearch:
         - ps_searchbar
       displayProductAdditionalInfo:

--- a/config/theme.yml
+++ b/config/theme.yml
@@ -88,7 +88,7 @@ global_settings:
       displayContactRightColumn:
         - ps_contactinfo
       displayContactContent:
-        - ps_contactinfo
+        - contactform
       displaySearch:
         - ps_searchbar
       displayProductAdditionalInfo:

--- a/templates/contact.tpl
+++ b/templates/contact.tpl
@@ -9,17 +9,17 @@
 {if $layout === 'layouts/layout-left-column.tpl'}
   {block name="left_column"}
     <div id="left-column" class="wrapper__left-column col-md-4 col-lg-3">
-      {widget name="ps_contactinfo" hook='displayLeftColumn'}
+      {hook h='displayContactLeftColumn'}
     </div>
   {/block}
 {else if $layout === 'layouts/layout-right-column.tpl'}
   {block name="right_column"}
     <div id="right-column" class="wrapper__right-column col-md-4 col-lg-3">
-      {widget name="ps_contactinfo" hook='displayRightColumn'}
+      {hook h='displayContactRightColumn'}
     </div>
   {/block}
 {/if}
 
 {block name='page_content'}
-  {widget name="contactform"}
+  {hook h='displayContactContent'}
 {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We want to move widgets to regular hooks to make life easier for theme developers
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29198.
| How to test?      | Verify that the contact page is working properly
| Possible impacts? | Contact page display

⚠️ need to be tested with a new version of `ps_contactinfo` as the current version is not compatible

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
