### PR TITLE
Fix smarty deprecation stripslashes

### DIFF
--- a/templates/customer/password-email.tpl
+++ b/templates/customer/password-email.tpl
@@ -27,7 +27,7 @@
     <section class="form-fields">
       <div class="mb-3">
         <label class="form-label required">{l s='Email address' d='Shop.Forms.Labels'}</label>
-        <input type="email" name="email" id="email" value="{if isset($smarty.post.email)}{$smarty.post.email|stripslashes}{/if}" class="form-control" required>
+        <input type="email" name="email" id="email" value="{if isset($smarty.post.email)}{stripslashes($smarty.post.email)}{/if}" class="form-control" required>
       </div>
       <button id="send-reset-link" class="form-control-submit btn btn-primary" name="submit" type="submit">
         {l s='Send reset link' d='Shop.Theme.Actions'}

--- a/templates/customer/password-new.tpl
+++ b/templates/customer/password-new.tpl
@@ -26,7 +26,7 @@
         {l
           s='Email address: %email%'
           d='Shop.Theme.Customeraccount'
-          sprintf=['%email%' => $customer_email|stripslashes]
+          sprintf=['%email%' => stripslashes($customer_email)]
         }
       </div>
       <div class="mb-3">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Passing `stripslashes` as a modifier in smarty is deprecated since Prestashop 8.0.4
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#32703](https://github.com/PrestaShop/PrestaShop/issues/32703)
| Sponsor company   | Société Biblique de Genève
| How to test?      | With PS 8.0.4 and PHP 8.1 (or 8.0) we no longer get user depreation notices in the error log.
