### PR TITLE
Url properties fix after removing product in cart

### DIFF
--- a/src/js/components/UseHandleCartAction.ts
+++ b/src/js/components/UseHandleCartAction.ts
@@ -3,7 +3,7 @@
  * file that was distributed with this source code.
  */
 
-const handleCartAction = (event: Event) => {
+const handleCartAction = (event: Event): void => {
   event.stopPropagation();
   event.preventDefault();
 
@@ -14,13 +14,13 @@ const handleCartAction = (event: Event) => {
   sendCartRefreshRequest(target);
 };
 
-const sendCartRefreshRequest = (target: HTMLElement) => {
+const sendCartRefreshRequest = (target: HTMLElement): void => {
   const {prestashop, Theme: {events}} = window;
   const {dataset} = target;
 
   const targetUrl = target.getAttribute('href');
 
-  if (!targetUrl) {
+  if (targetUrl === null) {
     return;
   }
 

--- a/src/js/components/UseHandleCartAction.ts
+++ b/src/js/components/UseHandleCartAction.ts
@@ -1,0 +1,51 @@
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+const handleCartAction = (event: Event) => {
+  event.stopPropagation();
+  event.preventDefault();
+
+  // Get the target element and its dataset
+  const target = event.target as HTMLElement;
+
+  // Make request to refresh the cart
+  sendCartRefreshRequest(target);
+};
+
+const sendCartRefreshRequest = (target: HTMLElement) => {
+  const {prestashop, Theme: {events}} = window;
+  const {dataset} = target;
+
+  const targetUrl = target.getAttribute('href');
+
+  if (!targetUrl) {
+    return;
+  }
+
+  const formData = new FormData();
+  formData.append('ajax', '1');
+  formData.append('action', 'update');
+
+  fetch(targetUrl, {
+    method: 'POST',
+    body: formData,
+  })
+    .then((resp: Response) => {
+    // Refresh cart preview
+      prestashop.emit(events.updateCart, {
+        reason: dataset,
+        resp,
+      });
+    })
+    .catch((err) => {
+      const errorData = err as Response;
+      prestashop.emit(events.handleError, {
+        eventType: 'updateProductInCart',
+        errorData,
+      });
+    });
+};
+
+export default handleCartAction;

--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -27,11 +27,13 @@ export const listing = {
 };
 
 export const cart = {
+  container: '.cart-container',
   overview: '.cart-overview',
   discountCode: '.js-discount .js-code',
   discountName: '[name=discount_name]',
   displayPromo: '.display-promo',
   promoCode: '#promo-code',
+  deleteLinkAction: 'delete-from-cart',
 };
 
 export const blockcart = {

--- a/src/js/pages/cart.ts
+++ b/src/js/pages/cart.ts
@@ -5,6 +5,7 @@
 
 import {Collapse} from 'bootstrap';
 import {isHTMLElement} from '@helpers/typeguards';
+import handleCartAction from '../components/UseHandleCartAction';
 
 export default () => {
   const {Theme} = window;
@@ -31,4 +32,16 @@ export default () => {
       return false;
     });
   });
+
+  const cartContainer = document.querySelector<HTMLElement>(Theme.selectors.cart.container);
+
+  if (cartContainer) {
+    cartContainer.addEventListener('click', (event: Event) => {
+      const eventTarget = event.target as HTMLElement;
+
+      if (eventTarget.dataset.linkAction === Theme.selectors.cart.deleteLinkAction) {
+        handleCartAction(event);
+      }
+    });
+  }
 };

--- a/types/selectors.d.ts
+++ b/types/selectors.d.ts
@@ -32,6 +32,8 @@ declare type cart = {
   discountName: string,
   displayPromo: string,
   promoCode: string,
+  deleteLinkAction: string,
+  container: string,
 };
 
 declare type blockcart = {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Previously request to delete product was in GET method. This fix making method to POST and emits prestashop `updateCart` method which refresh page without page load and fixes the url issue mentioned in #478 ticket.
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/hummingbird/issues/487
| How to test?      | Add products into cart and enter the cart page. After clicking remove button on product, url must stay the same. 

Before product deletion:
![image](https://user-images.githubusercontent.com/96050852/235070946-b141280a-faf5-4fc7-81b6-0be2c0aee6a4.png)

After product deletion:
![image](https://user-images.githubusercontent.com/96050852/235070978-d5ed618c-4984-41a2-a733-0ec238e71492.png)

