### PR TITLE
fix: checkbox description display html

### DIFF
--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -82,7 +82,7 @@
             {if $field.required}required{/if}
           >
           <label class="form-check-label" for="field-{$field.name}">
-            {$field.label nofilter}
+            {$field.label|unescape:"html" nofilter}
           </label>
         </div>
       {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | when the description of the checkbox elements included HTML, it displayed the HTML tags. This PR solves the problem.
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | @PrestaShopCorp
| How to test?      | You can access to the page create an account and check if the HTML is well displayed.

Before
![image](https://github.com/PrestaShop/hummingbird/assets/52718717/fd343a4f-24c3-4fd3-89aa-8cccb1de50ef)

After
![image](https://github.com/PrestaShop/hummingbird/assets/52718717/eae0e454-3088-444d-a3a6-c84a6650fb62)
