### PR TITLE
check catalog mode before placing add-to-cart button

### DIFF
--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -168,7 +168,7 @@
               {/block}
             </div>
 
-            {if $product.add_to_cart_url}
+            {if $product.add_to_cart_url && !$configuration.is_catalog}
               <form action="{$urls.pages.cart}" method="post" class="d-flex align-items-center mt-3">
                 <input type="hidden" value="{$product.id_product}" name="id_product">
                 <input type="hidden" name="token" value="{$static_token}" />


### PR DESCRIPTION
Mini add-to-cart button is now checking for catalog mode before show up

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing this change. What did you change? Why?
| Type?             | bug fix 
| BC breaks?        |no
| Deprecations?     |no
| Fixed ticket?     | Fixes #455 
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | Indicate how to verify that this change works as expected.
