### PR TITLE
Partially fix checkout tabs

### DIFF
--- a/src/js/pages/checkout.ts
+++ b/src/js/pages/checkout.ts
@@ -29,7 +29,7 @@ const initCheckout = () => {
       responsiveStep?.classList.remove('d-none');
     }
 
-    content.classList.add('js-current-step');
+    content.classList.add('js-current-step', 'step--current');
   };
 
   actionButtons.forEach((button) => {

--- a/templates/checkout/_partials/steps/checkout-step.tpl
+++ b/templates/checkout/_partials/steps/checkout-step.tpl
@@ -12,8 +12,10 @@
                         'step--reachable'      => $step_is_reachable,
                         'step--complete'       => $step_is_complete && !$step_is_current,
                         'js-current-step' => $step_is_current,
-                        'active' => $step_is_current
+                        'active' => $step_is_current,
+                        'show' => $step_is_current
                     ]|classnames} mb-5"
+            role = "tabpanel"
   >
     <div class="step__title js-step-title">
       <h1 class="step__title-left h3">

--- a/templates/checkout/checkout-steps.tpl
+++ b/templates/checkout/checkout-steps.tpl
@@ -10,7 +10,7 @@
 
 {block name='checkout_steps'}
 <div class="{$componentName} bg-light py-2 {if isset($notifications) && $hasNotifications}mb-2 mb-lg-4{else}mb-3 mb-lg-5{/if} py-md-4">
-    <ul class="{$componentName}__list nav nav-tabs border-0 row mb-0 d-none d-md-flex">
+    <ul class="{$componentName}__list nav nav-tabs border-0 row mb-0 d-none d-md-flex" role="tablist">
       <li 
         class="{$componentName}__item nav-item js-step-item text-center col-3" 
         data-step="checkout-personal-information-step" 
@@ -23,6 +23,7 @@
           class="{$componentName}__text nav-link w-100 bg-transparent btn p-0 border-0 mb-0"
           data-bs-toggle="tab" 
           data-bs-target="#checkout-personal-information-step"
+          role="tab"
         >
           {l s='Personal Information' d='Shop.Theme.Checkout'}
         </button>
@@ -40,6 +41,7 @@
           class="{$componentName}__text nav-link w-100 bg-transparent btn p-0 border-0 mb-0"
           data-bs-toggle="tab" 
           data-bs-target="#checkout-addresses-step"
+          role="tab"
         >
           {l s='Addresses' d='Shop.Theme.Checkout'}
         </button>
@@ -57,6 +59,7 @@
           class="{$componentName}__text nav-link w-100 bg-transparent btn p-0 border-0 mb-0"
           data-bs-toggle="tab" 
           data-bs-target="#checkout-delivery-step"
+          role="tab"
         >
           {l s='Shipping method' d='Shop.Theme.Checkout'}
         </button>
@@ -74,6 +77,7 @@
           class="{$componentName}__text nav-link w-100 bg-transparent btn p-0 border-0 mb-0"
           data-bs-toggle="tab" 
           data-bs-target="#checkout-payment-step"
+          role="tab"
         >
           {l s='Payment' d='Shop.Theme.Checkout'}
         </button>

--- a/templates/checkout/checkout.tpl
+++ b/templates/checkout/checkout.tpl
@@ -20,12 +20,12 @@
   <div class="container">
     <div class="row">
 
-      <div class="cart-grid-body tab-content col-lg-7 order-1 order-lg-0">
+      <div class="cart-grid-body tab-content col-lg-7">
         {block name='checkout_process'}
           {render file='checkout/checkout-process.tpl' ui=$checkout_process}
         {/block}
       </div>
-      <div class="cart-grid-right col-lg-5 order-0 order-lg-1">
+      <div class="cart-grid-right col-lg-5">
         <div class="accordion">
           <div class="accordion-item bg-transparent">
             <button class="accordion-button collapsed px-0 mb-3 d-flex d-lg-none bg-transparent" type="button" data-bs-target="#js-checkout-summary" data-bs-toggle="collapse" aria-expanded="false">


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Checkout steps were missing some information during initial render.
| Type?             | 
| BC breaks?        |
| Deprecations?     | 
| Fixed ticket?     |
| Sponsor company   | 
| How to test?      | 

Ping @SharakPL Button in the breadcrumbs `(checkout-steps.tpl)` is still missing `active` class, causing buggy step switching. I don't know where to get this information.
