### PR TITLE
Improvements : small theme improvements

### DIFF
--- a/modules/ps_imageslider/views/templates/hook/slider.tpl
+++ b/modules/ps_imageslider/views/templates/hook/slider.tpl
@@ -20,7 +20,7 @@
             aria-hidden="{if $smarty.foreach.homeslider.first}false{else}true{/if}">
             {if !empty($slide.url)}<a class="carousel-link" href="{$slide.url}">{/if}
               <figure class="carousel-content">
-                <img src="{$slide.image_url}" alt="{$slide.legend|escape}" loading="lazy" {$slide.size|replace: '"':''}>
+                <img src="{$slide.image_url}" alt="{$slide.legend|escape}" {if $slide@iteration == 1}loading="eager"{else}loading="lazy"{/if} {$slide.size|replace: '"':''}>
                 {if $slide.title || $slide.description}
                   <figcaption class="carousel-caption caption">
                     <h2 class="display-1 text-uppercase">{$slide.title}</h2>

--- a/src/scss/core/components/_pagination.scss
+++ b/src/scss/core/components/_pagination.scss
@@ -9,6 +9,7 @@
 
   &-container {
     align-items: center;
-    margin: 1rem 0;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
   }
 }

--- a/src/scss/core/pages/_home.scss
+++ b/src/scss/core/pages/_home.scss
@@ -1,6 +1,0 @@
-.page-index {
-  .breadcrumb__wrapper {
-    // stylelint-disable-next-line
-    display: none !important;
-  }
-}

--- a/src/scss/core/pages/_index.scss
+++ b/src/scss/core/pages/_index.scss
@@ -1,3 +1,2 @@
-@import "home";
 @import "product";
 @import "page-not-found";

--- a/templates/_partials/microdata/product-jsonld.tpl
+++ b/templates/_partials/microdata/product-jsonld.tpl
@@ -31,10 +31,15 @@
     {if $product.ean13},"gtin13": "{$product.ean13}"
     {else if $product.upc},"gtin13": "{$product.upc}"
     {/if}
-    {if $product_manufacturer->name OR $shop.name},
+    {if $product_manufacturer->name},
+    "brand": {
+      "@type": "Brand",
+      "name": "{$product_manufacturer->name|escape:'html':'UTF-8'}"
+    }
+    {elseif $shop.name},
     "brand": {
       "@type": "Thing",
-      "name": "{if $product_manufacturer->name}{$product_manufacturer->name|escape:'html':'UTF-8'}{else}{$shop.name}{/if}"
+      "name": "{$shop.name}"
     }
     {/if}
     {if $hasAggregateRating},

--- a/templates/_partials/pagination.tpl
+++ b/templates/_partials/pagination.tpl
@@ -5,13 +5,13 @@
 {$componentName = 'pagination'}
 
 <nav class="{$componentName}-container row">
-  <div class="{$componentName}-number col-md-4">
+  <div class="{$componentName}-number text-center text-lg-start col-lg-4">
     {block name='pagination_summary'}
       {l s='Showing %from%-%to% of %total% item(s)' d='Shop.Theme.Catalog' sprintf=['%from%' => $pagination.items_shown_from ,'%to%' => $pagination.items_shown_to, '%total%' => $pagination.total_items]}
     {/block}
   </div>
 
-  <div class="{$componentName}-list-container col-md-6 offset-md-2 pr-0">
+  <div class="{$componentName}-list-container d-flex justify-content-center justify-content-lg-end col-lg-8">
     {block name='pagination_page_list'}
       <nav aria-label="{l s='Products pagination' d='Shop.Theme.Catalog'}">
         {if $pagination.should_be_displayed}
@@ -44,5 +44,4 @@
       </nav>
     {/block}
   </div>
-
 </nav>

--- a/templates/index.tpl
+++ b/templates/index.tpl
@@ -4,6 +4,8 @@
  *}
 {extends file=$layout}
 
+{block name='breadcrumb'}{/block}
+
 {block name="content_columns"}
   {block name="left_column"}{/block}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR has for objective to add some improvements to the theme.
| Type?             | bug fix / improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | --
| Sponsor company   | @PrestaShopCorp
| How to test?      | --

1. The breadcrumb has been removed in smarty from the homepage instead of making him invisible with CSS.
2. A condition has been added on jsonld data to adapt the "Type" if a product has a brand associated or not.
3. The loading attribute of ps_imageslider images has been optimized, the first image is charge with the loading parameter value `eager` which is better in terms of performance because the first image is identified as the LCP.
4. Improve the responsiveness of the pagination on category pages which have a lot of pages, like in the capture below, which show a content overflow on small devices:

![image](https://github.com/PrestaShop/hummingbird/assets/110676325/3479687e-a178-4aea-8185-589a89719878)

