### PR TITLE
Make carrier logo image fluid

### DIFF
--- a/templates/checkout/_partials/steps/shipping.tpl
+++ b/templates/checkout/_partials/steps/shipping.tpl
@@ -34,7 +34,7 @@
                             <div class="row align-items-center">
                               {if $carrier.logo}
                                 <div class="col-md-4 carrier__logo">
-                                    <img src="{$carrier.logo}" class="rounded" alt="{$carrier.name}" loading="lazy" />
+                                    <img src="{$carrier.logo}" class="rounded img-fluid" alt="{$carrier.name}" loading="lazy" />
                                 </div>
                               {/if}
 


### PR DESCRIPTION
add ```image-fluid``` to ```carrier__logo>img```

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixes carrier logo is too big issue #439 
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #439 
| Sponsor company   | 
| How to test?      | Order page 3, shipping
