### PR TITLE
Format templates "cms"

### DIFF
--- a/templates/cms/_partials/sitemap-nested-list.tpl
+++ b/templates/cms/_partials/sitemap-nested-list.tpl
@@ -2,13 +2,15 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
+
 {block name='sitemap_item'}
-  <ul{if !empty($is_nested)} class="nested"{/if}>
+  <ul {if !empty($is_nested)}class="nested"{/if}>
     {foreach $links as $link}
       <li>
         <a id="{$link.id}" href="{$link.url}" title="{$link.label}">
           {$link.label}
         </a>
+
         {if !empty($link.children)}
           {include file='cms/_partials/sitemap-nested-list.tpl' links=$link.children is_nested=true}
         {/if}

--- a/templates/cms/category.tpl
+++ b/templates/cms/category.tpl
@@ -2,6 +2,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
+
 {extends file='page.tpl'}
 
 {block name='page_title'}
@@ -11,10 +12,17 @@
 {block name='page_content'}
   {block name='cms_sub_categories'}
     {if $sub_categories}
-      <p>{l s='List of sub categories in %name%:' d='Shop.Theme.Global' sprintf=['%name%' => $cms_category.name]}</p>
+      <p>
+        {l s='List of sub categories in %name%:' d='Shop.Theme.Global' sprintf=['%name%' => $cms_category.name]}
+      </p>
+
       <ul>
         {foreach from=$sub_categories item=sub_category}
-          <li><a href="{$sub_category.link}">{$sub_category.name}</a></li>
+          <li>
+            <a href="{$sub_category.link}">
+              {$sub_category.name}
+            </a>
+          </li>
         {/foreach}
       </ul>
     {/if}
@@ -22,10 +30,17 @@
 
   {block name='cms_sub_pages'}
     {if $cms_pages}
-      <p>{l s='List of pages in %category_name%:' d='Shop.Theme.Global' sprintf=['%category_name%' => $cms_category.name]}</p>
+      <p>
+        {l s='List of pages in %category_name%:' d='Shop.Theme.Global' sprintf=['%category_name%' => $cms_category.name]}
+      </p>
+
       <ul>
         {foreach from=$cms_pages item=cms_page}
-          <li><a href="{$cms_page.link}">{$cms_page.meta_title}</a></li>
+          <li>
+            <a href="{$cms_page.link}">
+              {$cms_page.meta_title}
+            </a>
+          </li>
         {/foreach}
       </ul>
     {/if}

--- a/templates/cms/page.tpl
+++ b/templates/cms/page.tpl
@@ -2,6 +2,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
+
 {extends file='page.tpl'}
 
 {block name='page_title'}

--- a/templates/cms/sitemap.tpl
+++ b/templates/cms/sitemap.tpl
@@ -2,6 +2,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
+
 {extends file='page.tpl'}
 
 {block name='page_title'}
@@ -12,9 +13,13 @@
   <div class="row sitemap">
     {foreach $sitemapUrls as $group}
       <div class="col-md-6 col-lg-3">
-        <h2 class="h3">{$group.name}</h2>
+        <h2 class="h3">
+          {$group.name}
+        </h2>
+
         {include file='cms/_partials/sitemap-nested-list.tpl' links=$group.links}
-        <hr class="d-block d-md-none" />
+
+        <hr class="d-block d-md-none">
       </div>
     {/foreach}
   </div>

--- a/templates/cms/stores.tpl
+++ b/templates/cms/stores.tpl
@@ -2,6 +2,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
+
 {extends file='page.tpl'}
 
 {block name='page_title'}
@@ -51,69 +52,114 @@
                     {/if}
                 </picture>
               </div>
+
               <div class="col-xl-6 store__description d-none d-md-block">
-                <h2 class="h6 store__name">{$store.name}</h2>
-                <address class="store__address">{$store.address.formatted nofilter}</address>
+                <h2 class="h6 store__name">
+                  {$store.name}
+                </h2>
+
+                <address class="store__address">
+                  {$store.address.formatted nofilter}
+                </address>
+
                 {if $store.note || $store.phone || $store.fax || $store.email}
-                  <a data-bs-toggle="collapse" href="#about-{$store.id}" aria-expanded="false" aria-controls="about-{$store.id}"><strong>{l s='About and Contact' d='Shop.Theme.Global'}</strong><i class="material-icons" aria-hidden="true">&#xE409;</i></a>
+                  <a data-bs-toggle="collapse" href="#about-{$store.id}" aria-expanded="false" aria-controls="about-{$store.id}">
+                    <strong>{l s='About and Contact' d='Shop.Theme.Global'}</strong><i class="material-icons" aria-hidden="true">&#xE409;</i>
+                  </a>
                 {/if}
+
                 <hr>
+
                 <table class="store__opening-times">
                   {foreach $store.business_hours as $day}
