### PR TITLE
Improved a11y for ps-emailsubscription templates

### DIFF
--- a/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription-column.tpl
+++ b/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription-column.tpl
@@ -5,7 +5,7 @@
 
 <div class="block_newsletter" id="blockEmailSubscription_{$hookName}">
   <form action="{$urls.current_url}#blockEmailSubscription_{$hookName}" method="post">
-    <p id="block-newsletter-label">{l s='Get our latest news and special sales' d='Shop.Theme.Global'}</p>
+    <p id="block-newsletter-label-{$hookName}">{l s='Get our latest news and special sales' d='Shop.Theme.Global'}</p>
     <div class="mb-1">
       <input
         class="btn btn-primary float-end"
@@ -19,7 +19,7 @@
           type="email"
           value="{$value}"
           placeholder="{l s='Your email address' d='Shop.Forms.Labels'}"
-          aria-labelledby="block-newsletter-label"
+          aria-labelledby="block-newsletter-label-{$hookName}"
           required
         >
       </div>

--- a/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription-column.tpl
+++ b/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription-column.tpl
@@ -20,6 +20,7 @@
           value="{$value}"
           placeholder="{l s='Your email address' d='Shop.Forms.Labels'}"
           aria-labelledby="block-newsletter-label"
+          required
         >
       </div>
       <input type="hidden" name="blockHookName" value="{$hookName}" />

--- a/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -9,7 +9,7 @@
   <div class="container px-1">
     <div class="{$componentName}__content row">
       <div class="{$componentName}__content__left col-md-5">
-        <p class="{$componentName}__label">{l s='Get our latest news and special sales' d='Shop.Theme.Global'}</p>
+        <p id="block-newsletter-label" class="{$componentName}__label">{l s='Get our latest news and special sales' d='Shop.Theme.Global'}</p>
       </div>
 
       <div class="{$componentName}__content__right col-md-7">

--- a/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -9,7 +9,7 @@
   <div class="container px-1">
     <div class="{$componentName}__content row">
       <div class="{$componentName}__content__left col-md-5">
-        <p id="block-newsletter-label" class="{$componentName}__label">{l s='Get our latest news and special sales' d='Shop.Theme.Global'}</p>
+        <p id="block-newsletter-label-{$hookName}" class="{$componentName}__label">{l s='Get our latest news and special sales' d='Shop.Theme.Global'}</p>
       </div>
 
       <div class="{$componentName}__content__right col-md-7">
@@ -21,7 +21,7 @@
               class="form-control"
               value="{$value}"
               placeholder="{l s='Your email address' d='Shop.Forms.Labels'}"
-              aria-labelledby="block-newsletter-label"
+              aria-labelledby="block-newsletter-label-{$hookName}"
               required
            >
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | `id` was missing for `aria-labelledby`. 
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | ~
| Possible impacts? | ~

Related to https://github.com/PrestaShop/hummingbird/issues/251. 

I also added a `required` attribute  in `modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription-column.tpl` because I think it was forgotten. 