### PR TITLE
Initiate useQuantityInput on facetedsearch dom change

### DIFF
--- a/src/js/modules/facetedsearch/update.ts
+++ b/src/js/modules/facetedsearch/update.ts
@@ -3,6 +3,8 @@
  * file that was distributed with this source code.
  */
 
+import useQuantityInput from '@js/components/useQuantityInput';
+
 // @TODO(NeOMakinG): Refactor this file, it comes from facetedsearch or classic
 export const parseSearchUrl = function (event: {target: HTMLElement}) {
   if (event.target.dataset.searchUrl !== undefined) {
@@ -96,6 +98,7 @@ export default () => {
 
   prestashop.on(events.updateProductList, (data: Record<string, never>) => {
     updateProductListDOM(data);
+    useQuantityInput();
     window.scrollTo(0, 0);
   });
 };


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If you use facetedsearch, the product list markup is getting replaced and the qty input is not working anymore, we need to initiate it again
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go on product list, click on the qty input, it should work, filter using facetedsearch, it should work again
| Possible impacts? | qty input on product list

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
