### PR TITLE
Add global error handler

### DIFF
--- a/src/js/errors.ts
+++ b/src/js/errors.ts
@@ -1,0 +1,19 @@
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import useToast from './components/useToast';
+
+const initErrorHandler = () => {
+  const {Theme: {events}} = window;
+  const {prestashop} = window;
+
+  prestashop.on(events.handleError, ({resp}: {resp: {errors: string[]}}) => {
+    resp.errors.forEach((error) => {
+      useToast(error, {type: 'danger'}).show();
+    });
+  });
+};
+
+export default initErrorHandler;

--- a/src/js/theme.ts
+++ b/src/js/theme.ts
@@ -16,6 +16,7 @@ import initSearchbar from './modules/ps_searchbar';
 import initLanguageSelector from './modules/ps_languageselector';
 import initCurrencySelector from './modules/ps_currencyselector';
 import initVisiblePassword from './visible-password';
+import initErrorHandler from './errors';
 import useToast from './components/useToast';
 import useAlert from './components/useAlert';
 import usePasswordPolicy from './components/usePasswordPolicy';
@@ -51,6 +52,7 @@ $(() => {
   initVisiblePassword();
   initDesktopMenu();
   initFormValidation();
+  initErrorHandler();
   usePasswordPolicy('.field-password-policy');
 
   prestashop.on(events.responsiveUpdate, () => {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The core sometime send some errors events that we want to handle and display toasts
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to add a product on product list with like 999999 quantity to trigger an error with https://github.com/PrestaShop/PrestaShop/pull/29016#event-8230441478 at the same time
| Possible impacts? | Nothing really

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
