### PR TITLE
Modified Add-to-card form and token function on homepage

### DIFF
--- a/src/js/theme.ts
+++ b/src/js/theme.ts
@@ -34,7 +34,7 @@ $(() => {
 
   // @TODO: Fix this on core.js side inside a major version of PrestaShop instead of minor
   // For reference: https://github.com/PrestaShop/hummingbird/pull/418#discussion_r1061938669
-  document.querySelectorAll<HTMLInputElement>('[name="token"]').forEach((el) => {
+  document.querySelectorAll<HTMLInputElement>('#add_to_card_hp [name="token"]').forEach((el) => {
     el.value = prestashop.static_token;
   });
 

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -169,7 +169,7 @@
             </div>
 
             {if $product.add_to_cart_url}
-              <form action="{$urls.pages.cart}" method="post" class="d-flex align-items-center mt-3">
+              <form action="{$urls.pages.cart}" method="post" class="d-flex align-items-center mt-3" id="add_to_card_hp">
                 <input type="hidden" value="{$product.id_product}" name="id_product">
                 <input type="hidden" name="token" value="{$static_token}" />
                 <div class="quantity-button js-quantity-button">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | An ID has been added to the 'add-to-card' form on the homepage and the function that provides tokens in the 'product.ts' file has been modified to only affect forms with that specific ID.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #441 
| Sponsor company   | 
| How to test?      | The ability to add items to a card on the homepage, the capability to include a new address during the checkout process, and the capability to add a new address in the 'My Account' page should be present and function correctly without any errors.
