### PR TITLE
Fix missing closing html tag

### DIFF
--- a/modules/productcomments/views/templates/hook/post-comment-modal.tpl
+++ b/modules/productcomments/views/templates/hook/post-comment-modal.tpl
@@ -59,6 +59,7 @@
                           height="{$product.cover.bySize.default_xs.height}"
                           alt="{$product.cover.legend}"
                           title="{$product.cover.legend}"
+                        >
                       </picture>
                     {else}
                       <picture>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | There was a missing closing tag we couldn't see because it seems that the browser is intelligent enough to close it alone
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | postcomment module should work as expected
| Possible impacts? | Postcomment images

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
