### PR TITLE
Reorder order confirmations hooks

### DIFF
--- a/templates/checkout/order-confirmation.tpl
+++ b/templates/checkout/order-confirmation.tpl
@@ -38,6 +38,10 @@
     {$HOOK_ORDER_CONFIRMATION nofilter}
   {/block}
 
+  {block name='hook_order_confirmation_1'}
+    {hook h='displayOrderConfirmation1'}
+  {/block}
+
   {block name='order_details'}
     <div class="{$componentName}__details card bg-light border-1 mb-3">
       <div class="card-body">
@@ -71,10 +75,6 @@
       </div>
     {/block}
   {/if}
-
-  {block name='hook_order_confirmation_1'}
-    {hook h='displayOrderConfirmation1'}
-  {/block}
 
   {block name='hook_order_confirmation_2'}
     {hook h='displayOrderConfirmation2'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | 2 hooks at the end was stupid, we need one inside the content
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #392 .
| How to test?      | Nothing really important to test, but you can hook on `displayOrderConfirmation1` and see if it's inside the content
| Possible impacts? | Order confirmations hooks

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
