### PR TITLE
fix: icon color on hover inside hompeage cta

### DIFF
--- a/src/scss/custom/modules/_featuredproducts.scss
+++ b/src/scss/custom/modules/_featuredproducts.scss
@@ -3,7 +3,9 @@
     color: var(--bs-primary);
   }
 
-  &:hover {
+  &:hover,
+  &:focus,
+  &:focus-visible {
     i {
       color: var(--bs-white);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | On homepage the CTA (like "all new product") got an issue cause the icon inside it don't change color on focus state. This PR fix this issue.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | @PrestaShopCorp
| How to test?      | Focus any CTA on homepage (don't forget to `npm run build` on this branche before testing.

Before
![image](https://github.com/PrestaShop/hummingbird/assets/52718717/5eaf1d4d-0191-4e28-a09b-6701540a6805)

After
![image](https://github.com/PrestaShop/hummingbird/assets/52718717/2bd84d6d-a18a-4563-9383-a5d1c2fbf925)
