### PR TITLE
search results dropdown fix

### DIFF
--- a/src/scss/core/components/_search.scss
+++ b/src/scss/core/components/_search.scss
@@ -62,7 +62,8 @@ $component-name: search;
 
   &-widgets {
     position: relative;
-    overflow: visible;
+    // stylelint-disable-next-line
+    overflow: visible !important;
 
     @include media-breakpoint-down(md) {
       max-width: inherit;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      |  css file from searchbar module overriding overflow, i added `!important to overflow`
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #409
| How to test?      | See screenshots below.

# Before
![image](https://user-images.githubusercontent.com/48727835/216596838-ec0c4d5d-e0fa-455a-9111-0ffdbdf055fd.png)

# After
![image](https://user-images.githubusercontent.com/48727835/216596852-00ee788f-46db-4bd8-898c-dd1ca9507c1b.png)
