### PR TITLE
Add CleanWebpackPlugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-loader": "^8.2.3",
     "bootstrap-touchspin": "^4.3.0",
     "bourbon": "^7.0.0",
+    "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^5.2.7",
     "css-minimizer-webpack-plugin": "^3.1.1",
     "cssjanus": "^2.1.0",

--- a/webpack/webpack.parts.js
+++ b/webpack/webpack.parts.js
@@ -160,10 +160,19 @@ exports.extractFonts = () => ({
 });
 
 exports.cleanDistFolders = () => ({
-  output: {
-    clean: true,
-  },
-});
+  plugins: [
+    new CleanWebpackPlugin({
+      dry: false,
+      dangerouslyAllowCleanPatternsOutsideProject: true,
+      cleanOnceBeforeBuildPatterns: [
+        path.join(__dirname, '../../assets/js/**'),
+        path.join(__dirname, '../../assets/css/**'),
+        path.join(__dirname, '../../assets/img-dist/**'),
+        path.join(__dirname, '../../assets/fonts/**')
+      ],
+    }),
+  ]
+})
 
 exports.externals = () => ({
   externals: {

--- a/webpack/webpack.parts.js
+++ b/webpack/webpack.parts.js
@@ -1,5 +1,6 @@
 const webpack = require('webpack');
 const path = require('path');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add CleanWebpackPlugin to manage assets, because with the official cleaning feature of webpack we can't exclude a folder. So if we want to add a PNG in `assets/img` and call it with `{$urls.img_url}` in img src, webpack will erase it during the build and image will be broken. So I copied [Oksydan's theme webpack config](https://github.com/Oksydan/modern-prestashop-starter-theme/blob/f8ea083772943985c85736fc6dd375898929a316/_dev/webpack/webpack.parts.js#L156) and added `clean-webpack-plugin` in `package.json`
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
