### PR TITLE
Hide Previous/Next labels for mobile screens

### DIFF
--- a/templates/_partials/pagination.tpl
+++ b/templates/_partials/pagination.tpl
@@ -28,9 +28,9 @@
                     class="page-link btn-with-icon {if $page.type === 'previous'}previous {elseif $page.type === 'next'}next {/if}{['disabled' => !$page.clickable, 'js-search-link' => true]|classnames}">
                     {if $page.type === 'previous'}
                       <i class="material-icons rtl-flip">&#xE314;</i>
-                      {l s='Previous' d='Shop.Theme.Actions'}
+                      <span class="hidden-on-mobile">{l s='Previous' d='Shop.Theme.Actions'}</span>
                     {elseif $page.type === 'next'}
-                      {l s='Next' d='Shop.Theme.Actions'}
+                      <span class="hidden-on-mobile">{l s='Next' d='Shop.Theme.Actions'}</span>
                       <i class="material-icons rtl-flip">&#xE315;</i>
                     {else}
                       {$page.page}


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      |Hide text label for mobile screen because there's a overflow in pagination. See issue #340
| Type?             |  improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #340
| How to test?      | See screenshots below

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
## Before
![image](https://user-images.githubusercontent.com/6523221/197803322-af9c150f-b27f-45a4-8048-34197e728966.png)

## After
![image](https://user-images.githubusercontent.com/6523221/197803591-86fd87c0-cfe6-4738-ba98-748bb948cb39.png)
