### PR TITLE
Put products page thumbnails on the left

### DIFF
--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -145,8 +145,8 @@ const selectorsMap = {
     carousel: '.js-product-carousel',
     miniature: '.js-product-miniature',
     thumbnail: '.js-thumb-container',
-    thumbnailsContainer: '.js-thumbnails-container',
-    activeThumbail: (id: number): string => `.js-thumb-container:nth-child(${id + 1})`,
+    thumbsContainer: '.js-thumbnails-container',
+    activeThumbnail: (id: number): string => `.js-thumb-container:nth-child(${id + 1})`,
   },
   order: {
     returnForm: '.js-order-return-form',

--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -145,6 +145,7 @@ const selectorsMap = {
     carousel: '.js-product-carousel',
     miniature: '.js-product-miniature',
     thumbnail: '.js-thumb-container',
+    thumbnailsContainer: '.js-thumbnails-container',
     activeThumbail: (id: number): string => `.js-thumb-container:nth-child(${id + 1})`,
   },
   order: {

--- a/src/js/product.ts
+++ b/src/js/product.ts
@@ -20,6 +20,7 @@ export default () => {
 
   function onProductSlide(event: ProductSlideEvent): void {
     const thumbnails = document.querySelectorAll(SelectorsMap.product.thumbnail);
+    const thumbnailsContainer = document.querySelector(SelectorsMap.product.thumbnailsContainer);
 
     thumbnails.forEach((e: Element) => {
       e.classList.remove('active');
@@ -28,6 +29,36 @@ export default () => {
     const activeThumbnail = document.querySelector(SelectorsMap.product.activeThumbail(event.to));
 
     if (activeThumbnail) {
+      const activeThumbailRect = activeThumbnail.getBoundingClientRect();
+
+      if (thumbnailsContainer) {
+        const thumbnailsContainerRect = thumbnailsContainer.getBoundingClientRect();
+        const safetyZone = 20;
+
+        if (
+          (thumbnailsContainerRect.bottom - safetyZone < activeThumbailRect.top
+          || thumbnailsContainerRect.top + safetyZone > activeThumbailRect.bottom)
+          && !prestashop.responsive.mobile
+        ) {
+          thumbnailsContainer.scroll({
+            left: thumbnailsContainer.scrollLeft + activeThumbailRect.left - thumbnailsContainerRect.left,
+            top: thumbnailsContainer.scrollTop + activeThumbailRect.top - thumbnailsContainerRect.top,
+            behavior: 'smooth',
+          });
+        }
+
+        if (
+          (thumbnailsContainerRect.right - safetyZone < activeThumbailRect.right
+          || thumbnailsContainerRect.left + safetyZone > activeThumbailRect.left)
+          && prestashop.responsive.mobile
+        ) {
+          thumbnailsContainer.scroll({
+            left: thumbnailsContainer.scrollLeft + activeThumbailRect.left - thumbnailsContainerRect.left,
+            top: thumbnailsContainer.scrollTop + activeThumbailRect.top - thumbnailsContainerRect.top,
+            behavior: 'smooth',
+          });
+        }
+      }
       activeThumbnail.classList.add('active');
     }
   }

--- a/src/js/product.ts
+++ b/src/js/product.ts
@@ -20,41 +20,41 @@ export default () => {
 
   function onProductSlide(event: ProductSlideEvent): void {
     const thumbnails = document.querySelectorAll(SelectorsMap.product.thumbnail);
-    const thumbContainer = document.querySelector(SelectorsMap.product.thumbContainer);
+    const thumbsContainer = document.querySelector(SelectorsMap.product.thumbsContainer);
 
     thumbnails.forEach((e: Element) => {
       e.classList.remove('active');
     });
 
-    const activeThumb = document.querySelector(SelectorsMap.product.activeThumbail(event.to));
+    const activeThumb = document.querySelector(SelectorsMap.product.activeThumbnail(event.to));
 
     if (activeThumb) {
       const activeThumbRect = activeThumb.getBoundingClientRect();
 
-      if (thumbContainer) {
-        const thumbContainerRect = thumbContainer.getBoundingClientRect();
+      if (thumbsContainer) {
+        const thumbsContainerRect = thumbsContainer.getBoundingClientRect();
         const safetyZone = 20;
 
         if (
-          (thumbContainerRect.bottom - safetyZone < activeThumbRect.top
-          || thumbContainerRect.top + safetyZone > activeThumbRect.bottom)
+          (thumbsContainerRect.bottom - safetyZone < activeThumbRect.top
+          || thumbsContainerRect.top + safetyZone > activeThumbRect.bottom)
           && !prestashop.responsive.mobile
         ) {
-          thumbContainer.scroll({
-            left: thumbContainer.scrollLeft + activeThumbRect.left - thumbContainerRect.left,
-            top: thumbContainer.scrollTop + activeThumbRect.top - thumbContainerRect.top,
+          thumbsContainer.scroll({
+            left: thumbsContainer.scrollLeft + activeThumbRect.left - thumbsContainerRect.left,
+            top: thumbsContainer.scrollTop + activeThumbRect.top - thumbsContainerRect.top,
             behavior: 'smooth',
           });
         }
 
         if (
-          (thumbContainerRect.right - safetyZone < activeThumbRect.right
-          || thumbContainerRect.left + safetyZone > activeThumbRect.left)
+          (thumbsContainerRect.right - safetyZone < activeThumbRect.right
+          || thumbsContainerRect.left + safetyZone > activeThumbRect.left)
           && prestashop.responsive.mobile
         ) {
-          thumbContainer.scroll({
-            left: thumbContainer.scrollLeft + activeThumbRect.left - thumbContainerRect.left,
-            top: thumbContainer.scrollTop + activeThumbRect.top - thumbContainerRect.top,
+          thumbsContainer.scroll({
+            left: thumbsContainer.scrollLeft + activeThumbRect.left - thumbsContainerRect.left,
+            top: thumbsContainer.scrollTop + activeThumbRect.top - thumbsContainerRect.top,
             behavior: 'smooth',
           });
         }

--- a/src/js/product.ts
+++ b/src/js/product.ts
@@ -20,7 +20,7 @@ export default () => {
 
   function onProductSlide(event: ProductSlideEvent): void {
     const thumbnails = document.querySelectorAll(SelectorsMap.product.thumbnail);
-    const thumbnailsContainer = document.querySelector(SelectorsMap.product.thumbnailsContainer);
+    const thumbContainer = document.querySelector(SelectorsMap.product.thumbContainer);
 
     thumbnails.forEach((e: Element) => {
       e.classList.remove('active');
@@ -31,8 +31,8 @@ export default () => {
     if (activeThumb) {
       const activeThumbRect = activeThumb.getBoundingClientRect();
 
-      if (thumbnailsContainer) {
-        const thumbContainerRect = thumbnailsContainer.getBoundingClientRect();
+      if (thumbContainer) {
+        const thumbContainerRect = thumbContainer.getBoundingClientRect();
         const safetyZone = 20;
 
         if (
@@ -40,9 +40,9 @@ export default () => {
           || thumbContainerRect.top + safetyZone > activeThumbRect.bottom)
           && !prestashop.responsive.mobile
         ) {
-          thumbnailsContainer.scroll({
-            left: thumbnailsContainer.scrollLeft + activeThumbRect.left - thumbContainerRect.left,
-            top: thumbnailsContainer.scrollTop + activeThumbRect.top - thumbContainerRect.top,
+          thumbContainer.scroll({
+            left: thumbContainer.scrollLeft + activeThumbRect.left - thumbContainerRect.left,
+            top: thumbContainer.scrollTop + activeThumbRect.top - thumbContainerRect.top,
             behavior: 'smooth',
           });
         }
@@ -52,9 +52,9 @@ export default () => {
           || thumbContainerRect.left + safetyZone > activeThumbRect.left)
           && prestashop.responsive.mobile
         ) {
-          thumbnailsContainer.scroll({
-            left: thumbnailsContainer.scrollLeft + activeThumbRect.left - thumbContainerRect.left,
-            top: thumbnailsContainer.scrollTop + activeThumbRect.top - thumbContainerRect.top,
+          thumbContainer.scroll({
+            left: thumbContainer.scrollLeft + activeThumbRect.left - thumbContainerRect.left,
+            top: thumbContainer.scrollTop + activeThumbRect.top - thumbContainerRect.top,
             behavior: 'smooth',
           });
         }

--- a/src/js/product.ts
+++ b/src/js/product.ts
@@ -26,40 +26,40 @@ export default () => {
       e.classList.remove('active');
     });
 
-    const activeThumbnail = document.querySelector(SelectorsMap.product.activeThumbail(event.to));
+    const activeThumb = document.querySelector(SelectorsMap.product.activeThumbail(event.to));
 
-    if (activeThumbnail) {
-      const activeThumbailRect = activeThumbnail.getBoundingClientRect();
+    if (activeThumb) {
+      const activeThumbRect = activeThumb.getBoundingClientRect();
 
       if (thumbnailsContainer) {
-        const thumbnailsContainerRect = thumbnailsContainer.getBoundingClientRect();
+        const thumbContainerRect = thumbnailsContainer.getBoundingClientRect();
         const safetyZone = 20;
 
         if (
-          (thumbnailsContainerRect.bottom - safetyZone < activeThumbailRect.top
-          || thumbnailsContainerRect.top + safetyZone > activeThumbailRect.bottom)
+          (thumbContainerRect.bottom - safetyZone < activeThumbRect.top
+          || thumbContainerRect.top + safetyZone > activeThumbRect.bottom)
           && !prestashop.responsive.mobile
         ) {
           thumbnailsContainer.scroll({
-            left: thumbnailsContainer.scrollLeft + activeThumbailRect.left - thumbnailsContainerRect.left,
-            top: thumbnailsContainer.scrollTop + activeThumbailRect.top - thumbnailsContainerRect.top,
+            left: thumbnailsContainer.scrollLeft + activeThumbRect.left - thumbContainerRect.left,
+            top: thumbnailsContainer.scrollTop + activeThumbRect.top - thumbContainerRect.top,
             behavior: 'smooth',
           });
         }
 
         if (
-          (thumbnailsContainerRect.right - safetyZone < activeThumbailRect.right
-          || thumbnailsContainerRect.left + safetyZone > activeThumbailRect.left)
+          (thumbContainerRect.right - safetyZone < activeThumbRect.right
+          || thumbContainerRect.left + safetyZone > activeThumbRect.left)
           && prestashop.responsive.mobile
         ) {
           thumbnailsContainer.scroll({
-            left: thumbnailsContainer.scrollLeft + activeThumbailRect.left - thumbnailsContainerRect.left,
-            top: thumbnailsContainer.scrollTop + activeThumbailRect.top - thumbnailsContainerRect.top,
+            left: thumbnailsContainer.scrollLeft + activeThumbRect.left - thumbContainerRect.left,
+            top: thumbnailsContainer.scrollTop + activeThumbRect.top - thumbContainerRect.top,
             behavior: 'smooth',
           });
         }
       }
-      activeThumbnail.classList.add('active');
+      activeThumb.classList.add('active');
     }
   }
 

--- a/src/scss/core/pages/product/_product.scss
+++ b/src/scss/core/pages/product/_product.scss
@@ -1,5 +1,6 @@
 .thumbnails__container {
-  margin-top: 1rem;
+  max-height: 38.125rem;
+  overflow-y: scroll;
 
   .thumbnail {
     &:not(:last-child) {

--- a/src/scss/core/pages/product/_product.scss
+++ b/src/scss/core/pages/product/_product.scss
@@ -3,6 +3,8 @@
   overflow-y: scroll;
 
   .thumbnail {
+    list-style-type: none;
+
     &:not(:last-child) {
       margin-bottom: 0.75rem;
     }

--- a/src/scss/custom/components/_slider.scss
+++ b/src/scss/custom/components/_slider.scss
@@ -93,10 +93,10 @@ $component-name: carousel;
   }
 
   & &-control-prev {
-    left: 3rem;
+    left: 1rem;
   }
 
   & &-control-next {
-    right: 3rem;
+    right: 1rem;
   }
 }

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -3,9 +3,61 @@
  * file that was distributed with this source code.
  *}
 
-<div class="product__images js-images-container">
+<div class="product__images js-images-container row">
   {if $product.images|@count > 0}
-    <div id="product-images" class="carousel slide js-product-carousel"
+    {block name='product_images'}
+      <div class="thumbnails__container col col-md-2"
+        <ul class="thumbnails__list row g-2">
+          {foreach from=$product.images item=image key=key}
+            <li
+              class="thumbnail js-thumb-container{if $image.id_image == $product.default_image.id_image} active{/if} col-3 col-md-2"
+              data-bs-target="#product-images"
+              data-bs-slide-to="{$key}"
+              {if $image.id_image == $product.default_image.id_image}
+                aria-current="true"
+              {/if}
+              aria-label="{l s='Product image %number%' d='Shop.Theme.Catalog' sprintf=['%number%' => $key]}"
+          >
+              <picture>
+                {if isset($image.bySize.default_xs.sources.avif)}
+                  <source 
+                    srcset="
+                      {$image.bySize.default_xs.sources.avif},
+                      {$image.bySize.default_m.sources.avif} 2x",
+                  type="image/avif"
+                  >
+                {/if}
+
+                {if isset($image.bySize.default_xs.sources.webp)}
+                  <source 
+                    srcset="
+                      {$image.bySize.default_xs.sources.webp},
+                      {$image.bySize.default_m.sources.webp} 2x"
+                    type="image/webp"
+                  >
+                {/if}
+
+                <img
+                  class="img-fluid js-thumb{if $image.id_image == $product.default_image.id_image} js-thumb-selected{/if}"
+                  srcset="
+                    {$image.bySize.default_xs.url},
+                    {$image.bySize.default_m.url} 2x"
+                  width="{$image.bySize.default_xs.width}"
+                  height="{$image.bySize.default_xs.height}"
+                  loading="lazy"
+                  alt="{$image.legend}"
+                  title="{$image.legend}"
+                >
+              </picture>
+            </li>
+          {/foreach}
+        </ul>
+      </div>
+    {/block}
+
+    {hook h='displayAfterProductThumbs' product=$product}
+
+    <div id="product-images" class="carousel slide js-product-carousel col col-md-10"
       data-bs-ride="carousel" data-bs-interval="false">
 
       <div class="carousel-inner">
@@ -69,58 +121,6 @@
         {/block}
       </div>
     </div>
-
-    {block name='product_images'}
-      <div class="thumbnails__container">
-        <ul class="thumbnails__list row g-2">
-          {foreach from=$product.images item=image key=key}
-            <li
-              class="thumbnail js-thumb-container{if $image.id_image == $product.default_image.id_image} active{/if} col-3 col-md-2"
-              data-bs-target="#product-images"
-              data-bs-slide-to="{$key}"
-              {if $image.id_image == $product.default_image.id_image}
-                aria-current="true"
-              {/if}
-              aria-label="{l s='Product image %number%' d='Shop.Theme.Catalog' sprintf=['%number%' => $key]}"
-          >
-              <picture>
-                {if isset($image.bySize.default_xs.sources.avif)}
-                  <source 
-                    srcset="
-                      {$image.bySize.default_xs.sources.avif},
-                      {$image.bySize.default_m.sources.avif} 2x",
-                  type="image/avif"
-                  >
-                {/if}
-
-                {if isset($image.bySize.default_xs.sources.webp)}
-                  <source 
-                    srcset="
-                      {$image.bySize.default_xs.sources.webp},
-                      {$image.bySize.default_m.sources.webp} 2x"
-                    type="image/webp"
-                  >
-                {/if}
-
-                <img
-                  class="img-fluid js-thumb{if $image.id_image == $product.default_image.id_image} js-thumb-selected{/if}"
-                  srcset="
-                    {$image.bySize.default_xs.url},
-                    {$image.bySize.default_m.url} 2x"
-                  width="{$image.bySize.default_xs.width}"
-                  height="{$image.bySize.default_xs.height}"
-                  loading="lazy"
-                  alt="{$image.legend}"
-                  title="{$image.legend}"
-                >
-              </picture>
-            </li>
-          {/foreach}
-        </ul>
-      </div>
-    {/block}
-
-    {hook h='displayAfterProductThumbs' product=$product}
   {else}
     <picture>
       {if isset($urls.no_picture_image.bySize.default_md.sources.avif)}

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -10,7 +10,7 @@
         <ul class="thumbnails__list row g-2">
           {foreach from=$product.images item=image key=key}
             <li
-              class="thumbnail js-thumb-container{if $image.id_image == $product.default_image.id_image} active{/if} col-3 col-md-2"
+              class="thumbnail js-thumb-container{if $image.id_image == $product.default_image.id_image} active{/if}"
               data-bs-target="#product-images"
               data-bs-slide-to="{$key}"
               {if $image.id_image == $product.default_image.id_image}
@@ -58,7 +58,7 @@
     {hook h='displayAfterProductThumbs' product=$product}
 
     <div id="product-images" class="carousel slide js-product-carousel col col-md-10"
-      data-bs-ride="carousel" data-bs-interval="false">
+      data-bs-ride="carousel" data-bs-interval="5000">
 
       <div class="carousel-inner">
         {include file='catalog/_partials/product-flags.tpl'}

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -6,11 +6,11 @@
 <div class="product__images js-images-container row">
   {if $product.images|@count > 0}
     {block name='product_images'}
-      <div class="thumbnails__container col col-md-2"
+      <div class="thumbnails__container row mt-4 mt-md-0 flex-nowrap flex-md-wrap js-thumbnails-container px-3 col-12 col-md-2 order-2 order-md-1"
         <ul class="thumbnails__list row g-2">
           {foreach from=$product.images item=image key=key}
             <li
-              class="thumbnail js-thumb-container{if $image.id_image == $product.default_image.id_image} active{/if}"
+              class="thumbnail p-md-0 col-4 col-sm-3 col-md-12 js-thumb-container{if $image.id_image == $product.default_image.id_image} active{/if}"
               data-bs-target="#product-images"
               data-bs-slide-to="{$key}"
               {if $image.id_image == $product.default_image.id_image}
@@ -57,7 +57,7 @@
 
     {hook h='displayAfterProductThumbs' product=$product}
 
-    <div id="product-images" class="carousel slide js-product-carousel col col-md-10"
+    <div id="product-images" class="carousel slide js-product-carousel col-12 col-md-10 order-1 order-md-2"
       data-bs-ride="carousel" data-bs-interval="5000">
 
       <div class="carousel-inner">

--- a/types/selectors.d.ts
+++ b/types/selectors.d.ts
@@ -132,7 +132,7 @@ type SelectorsMap = {
     carousel: string,
     miniature: string,
     thumbnail: string,
-    activeThumbail: (id: number) => string,
+    activeThumbnail: (id: number) => string,
   },
   modalBody: string,
   pageCms: string,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | It's scrollable and scrolling in case the element is out of the scrollable div
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go on a product page with a ton of thumbnails
| Possible impacts? | Product page images

<img width="627" alt="image" src="https://user-images.githubusercontent.com/14963751/208091268-78364b4e-16be-4066-b9ba-3327b93a3057.png">



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
