### PR TITLE
Fix: product listing responsive

### DIFF
--- a/src/scss/core/components/product/_product-miniature.scss
+++ b/src/scss/core/components/product/_product-miniature.scss
@@ -27,6 +27,11 @@ $component-name: product-miniature;
     &__bottom {
       margin-bottom: 1rem;
       margin-top: auto;
+      @media (max-width: 767px) {
+        .quantity-button input {
+          max-width: unset;
+        }
+      }
     }
   }
 

--- a/src/scss/core/components/product/_product-miniature.scss
+++ b/src/scss/core/components/product/_product-miniature.scss
@@ -9,6 +9,9 @@ $component-name: product-miniature;
     position: relative;
     z-index: 90;
     padding: 0;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
 
     &__top,
     &__bottom {
@@ -18,10 +21,12 @@ $component-name: product-miniature;
 
     &__top {
       padding-top: 0.5rem;
+      height: 100%;
     }
 
     &__bottom {
       margin-bottom: 1rem;
+      margin-top: auto;
     }
   }
 

--- a/src/scss/core/components/product/_product-miniature.scss
+++ b/src/scss/core/components/product/_product-miniature.scss
@@ -8,10 +8,10 @@ $component-name: product-miniature;
   & &__infos {
     position: relative;
     z-index: 90;
-    padding: 0;
     display: flex;
     flex-direction: column;
     flex-grow: 1;
+    padding: 0;
 
     &__top,
     &__bottom {
@@ -20,13 +20,13 @@ $component-name: product-miniature;
     }
 
     &__top {
-      padding-top: 0.5rem;
       height: 100%;
+      padding-top: 0.5rem;
     }
 
     &__bottom {
-      margin-bottom: 1rem;
       margin-top: auto;
+      margin-bottom: 1rem;
       @media (max-width: 767px) {
         .quantity-button input {
           max-width: unset;

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -15,25 +15,25 @@
             {if $product.cover}
               <picture>
                 {if isset($product.cover.bySize.default_md.sources.avif)}
-                  <source 
+                  <source
                     srcset="
                       {$product.cover.bySize.default_xs.sources.avif} 120w,
                       {$product.cover.bySize.default_m.sources.avif} 200w,
                       {$product.cover.bySize.default_md.sources.avif} 320w,
                       {$product.cover.bySize.product_main.sources.avif} 720w"
-                    sizes="(min-width: 1300px) 720px, (min-width: 768px) 50vw, 50vw" 
+                    sizes="(min-width: 1300px) 720px, (min-width: 768px) 50vw, 50vw"
                     type="image/avif"
                   >
                 {/if}
 
                 {if isset($product.cover.bySize.default_md.sources.webp)}
-                  <source 
+                  <source
                     srcset="
                       {$product.cover.bySize.default_xs.sources.webp} 120w,
                       {$product.cover.bySize.default_m.sources.webp} 200w,
                       {$product.cover.bySize.default_md.sources.webp} 320w,
                       {$product.cover.bySize.product_main.sources.webp} 720w"
-                    sizes="(min-width: 1300px) 320px, (min-width: 768px) 120px, 50vw" 
+                    sizes="(min-width: 1300px) 320px, (min-width: 768px) 120px, 50vw"
                     type="image/webp"
                   >
                 {/if}
@@ -45,8 +45,8 @@
                     {$product.cover.bySize.default_m.url} 200w,
                     {$product.cover.bySize.default_md.url} 320w,
                     {$product.cover.bySize.product_main.url} 720w"
-                  sizes="(min-width: 1300px) 320px, (min-width: 768px) 120px, 50vw" 
-                  src="{$product.cover.bySize.default_md.url}" 
+                  sizes="(min-width: 1300px) 320px, (min-width: 768px) 120px, 50vw"
+                  src="{$product.cover.bySize.default_md.url}"
                   width="{$product.cover.bySize.default_md.width}"
                   height="{$product.cover.bySize.default_md.height}"
                   loading="lazy"
@@ -58,25 +58,25 @@
             {else}
               <picture>
                 {if isset($urls.no_picture_image.bySize.default_md.sources.avif)}
-                  <source 
+                  <source
                     srcset="
                       {$urls.no_picture_image.bySize.default_xs.sources.avif} 120w,
                       {$urls.no_picture_image.bySize.default_m.sources.avif} 200w,
                       {$urls.no_picture_image.bySize.default_md.sources.avif} 320w,
                       {$urls.no_picture_image.bySize.product_main.sources.avif} 720w"
-                    sizes="(min-width: 1300px) 720px, (min-width: 768px) 50vw, 50vw" 
+                    sizes="(min-width: 1300px) 720px, (min-width: 768px) 50vw, 50vw"
                     type="image/avif"
                   >
                 {/if}
 
                 {if isset($urls.no_picture_image.bySize.default_md.sources.webp)}
-                  <source 
+                  <source
                     srcset="
                       {$urls.no_picture_image.bySize.default_xs.sources.webp} 120w,
                       {$urls.no_picture_image.bySize.default_m.sources.webp} 200w,
                       {$urls.no_picture_image.bySize.default_md.sources.webp} 320w,
                       {$urls.no_picture_image.bySize.product_main.sources.webp} 720w"
-                    sizes="(min-width: 1300px) 320px, (min-width: 768px) 120px, 50vw" 
+                    sizes="(min-width: 1300px) 320px, (min-width: 768px) 120px, 50vw"
                     type="image/webp"
                   >
                 {/if}
@@ -88,10 +88,10 @@
                     {$urls.no_picture_image.bySize.default_m.url} 200w,
                     {$urls.no_picture_image.bySize.default_md.url} 320w,
                     {$urls.no_picture_image.bySize.product_main.url} 720w"
-                  sizes="(min-width: 1300px) 320px, (min-width: 768px) 120px, 50vw" 
+                  sizes="(min-width: 1300px) 320px, (min-width: 768px) 120px, 50vw"
                   width="{$urls.no_picture_image.bySize.default_md.width}"
                   height="{$urls.no_picture_image.bySize.default_md.height}"
-                  src="{$urls.no_picture_image.bySize.default_md.url}" 
+                  src="{$urls.no_picture_image.bySize.default_md.url}"
                   loading="lazy"
                   alt="{l s='No image available' d='Shop.Theme.Catalog'}"
                   title="{l s='No image available' d='Shop.Theme.Catalog'}"
@@ -169,10 +169,10 @@
             </div>
 
             {if $product.add_to_cart_url}
-              <form action="{$urls.pages.cart}" method="post" class="d-flex align-items-center mt-3">
+              <form action="{$urls.pages.cart}" method="post" class="d-flex flex-wrap flex-md-nowrap gap-3 align-items-center mt-3">
                 <input type="hidden" value="{$product.id_product}" name="id_product">
                 <input type="hidden" name="token" value="{$static_token}" />
-                <div class="quantity-button js-quantity-button">
+                <div class="quantity-button js-quantity-button w-100 w-sm-auto">
                   {include file='components/qty-input.tpl'
                     attributes=[
                       "id"=>"quantity_wanted_{$product.id_product}",
@@ -182,7 +182,7 @@
                     marginHelper="mb-0"
                   }
                 </div>
-                <button data-button-action="add-to-cart" class="btn btn-primary ms-3">
+                <button data-button-action="add-to-cart" class="btn btn-primary flex-grow-1 flex-md-grow-0">
                   <i class="material-icons" aria-hidden="true">&#xe854;</i>
                   <span class="visually-hidden">{l s='Add to cart' d='Shop.Theme.Actions'}</span>
                 </button>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When the screen is too small we can't see the number we want to add on cart for the products (homepage or category page). This PR fix this issue and she also align the product price and add to cart to the bottom of product cards.
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | @PrestaShopCorp
| How to test?      | Try to resize your screen on very small mobile (360px) and see the products on homepage or category page

Before
![image](https://github.com/PrestaShop/hummingbird/assets/52718717/99abb8c8-46fd-4ac5-909e-a8b46a19affa)

After
![image](https://github.com/PrestaShop/hummingbird/assets/52718717/33b910fb-79cc-43a7-bd2c-52abdb79f3bd)

