### PR TITLE
Reproducible installs with npm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 
 name: Build ZIP File
-on: 
+on:
   pull_request:
   push:
   workflow_dispatch:
@@ -19,7 +19,7 @@ jobs:
           node-version: 14
 
       - name: Install dependencies
-        run: npm i
+        run: npm ci
 
       - name: Copy Webpack config
         run: cp ./webpack/.env-example ./webpack/.env
@@ -50,7 +50,7 @@ jobs:
           rm postcss.config.js
           rm tsconfig.json
           rm webpack.config.js
-        
+
       - name: Create & Upload artifact
         uses: actions/upload-artifact@v1
         with:
@@ -65,17 +65,17 @@ jobs:
             uses: actions/download-artifact@v1
             with:
                 name: ${{ github.event.repository.name }}
-          
+
           - id: release_info
             uses: toolmantim/release-drafter@v5
             env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
           - name: Prepare for Release
             run: |
                 cd ${{ github.event.repository.name }}
                 zip -r ${{ github.event.repository.name }}.zip ${{ github.event.repository.name }}
-          
+
           - name: Clean existing assets
             shell: bash
             run: |
@@ -87,7 +87,7 @@ jobs:
                 done
             env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
           - name: Publish to GitHub Release
             uses: actions/upload-release-asset@v1.0.1
             env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup node env
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install dependencies
-        run: npm i
+        run: npm ci
 
       - name: Generate
         run: npm run build-storybook

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14]
+        node: [16]
 
     steps:
       - name: Checkout
         uses: actions/checkout@master
 
       - name: Setup node env
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 16
 
       - name: Lint scss
         run: npm ci && npm run scss-lint
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 16
 
       - name: Lint js
         run: touch ./webpack/.env && npm ci && npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: '14.x'
 
       - name: Lint scss
-        run: npm install && npm run scss-lint
+        run: npm ci && npm run scss-lint
   eslint:
     name: ESLint
     runs-on: ubuntu-latest
@@ -26,4 +26,4 @@ jobs:
           node-version: '14.x'
 
       - name: Lint js
-        run: touch ./webpack/.env && npm install && npm run lint
+        run: touch ./webpack/.env && npm ci && npm run lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,5 +24,5 @@ jobs:
           restore-keys: ${{ runner.os }}-node-
 
       - name: Run tests
-        run: npm install && npm run test
+        run: npm ci && npm run test
         working-directory: ./

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,10 @@ jobs:
     name: Run unit tests
     strategy:
       matrix:
-        js: [ '14' ]
+        js: [ '16' ]
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.js }}
 

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -13,4 +13,4 @@ jobs:
           node-version: '14.x'
 
       - name: Build and check types
-        run: touch ./webpack/.env && npm install && npm run build
+        run: touch ./webpack/.env && npm ci && npm run build

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -8,9 +8,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 16
 
       - name: Build and check types
         run: touch ./webpack/.env && npm ci && npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ There are few things to do before you are ready to contribute.
 
 First you need to install every node module:
 
-`npm i`
+`npm ci`
 
 then create a `.env` file inside the *webpack* folder by copying `webpack/.env-example` and complete it with your environment's informations. Please use a free tcp port.
 
@@ -35,7 +35,7 @@ then build assets:
 ### Good practices
 
 - Follow the BEM convention
-- Be careful about creating SCSS files in the right folder, refer to the [documentation](https://build.prestashop.com/hummingbird/) for further informations. 
+- Be careful about creating SCSS files in the right folder, refer to the [documentation](https://build.prestashop.com/hummingbird/) for further informations.
 - When you want to submit a PR, please make sure that you ran both linters using `npm run lint-fix && npm run scss-fix` and fixed every lint issues.
 - If your PR is a work in progress, make sure that you use the Github draft mode.
 - Fill the PR template as much as possible, it's important to speed the process of testing, reviewing...

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Same as the PrestaShop project, you need at least **NodeJS 14.x** and **NPM 7** 
 
 First you need to install every node module:
 
-`npm i`
+`npm ci`
 
 then create a `.env` file inside the *webpack* folder by copying `webpack/.env-example` and complete it with your environment's informations. Please use a free tcp port.
 
@@ -39,6 +39,6 @@ When develop is merged into master, the Storybook is delivered almost instantly 
 
 ## License
 
-This theme is released under the [Academic Free License 3.0][AFL-3.0] 
+This theme is released under the [Academic Free License 3.0][AFL-3.0]
 
 [AFL-3.0]: https://opensource.org/licenses/AFL-3.0


### PR DESCRIPTION
Use `npm ci` to install packages. This obeys package-lock.json.



<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use `npm ci` to install packages. This is repeateable and obeys package-lock.json . See https://docs.npmjs.com/cli/v9/commands/npm-ci
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | its a readme :)