-                  <tr>
-                    <th>{$day.day|truncate:4:'.'}</th>
-                    <td>
-                      <ul>
-                      {foreach $day.hours as $h}
-                        <li>{$h}</li>
-                      {/foreach}
-                      </ul>
-                    </td>
-                  </tr>
-                  {/foreach}
-                </table>
-              </div>
-              <div class="store__description accordion d-block d-md-none">
-                <div class="accordion-item">
-                  <h2 class="h6 store__name">{$store.name}</h2>
-                  <address class="store__address">{$store.address.formatted nofilter}</address>
-                  {if $store.note || $store.phone || $store.fax || $store.email}
-                    <a data-bs-toggle="collapse" href="#about-{$store.id}" aria-expanded="false" aria-controls="about-{$store.id}"><strong>{l s='About and Contact' d='Shop.Theme.Global'}</strong><i class="material-icons" aria-hidden="true">&#xE409;</i></a>
-                  {/if}
-                  <hr>
-                  <button class="store__toggle accordion-button collapsed pb-2 px-0" data-bs-toggle="collapse" data-bs-target="#table-{$store.id}">{l s='View schedules' d='Shop.Theme.Global'}</button>
-                  <table id="table-{$store.id}" class="store__opening-times accordion-collapse collapse">
-                    {foreach $store.business_hours as $day}
                     <tr>
-                      <th>{$day.day|truncate:4:'.'}</th>
+                      <th>
+                        {$day.day|truncate:4:'.'}
+                      </th>
+
                       <td>
                         <ul>
-                        {foreach $day.hours as $h}
-                          <li>{$h}</li>
-                        {/foreach}
+                          {foreach $day.hours as $h}
+                            <li>
+                              {$h}
+                            </li>
+                          {/foreach}
                         </ul>
                       </td>
                     </tr>
+                  {/foreach}
+                </table>
+              </div>
+
+              <div class="store__description accordion d-block d-md-none">
+                <div class="accordion-item">
+                  <h2 class="h6 store__name">
+                    {$store.name}
+                  </h2>
+
+                  <address class="store__address">
+                    {$store.address.formatted nofilter}
+                  </address>
+
+                  {if $store.note || $store.phone || $store.fax || $store.email}
+                    <a data-bs-toggle="collapse" href="#about-{$store.id}" aria-expanded="false" aria-controls="about-{$store.id}">
+                      <strong>{l s='About and Contact' d='Shop.Theme.Global'}</strong><i class="material-icons" aria-hidden="true">&#xE409;</i>
+                    </a>
+                  {/if}
+
+                  <hr>
+
+                  <button class="store__toggle accordion-button collapsed pb-2 px-0" data-bs-toggle="collapse" data-bs-target="#table-{$store.id}">
+                    {l s='View schedules' d='Shop.Theme.Global'}
+                  </button>
+
+                  <table id="table-{$store.id}" class="store__opening-times accordion-collapse collapse">
+                    {foreach $store.business_hours as $day}
+                      <tr>
+                        <th>
+                          {$day.day|truncate:4:'.'}
+                        </th>
+
+                        <td>
+                          <ul>
+                            {foreach $day.hours as $h}
+                              <li>
+                                {$h}
+                              </li>
+                            {/foreach}
+                          </ul>
+                        </td>
+                      </tr>
                     {/foreach}
                   </table>
                 </div>
               </div>
             </div>
           </div>
+
           {if $store.note || $store.phone || $store.fax || $store.email}
             <div class="card-footer store__footer collapse" id="about-{$store.id}">
               {if $store.note}
                   <p class="store__note">{$store.note}</p>
               {/if}
+
               <ul class="store__contacts">
                 {if $store.phone}
-                  <li><i class="material-icons" aria-hidden="true">&#xE0B0;</i>{$store.phone}</li>
+                  <li>
+                    <i class="material-icons" aria-hidden="true">&#xE0B0;</i>{$store.phone}
+                  </li>
                 {/if}
+
                 {if $store.fax}
-                  <li><i class="material-icons" aria-hidden="true">&#xE8AD;</i>{$store.fax}</li>
+                  <li>
+                    <i class="material-icons" aria-hidden="true">&#xE8AD;</i>{$store.fax}
+                  </li>
                 {/if}
+
                 {if $store.email}
-                  <li><i class="material-icons" aria-hidden="true">&#xE0BE;</i>{$store.email}</li>
+                  <li>
+                    <i class="material-icons" aria-hidden="true">&#xE0BE;</i>{$store.email}
+                  </li>
                 {/if}
               </ul>
             </div>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Template files are often too condensed. Here, I've reformatted them by adding more spaces. I've only done this for "cms" but the aim is to do it everywhere.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | N/A
| How to test?      | Install the theme and tests CMS pages
