### PR TITLE
Several bug fix on cart related with products stock

### DIFF
--- a/src/js/components/useQuantityInput.ts
+++ b/src/js/components/useQuantityInput.ts
@@ -145,13 +145,13 @@ const updateQuantity = async (qtyInputGroup: Theme.QuantityInput.InputGroup, cha
                 (product: Record<string, unknown>) => data.id_product === Number(product.id_product)
                       && data.id_product_attribute === Number(product.id_product_attribute));
 
-              if (productData) {
-                if (productData.availability === 'unavailable'
-                    && productData.allow_oosp === 0
-                    && Number(productData.quantity_wanted) > Number(productData.stock_quantity)) {
-                  const diff = Number(productData.stock_quantity) - Number(productData.quantity_wanted);
-                  await sendUpdateCartRequest(productData.update_quantity_url as string, diff);
-                }
+              if (productData
+                  && productData.availability === 'unavailable'
+                  && productData.allow_oosp === 0
+                  && Number(productData.quantity_wanted) > Number(productData.stock_quantity)
+              ) {
+                const diff = Number(productData.stock_quantity) - Number(productData.quantity_wanted);
+                await sendUpdateCartRequest(productData.update_quantity_url as string, diff);
               }
             }
 

--- a/src/js/components/useQuantityInput.ts
+++ b/src/js/components/useQuantityInput.ts
@@ -159,11 +159,11 @@ const updateQuantity = async (qtyInputGroup: Theme.QuantityInput.InputGroup, cha
               reason: qtyInput.dataset,
               resp: data,
             });
+
             // Change the input value based on returned quantity
             qtyInput.value = data.quantity;
             // If user used the confirmation mode, need to update input value in the DOM
             qtyInput.setAttribute('value', data.quantity);
-
           } else {
             // Something went wrong so call the catch block
             throw response;

--- a/src/js/pages/checkout.ts
+++ b/src/js/pages/checkout.ts
@@ -170,9 +170,14 @@ const initCheckout = () => {
 
   const setMaxHeightToActiveCarrierExtraContent = () => {
     const activeExtraContent = document.querySelector(`${CheckoutMap.carrierExtraContentActive}`) as HTMLElement;
+
+    if (activeExtraContent === null) {
+      return;
+    }
+
     const content = activeExtraContent.querySelector(CheckoutMap.carrierExtraContent) as HTMLElement;
 
-    if (activeExtraContent != null && content != null) {
+    if (content != null) {
       activeExtraContent.style.maxHeight = `${content.clientHeight}px`;
     }
   };

--- a/templates/checkout/_partials/cart-detailed-actions.tpl
+++ b/templates/checkout/_partials/cart-detailed-actions.tpl
@@ -3,16 +3,22 @@
  * file that was distributed with this source code.
  *}
 {block name='cart_detailed_actions'}
+    {$disableCheckout = false}
+    {foreach $cart.products as $product}
+        {if isset($product.availability) && $product.availability == 'unavailable' }
+            {$disableCheckout = true}
+        {/if}
+    {/foreach}
   <div class="checkout cart-detailed__actions js-cart-detailed-actions card-footer">
     {if $cart.minimalPurchaseRequired}
       <div class="alert alert-warning" role="alert">
         {$cart.minimalPurchaseRequired}
       </div>
-      <div class="text-sm-center">
+      <div class="text-sm-center d-grid">
         <button type="button" class="btn btn-primary disabled" disabled>{l s='Proceed to checkout' d='Shop.Theme.Actions'}</button>
       </div>
-    {elseif empty($cart.products) }
-      <div class="text-sm-center">
+    {elseif empty($cart.products) || $disableCheckout === true}
+      <div class="text-sm-center d-grid">
         <button type="button" class="btn btn-primary disabled" disabled>{l s='Proceed to checkout' d='Shop.Theme.Actions'}</button>
       </div>
     {else}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | There is several bug fixes. First of them is "Proceed to checkout" button disabling in cart page if order is not available and product has not enough quantity. Second is about the toast color which changed from yellow (warning) to red (danger).  Third. The product quantity in input and in cart is set to max if customer has more then it exist in stock. This fix will not allow customer to add more products into cart if quantity is more then in stock and allow out-of-stock products is disabled is and both input and cart is falling back into previous value. As well this fix contains console error fix.
| Type?             | bug fix
| BC breaks?        |no
| Deprecations?     | no
| Fixed ticket?     | Fixes #488
| Sponsor company   | PrestaShop Corp.
## How to test:
### Button Disabled:
Steps:
1. Go to back office and set "Mug Today is a good day" quantity to 1 and allow out-of-stock product to order.
2. Go to front office and add more then 1 "Mug Today is a good day" 
3. Go back to back office and deny out-of-stock product to order.
4. Go back to front office refresh the page and see the disabled button.
![image](https://github.com/PrestaShop/hummingbird/assets/96050852/daa2225a-ae36-40df-855b-26e81bac1fdc)

### Toast Color:
1. Go to back office and set "Mug Today is a good day" quantity to 1 and deny out-of-stock product to order.
2. Go to front office and add more then 1 "Mug Today is a good day" 
3. Go to cart and increase quantity of that product.
4. The toast color should be red.
![image](https://github.com/PrestaShop/hummingbird/assets/96050852/de41ab77-3a1b-443d-81a1-4eee57236e93)


### Product quantity fix:
1. Go to back office and set "Mug Today is a good day" quantity to 1 and deny out-of-stock product to order.
2. Go to front office and add more then 1 "Mug Today is a good day" 
3. Go to cart and increase quantity of that product.
4. Then amount in cart is exceeded with current stock amount you should see the toast and input value which will change back to previous.

### Bonus fix:
Console error:
![image](https://github.com/PrestaShop/hummingbird/assets/96050852/262fdb3f-c48c-4917-aa22-813e573d9127)

This error is occurred due to loading element which does not exist yet, but it's trying to initiate it on checkout pages. This error related with carrier extra content on checkout.
To test it need to check if carrier extra content works as previously.

#### Environment:
Hummingbird version: develop
PrestaShop version 8.1.0
