### PR TITLE
Fix price slider implementation stripping parameters

### DIFF
--- a/src/js/modules/facetedsearch/urlparser.ts
+++ b/src/js/modules/facetedsearch/urlparser.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+const getQueryParameters = (params: string) => params.split('&').map((str) => {
+  const [key, val] = str.split('=');
+
+  return {
+    name: key,
+    value: decodeURIComponent(val).replace(/\+/g, ' '),
+  };
+});
+
+export default getQueryParameters;

--- a/templates/catalog/listing/search.tpl
+++ b/templates/catalog/listing/search.tpl
@@ -14,6 +14,14 @@
 
 {block name='product_list_header'}
   <h1 id="js-product-list-header" class="h4">
-    {if $listing.products|count}{l s='Search results for' d='Shop.Theme.Catalog'}{else}{l s='No search results for' d='Shop.Theme.Catalog'}{/if} "{$smarty.get.s}"
+    {if empty($smarty.get.s)}
+      {l s='Nothing to search for' d='Shop.Theme.Catalog'}
+    {else}
+      {if $listing.products|count}
+        {l s='Search results for' d='Shop.Theme.Catalog'}
+      {else}
+        {l s='No search results for' d='Shop.Theme.Catalog'}
+      {/if} "{$smarty.get.s}"
+    {/if}
   </h1>
 {/block}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Price slider implementation was stripping all other parameters except `q`. For example, this resulted in breaking filtering on a search page.
| Type?             | 
| BC breaks?        | 
| Deprecations?     | 
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | 