### PR TITLE
Upgrade autoprefixer to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/wnumb": "^1.2.1",
     "@typescript-eslint/eslint-plugin": "^5.12.0",
     "@typescript-eslint/parser": "^5.12.0",
-    "autoprefixer": "^6.7.7",
+    "autoprefixer": "^10.4.11",
     "babel-loader": "^8.2.3",
     "bootstrap-touchspin": "^4.3.0",
     "bourbon": "^7.0.0",


### PR DESCRIPTION
I was having a `Term expected` error in compiled `assets/css/theme.css`. It was some `ms-grid-` prefix added by `autoprefixer`. So, I upgraded autoprefixer to the latest version and error is gone.