### PR TITLE
Change second $badge-padding-y to $badge-padding-x

### DIFF
--- a/src/scss/abstract/variables/bootstrap/_badges.scss
+++ b/src/scss/abstract/variables/bootstrap/_badges.scss
@@ -2,4 +2,4 @@ $badge-font-size: 0.875rem;
 $badge-font-weight: 500;
 $badge-border-radius: 4px;
 $badge-padding-y: 0.3125rem;
-$badge-padding-y: 0.625rem;
+$badge-padding-x: 0.625rem;


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This file has 2 $badge-padding-y variables. I believe the last $badge-padding-y it was supposed to be $badge-padding-x.
| Type?             | refacto
| BC breaks?        |  no
| Deprecations?     | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
