### PR TITLE
Fixed searchbar blank space on mobile screen

### DIFF
--- a/templates/_partials/header.tpl
+++ b/templates/_partials/header.tpl
@@ -46,7 +46,7 @@
             </a>
           </div>
 
-          <div class="search__offcanvas js-search-offcanvas offcanvas offcanvas-top" data-bs-backdrop="false" data-bs-scroll="true" tabindex="-1" id="searchCanvas" aria-labelledby="offcanvasTopLabel">
+          <div class="search__offcanvas js-search-offcanvas offcanvas offcanvas-top h-auto" data-bs-backdrop="false" data-bs-scroll="true" tabindex="-1" id="searchCanvas" aria-labelledby="offcanvasTopLabel">
             <div class="offcanvas-header">
               <div id="_mobile_search" class="search__container"></div>
               <button type="button" class="btn-close text-reset ms-1" data-bs-dismiss="offcanvas" aria-label="Close">{l s='Cancel' d='Shop.Theme.Global'}</button>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixed searchbar blank space on mobile screen
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #503
| Sponsor company   | PrestaShop
| How to test?      | Resize screen to the mobile size and click on the search button and see the changes.

Before:
![image](https://github.com/GytisZum/hummingbird/assets/96050852/37f0b2cd-617e-4f51-9917-11e55c22fedc)

After:
![image](https://github.com/GytisZum/hummingbird/assets/96050852/e91e2101-d999-48fb-8b6d-7334048a2602)