### PR TITLE
fix: The price is displayed twice as if there was a discount

### DIFF
--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -100,10 +100,10 @@
         {/if}
       </div>
 
-      <div class="product-line__basic">
-        <span class="product-line__regular">{$product.regular_price}</span>
+      {if $product.has_discount}
+        <div class="product-line__basic">
+          <span class="product-line__regular">{$product.regular_price}</span>
 
-        {if $product.has_discount}
           {if $product.discount_type === 'percentage'}
             <span class="discount badge discount">
               -{$product.discount_percentage_absolute}
@@ -113,8 +113,8 @@
               -{$product.discount_to_display}
             </span>
           {/if}
-        {/if}
-      </div>
+        </div>
+      {/if}
     </div>
   </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Correct the issue 535
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixe https://github.com/PrestaShop/hummingbird/issues/535
| Sponsor company   | @PrestaShopCorp
| How to test?      | You can refer to the issue
