### PR TITLE
product page - gallery zoom photoswipe

### DIFF
--- a/src/scss/custom/components/_slider.scss
+++ b/src/scss/custom/components/_slider.scss
@@ -10,9 +10,6 @@ $component-name: carousel;
     justify-content: center;
     height: 100%;
 
-    // &.active {
-    //   display: flex;
-    // }
 
     img {
       width: 100%;

--- a/src/scss/custom/components/_slider.scss
+++ b/src/scss/custom/components/_slider.scss
@@ -10,9 +10,9 @@ $component-name: carousel;
     justify-content: center;
     height: 100%;
 
-    &.active {
-      display: flex;
-    }
+    // &.active {
+    //   display: flex;
+    // }
 
     img {
       width: 100%;

--- a/src/scss/custom/pages/product/_product.scss
+++ b/src/scss/custom/pages/product/_product.scss
@@ -23,6 +23,23 @@
         overflow: hidden;
         border-radius: 8px;
       }
+
+      &__modal-opener {
+        position: absolute;
+        right: 0.635rem;
+        bottom: 0.635rem;
+        z-index: 10;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 2.5rem;
+        min-width: 2.5rem;
+        height: 2.5rem;
+        background-color: #fff;
+        border: none;
+        border-radius: 50%;
+        box-shadow: 0.125rem -0.125rem 0.25rem 0 rgb(0 0 0 / 20%);
+      }
     }
 
     &__description-short {

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -5,8 +5,11 @@
 
 <div class="product__images js-images-container">
   {if $product.images|@count > 0}
-    <div id="product-images" class="carousel slide js-product-carousel"
-      data-bs-ride="carousel">
+    <div
+      id="product-images"
+      class="carousel slide js-product-carousel"
+      data-bs-ride="carousel"
+      >
 
       <div class="carousel-inner">
         {include file='catalog/_partials/product-flags.tpl'}
@@ -24,7 +27,10 @@
 
         {block name='product_cover'}
           {foreach from=$product.images item=image key=key name=productImages}
-            <div class="carousel-item{if $image.id_image == $product.default_image.id_image} active{/if}">
+            <div class="carousel-item{if $image.id_image == $product.default_image.id_image} active{/if}"
+              data-bs-target="#product-images-modal"
+              data-bs-slide-to="{$key}"
+              >
               <picture>
                 {if isset($image.bySize.default_md.sources.avif)}
                   <source 
@@ -64,6 +70,9 @@
                   data-full-size-image-url="{$image.bySize.home_default.url}"
                 >
               </picture>
+              <div class="product__images__modal-opener" data-bs-toggle="modal" data-bs-target="#product-modal">
+                <i class="material-icons zoom-in">search</i>
+              </div>
             </div>
           {/foreach}
         {/block}

--- a/templates/catalog/_partials/product-images-modal.tpl
+++ b/templates/catalog/_partials/product-images-modal.tpl
@@ -3,56 +3,72 @@
  * file that was distributed with this source code.
  *}
 <div class="modal fade js-product-images-modal" id="product-modal">
