### PR TITLE
Fix checkout with outstock product

### DIFF
--- a/src/js/components/useQuantityInput.ts
+++ b/src/js/components/useQuantityInput.ts
@@ -134,8 +134,25 @@ const updateQuantity = async (qtyInputGroup: Theme.QuantityInput.InputGroup, cha
               const errors = data.errors as string;
 
               if (errors) {
-                useToast(errors, {type: 'warning', autohide: false}).show();
+                useToast(errors, {type: 'danger', autohide: false}).show();
               }
+              // we check if the quantity is more than wanted and if oosp is disabled
+              // to recall with the correct number we can have
+              if (data.cart?.products?.length > 0) {
+                const productData = data.cart.products.find(
+                  (product: Record<string, unknown>) => data.id_product === product.id_product
+                    && data.id_product_attribute === product.id_product_attribute);
+
+                if (productData) {
+                  if (productData.availability === 'unavailable'
+                        && productData.allow_oosp === 0
+                        && Number(productData.quantity_wanted) > Number(productData.stock_quantity)) {
+                    const diff = Number(productData.stock_quantity) - Number(productData.quantity_wanted);
+                    await sendUpdateCartRequest(productData.update_quantity_url as string, diff);
+                  }
+                }
+              }
+
               prestashop.emit(events.updateCart, {
                 reason: qtyInput.dataset,
                 resp: data,

--- a/templates/checkout/_partials/cart-detailed-actions.tpl
+++ b/templates/checkout/_partials/cart-detailed-actions.tpl
@@ -3,16 +3,22 @@
  * file that was distributed with this source code.
  *}
 {block name='cart_detailed_actions'}
+  {$disableCheckout = false}
+  {foreach $cart.products as $product}
+      {if isset($product.availability) && $product.availability == 'unavailable' }
+          {$disableCheckout = true}
+      {/if}
+  {/foreach}
   <div class="checkout cart-detailed__actions js-cart-detailed-actions card-footer">
     {if $cart.minimalPurchaseRequired}
       <div class="alert alert-warning" role="alert">
         {$cart.minimalPurchaseRequired}
       </div>
-      <div class="text-sm-center">
+      <div class="text-sm-center d-grid">
         <button type="button" class="btn btn-primary disabled" disabled>{l s='Proceed to checkout' d='Shop.Theme.Actions'}</button>
       </div>
-    {elseif empty($cart.products) }
-      <div class="text-sm-center">
+    {elseif empty($cart.products) || $disableCheckout === true }
+      <div class="text-sm-center d-grid">
         <button type="button" class="btn btn-primary disabled" disabled>{l s='Proceed to checkout' d='Shop.Theme.Actions'}</button>
       </div>
     {else}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This fix is not the best fix we can do, but it works without touching any module or Core. We're disabling the checkout button on layout if any product is no more available, and we put the max limit of the product if you try to take more than in stock.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#485](https://github.com/PrestaShop/hummingbird/issues/485)
| Sponsor company   | @PrestaShopCorp
| How to test?      | Try to go to the cart page with limited product (without oops active) and put more than that is in stock.
