### PR TITLE
Add an add to cart button to the product list

### DIFF
--- a/src/js/theme.ts
+++ b/src/js/theme.ts
@@ -31,6 +31,12 @@ initEmitter();
 $(() => {
   const {prestashop, Theme: {events}} = window;
 
+  // @TODO: Fix this on core.js side inside a major version of PrestaShop instead of minor
+  // For reference: https://github.com/PrestaShop/hummingbird/pull/418#discussion_r1061938669
+  document.querySelectorAll<HTMLInputElement>('[name="token"]').forEach((el) => {
+    el.value = prestashop.static_token;
+  });
+
   initProductBehavior();
   initQuickview();
   initCheckout();

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -167,6 +167,11 @@
                 {/if}
               {/block}
             </div>
+            {if $product.attributes|@count}
+              <a href="{$product.url}" class="btn btn-outline-primary mt-3">
+                {l s='Choose variant' d='Shop.Theme.Actions'}
+              </a>
+            {/if}
 
             {if $product.add_to_cart_url && !$product.is_customizable && !$product.attributes|@count}
               <form action="{$urls.pages.cart}" method="post" class="d-flex align-items-center mt-3">

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -182,7 +182,10 @@
                     marginHelper="mb-0"
                   }
                 </div>
-                <button data-button-action="add-to-cart" class="btn btn-primary ms-3"><i class="material-icons">&#xe854;</i></button>
+                <button data-button-action="add-to-cart" class="btn btn-primary ms-3">
+                  <i class="material-icons">&#xe854;</i>
+                  <span class="visually-hidden">{l s='Add to cart' d='Shop.Theme.Actions'}</span>
+                </button>
               </form>
             {/if}
           </div>

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -167,13 +167,14 @@
                 {/if}
               {/block}
             </div>
+
             {if $product.attributes|@count}
               <a href="{$product.url}" class="btn btn-outline-primary mt-3">
-                {l s='Choose variant' d='Shop.Theme.Actions'}
+                {l s='See details' d='Shop.Theme.Actions'}
               </a>
             {/if}
 
-            {if $product.add_to_cart_url && !$product.is_customizable && !$product.attributes|@count}
+            {if $product.add_to_cart_url && !$product.attributes|@count}
               <form action="{$urls.pages.cart}" method="post" class="d-flex align-items-center mt-3">
                 <input type="hidden" value="{$product.id_product}" name="id_product">
                 <input type="hidden" name="token" value="{$static_token}" />

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -168,14 +168,14 @@
               {/block}
             </div>
 
-            {if $product.add_to_cart_url}
+            {if $product.add_to_cart_url && !$product.is_customizable && !$product.attributes|@count}
               <form action="{$urls.pages.cart}" method="post" class="d-flex align-items-center mt-3">
                 <input type="hidden" value="{$product.id_product}" name="id_product">
                 <input type="hidden" name="token" value="{$static_token}" />
                 <div class="quantity-button js-quantity-button">
                   {include file='components/qty-input.tpl'
                     attributes=[
-                      "id"=>"quantity_wanted",
+                      "id"=>"quantity_wanted_{$product.id_product}",
                       "value"=>"1",
                       "min"=>"{if $product.quantity_wanted}{$product.minimal_quantity}{else}1{/if}"
                     ]

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -168,6 +168,23 @@
               {/block}
             </div>
 
+            {if $product.add_to_cart_url}
+              <form action="{$urls.pages.cart}" method="post" class="d-flex align-items-center mt-3">
+                <input type="hidden" value="{$product.id_product}" name="id_product">
+                <input type="hidden" name="token" value="{$static_token}" />
+                <div class="quantity-button js-quantity-button">
+                  {include file='components/qty-input.tpl'
+                    attributes=[
+                      "id"=>"quantity_wanted",
+                      "value"=>"1",
+                      "min"=>"{if $product.quantity_wanted}{$product.minimal_quantity}{else}1{/if}"
+                    ]
+                    marginHelper="mb-0"
+                  }
+                </div>
+                <button data-button-action="add-to-cart" class="btn btn-primary ms-3"><i class="material-icons">&#xe854;</i></button>
+              </form>
+            {/if}
           </div>
         </div>
       {/block}

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -168,13 +168,13 @@
               {/block}
             </div>
 
-            {if $product.attributes|@count}
+            {if !$product.add_to_cart_url}
               <a href="{$product.url}" class="btn btn-outline-primary mt-3">
                 {l s='See details' d='Shop.Theme.Actions'}
               </a>
             {/if}
 
-            {if $product.add_to_cart_url && !$product.attributes|@count}
+            {if $product.add_to_cart_url}
               <form action="{$urls.pages.cart}" method="post" class="d-flex align-items-center mt-3">
                 <input type="hidden" value="{$product.id_product}" name="id_product">
                 <input type="hidden" name="token" value="{$static_token}" />

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -168,12 +168,6 @@
               {/block}
             </div>
 
-            {if !$product.add_to_cart_url}
-              <a href="{$product.url}" class="btn btn-outline-primary mt-3">
-                {l s='See details' d='Shop.Theme.Actions'}
-              </a>
-            {/if}
-
             {if $product.add_to_cart_url}
               <form action="{$urls.pages.cart}" method="post" class="d-flex align-items-center mt-3">
                 <input type="hidden" value="{$product.id_product}" name="id_product">
@@ -193,6 +187,10 @@
                   <span class="visually-hidden">{l s='Add to cart' d='Shop.Theme.Actions'}</span>
                 </button>
               </form>
+            {else}
+              <a href="{$product.url}" class="btn btn-outline-primary mt-3">
+                {l s='See details' d='Shop.Theme.Actions'}
+              </a>
             {/if}
           </div>
         </div>

--- a/templates/components/qty-input.tpl
+++ b/templates/components/qty-input.tpl
@@ -18,7 +18,7 @@
   {assign var="append" value=["button"=>"increment", "icon"=>$increment_icon, "confirm_icon"=>$submit_icon]}
 {/if}
 
-<div class="input-group flex-nowrap mb-3">
+<div class="input-group flex-nowrap{if isset($marginHelper)} {$marginHelper}{else} mb-3{/if}">
   <button class="btn {$prepend.button} js-{$prepend.button}-button" type="button">
     <i class="material-icons">&#x{$prepend.icon};</i>
     <i class="material-icons confirmation d-none">&#x{$prepend.confirm_icon};</i>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We want to add an add to cart button to the product list, if child themes wants to remove it, they can override `product.tpl` and remove that markup
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go on product lists and try to add some products from there
| Possible impacts? | Product list

<img width="1338" alt="image" src="https://user-images.githubusercontent.com/14963751/210335263-e3e1c5be-a85e-4c40-b5fb-2d25e5b315bf.png">



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