-  <div class="modal-dialog" role="document">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-body">
-        {assign var=imagesCount value=$product.images|count}
-        <figure>
-          {if $product.default_image}
-            <img
-              class="js-modal-product-cover product-cover-modal"
-              width="{$product.default_image.bySize.large_default.width}"
-              src="{$product.default_image.bySize.large_default.url}"
-              alt="{$product.default_image.legend}"
-              title="{$product.default_image.legend}"
-              height="{$product.default_image.bySize.large_default.height}"
-           >
-          {else}
-            <img src="{$urls.no_picture_image.bySize.large_default.url}" loading="lazy" width="{$urls.no_picture_image.bySize.large_default.width}" height="{$urls.no_picture_image.bySize.large_default.height}" />
-          {/if}
-          <figcaption class="image-caption">
-          {block name='product_description_short'}
-            <div id="product-description-short">{$product.description_short nofilter}</div>
-          {/block}
-        </figcaption>
-        </figure>
-        <aside id="thumbnails" class="thumbnails js-thumbnails text-sm-center">
-          {block name='product_images'}
-            <div class="js-modal-mask mask {if $imagesCount <= 5} nomargin {/if}">
-              <ul class="product-images js-modal-product-images">
-                {foreach from=$product.images item=image}
-                  <li class="thumb-container js-thumb-container">
-                    <img
-                      data-image-large-src="{$image.large.url}"
-                      class="thumb js-modal-thumb"
-                      src="{$image.medium.url}"
-                      alt="{$image.legend}"
-                      title="{$image.legend}"
-                      width="{$image.medium.width}"
-                      height="148"
-                   >
-                  </li>
-                {/foreach}
-              </ul>
-            </div>
-          {/block}
-          {if $imagesCount> 5}
-            <div class="arrows js-modal-arrows">
-              <i class="material-icons arrow-up js-modal-arrow-up">&#xE5C7;</i>
-              <i class="material-icons arrow-down js-modal-arrow-down">&#xE5C5;</i>
-            </div>
-          {/if}
-        </aside>
+        <div
+          id="product-images-modal"
+          class="carousel slide js-product-images-modal-carousel"
+          data-bs-ride="carousel"
+        >
+          <div class="carousel-inner">
+
+            {if $product.images|@count > 1}
+              <button class="carousel-control-prev" type="button" data-bs-target="#product-images-modal" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Previous</span>
+              </button>
+              <button class="carousel-control-next" type="button" data-bs-target="#product-images-modal" data-bs-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Next</span>
+              </button>
+            {/if}
+
+            {foreach from=$product.images item=image key=key name=productImages}
+              <div class="carousel-item{if $image.id_image == $product.default_image.id_image} active{/if}">
+                <picture>
+                  {if isset($image.bySize.default_md.sources.avif)}
+                    <source 
+                      srcset="
+                        {$image.bySize.default_md.sources.avif} 320w,
+                        {$image.bySize.product_main.sources.avif} 720w,
+                        {$image.bySize.product_main_2x.sources.avif} 1440w"
+                      sizes="(min-width: 1300px) 720px, (min-width: 768px) 50vw, 100vw" 
+                      type="image/avif"
+                    >
+                  {/if}
+
+                  {if isset($image.bySize.default_md.sources.webp)}
+                    <source 
+                      srcset="
+                        {$image.bySize.default_md.sources.webp} 320w,
+                        {$image.bySize.product_main.sources.webp} 720w,
+                        {$image.bySize.product_main_2x.sources.webp} 1440w"
+                      sizes="(min-width: 1300px) 720px, (min-width: 768px) 50vw, 100vw" 
+                      type="image/webp"
+                    >
+                  {/if}
+
+                  <img
+                    class="img-fluid"
+                    srcset="
+                      {$image.bySize.default_md.url} 320w,
+                      {$image.bySize.product_main.url} 720w,
+                      {$image.bySize.product_main_2x.url} 1440w"
+                    sizes="(min-width: 1300px) 720px, (min-width: 768px) 50vw, 100vw" 
+                    src="{$image.bySize.product_main.url}" 
+                    width="{$image.bySize.product_main.width}"
+                    height="{$image.bySize.product_main.height}"
+                    loading="{if $smarty.foreach.productImages.first}eager{else}lazy{/if}"
+                    alt="{$image.legend}"
+                    title="{$image.legend}"
+                    data-full-size-image-url="{$image.bySize.home_default.url}"
+                  >
+                </picture>
+              </div>
+            {/foreach}
+          </div>
+        </div>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If I understood the task correctly, I added a slider for the photo gallery in the modal, after clicking on the icon, we should see the correct photo and the modal with the slider, I also found a bug when we added the `display flex`  to the class active in slider, it looks wrong. below is an example
| Type?             | bug fix / improvement
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #421 


## Active class with display: flex;
https://user-images.githubusercontent.com/48727835/213734964-de8a7ad4-acc4-403e-b68f-1d523a35dc29.mp4

## Active class without display: flex;
https://user-images.githubusercontent.com/48727835/213735168-b9ea5460-2fc2-41c5-9ea5-361dff4b9ef4.mp4

## Appearance after changes
https://user-images.githubusercontent.com/48727835/213735317-54c90b04-98dc-4865-825c-d0d27566fc1f.mp4

## Mobile view
![mobile_photo](https://user-images.githubusercontent.com/48727835/213735399-09247339-1741-43ac-bf6f-6519d7855a62.png)



