### PR TITLE
Add blockwishlist to theme.yml displayFooter

### DIFF
--- a/config/theme.yml
+++ b/config/theme.yml
@@ -85,7 +85,7 @@ global_settings:
         - ps_linklist
         - ps_customeraccountlinks
         - ps_contactinfo
-        - ~
+        - blockwishlist
       displayLeftColumn:
         - ps_categorytree
         - ps_facetedsearch


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Blockwishlist missing in displayFooter hook cause missing EventBus, so there is no Blockwishlist listener on fresh Hummingbird installation
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
