### PR TITLE
Fix product page overflow in mobile view

### DIFF
--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -29,7 +29,7 @@
 
 {block name='content'}
   {* FIRST PART - PHOTO, NAME, PRICES, ADD TO CART*}
-  <div class="row g-5 product js-product-container">
+  <div class="row g-lg-5 product js-product-container">
     <div class="product__left col-12 col-lg-6 col-xl-7">
       {block name='product_cover_thumbnails'}
         {include file='catalog/_partials/product-cover-thumbnails.tpl'}

--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -29,14 +29,14 @@
 
 {block name='content'}
   {* FIRST PART - PHOTO, NAME, PRICES, ADD TO CART*}
-  <div class="row g-lg-5 product js-product-container">
-    <div class="product__left col-lg-6 col-xl-7">
+  <div class="row g-5 product js-product-container">
+    <div class="product__left col-12 col-lg-6 col-xl-7">
       {block name='product_cover_thumbnails'}
         {include file='catalog/_partials/product-cover-thumbnails.tpl'}
       {/block}
     </div>
 
-    <div class="product__col col-lg-6 col-xl-5">
+    <div class="product__col col col-lg-6 col-xl-5">
       {block name='product_header'}
         <h1 class="h4 product__name">{block name='page_title'}{$product.name}{/block}</h1>
       {/block}

--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -29,7 +29,7 @@
 
 {block name='content'}
   {* FIRST PART - PHOTO, NAME, PRICES, ADD TO CART*}
-  <div class="row g-5 product js-product-container">
+  <div class="row g-lg-5 product js-product-container">
     <div class="product__left col-lg-6 col-xl-7">
       {block name='product_cover_thumbnails'}
         {include file='catalog/_partials/product-cover-thumbnails.tpl'}

--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -29,14 +29,14 @@
 
 {block name='content'}
   {* FIRST PART - PHOTO, NAME, PRICES, ADD TO CART*}
-  <div class="row g-lg-5 product js-product-container">
-    <div class="product__left col-12 col-lg-6 col-xl-7">
+  <div class="row g-4 g-xl-5 product js-product-container">
+    <div class="product__left col-lg-6 col-xl-7">
       {block name='product_cover_thumbnails'}
         {include file='catalog/_partials/product-cover-thumbnails.tpl'}
       {/block}
     </div>
 
-    <div class="product__col col col-lg-6 col-xl-5">
+    <div class="product__col col-lg-6 col-xl-5">
       {block name='product_header'}
         <h1 class="h4 product__name">{block name='page_title'}{$product.name}{/block}</h1>
       {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In `product.tpl` there is a `g-5` class in `<div class="row g-5 product js-product-container">` that causes a slight overflow. Changing it to `g-lg-5` fixes that.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #382
| How to test?      | Mobile view in product page 
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
