### PR TITLE
Set product-miniature card height to 100%

### DIFF
--- a/src/scss/core/components/product/_product-miniature.scss
+++ b/src/scss/core/components/product/_product-miniature.scss
@@ -1,6 +1,9 @@
 $component-name: product-miniature;
 
 .#{$component-name} {
+  .card {
+    height: 100%;
+  }
   & &__infos {
     position: relative;
     z-index: 90;


### PR DESCRIPTION
Set height to 100% to align cards in category page for example.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing the PR. Every detail helps: What are you changing? Why?
| Type?             | bug fix / improvement / new feature / refacto / critical
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes {paste the issue here}.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
