### PR TITLE
Show/Hide Password: Accessibility on the button

### DIFF
--- a/src/js/visible-password.ts
+++ b/src/js/visible-password.ts
@@ -9,16 +9,24 @@ const initVisiblePassword = () => {
   const visiblePasswordList = document.querySelectorAll(visiblePasswordMap.visiblePassword);
 
   visiblePasswordList.forEach((input: HTMLInputElement) => {
-    const button = input?.nextElementSibling;
+    const button = input?.nextElementSibling as HTMLElement;
 
     button?.addEventListener('click', () => {
       const newType = input.getAttribute('type') === 'text' ? 'password' : 'text';
       input.setAttribute('type', newType);
+      button.setAttribute('aria-expanded', newType === 'text' ? 'true' : 'false');
 
       const icon = button.firstElementChild;
 
       if (icon) {
         icon.innerHTML = newType === 'text' ? 'visibility_off' : 'visibility';
+
+        const textShow = button.dataset.textShow;
+        const textHide = button.dataset.textHide;
+
+        if (textShow && textHide) {
+          button.setAttribute('aria-label', newType === 'text' ? textHide : textShow);
+        }
       }
     });
   });

--- a/src/js/visible-password.ts
+++ b/src/js/visible-password.ts
@@ -21,7 +21,7 @@ const initVisiblePassword = () => {
       if (icon) {
         icon.innerHTML = newType === 'text' ? 'visibility_off' : 'visibility';
 
-        const { textHide, textShow } = button.dataset;
+        const {textHide, textShow} = button.dataset;
 
         if (textShow && textHide) {
           button.setAttribute('aria-label', newType === 'text' ? textHide : textShow);

--- a/src/js/visible-password.ts
+++ b/src/js/visible-password.ts
@@ -21,8 +21,7 @@ const initVisiblePassword = () => {
       if (icon) {
         icon.innerHTML = newType === 'text' ? 'visibility_off' : 'visibility';
 
-        const textShow = button.dataset.textShow;
-        const textHide = button.dataset.textHide;
+        const { textHide, textShow } = button.dataset;
 
         if (textShow && textHide) {
           button.setAttribute('aria-label', newType === 'text' ? textHide : textShow);

--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -145,8 +145,10 @@
             class="btn btn-primary"
             type="button"
             data-action="show-password"
-            data-text-show="{l s='Show' d='Shop.Theme.Actions'}"
-            data-text-hide="{l s='Hide' d='Shop.Theme.Actions'}"
+            data-text-show="{l s='Show Password' d='Shop.Theme.Actions'}"
+            data-text-hide="{l s='Hide Password' d='Shop.Theme.Actions'}"
+            aria-label="{l s='Show Password' d='Shop.Theme.Actions'}"
+            aria-expanded="false"
           >
             <i class="material-icons">visibility</i>
           </button>

--- a/templates/customer/password-new.tpl
+++ b/templates/customer/password-new.tpl
@@ -37,8 +37,10 @@
             class="btn btn-primary"
             type="button"
             data-action="show-password"
-            data-text-show="{l s='Show' d='Shop.Theme.Actions'}"
-            data-text-hide="{l s='Hide' d='Shop.Theme.Actions'}"
+            data-text-show="{l s='Show Password' d='Shop.Theme.Actions'}"
+            data-text-hide="{l s='Hide Password' d='Shop.Theme.Actions'}"
+            aria-label="{l s='Show Password' d='Shop.Theme.Actions'}"
+            aria-expanded="false"
           >
             <i class="material-icons">visibility</i>
           </button>
@@ -52,8 +54,10 @@
             class="btn btn-primary"
             type="button"
             data-action="show-password"
-            data-text-show="{l s='Show' d='Shop.Theme.Actions'}"
-            data-text-hide="{l s='Hide' d='Shop.Theme.Actions'}"
+            data-text-show="{l s='Show Password' d='Shop.Theme.Actions'}"
+            data-text-hide="{l s='Hide Password' d='Shop.Theme.Actions'}"
+            aria-label="{l s='Show Password' d='Shop.Theme.Actions'}"
+            aria-expanded="false"
           >
             <i class="material-icons">visibility</i>
           </button>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds accessibility to the button to show/hide the password
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Improve #251
| Sponsor company   | N/A
| How to test?      | For a dev: Open dev console and sees aria-label and aria-expanded. (tested), for QA: see that showing/hiding password during registration works as expected.
