### PR TITLE
Change qty input min and value to match with minimal quantity

### DIFF
--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -176,8 +176,8 @@
                   {include file='components/qty-input.tpl'
                     attributes=[
                       "id"=>"quantity_wanted_{$product.id_product}",
-                      "value"=>"1",
-                      "min"=>"{if $product.quantity_wanted}{$product.minimal_quantity}{else}1{/if}"
+                      "value"=>"{if $product.cart_quantity && $product.cart_quantity >= $product.minimal_quantity}1{else}{$product.minimal_quantity}{/if}",
+                      "min"=>"{if $product.cart_quantity && $product.cart_quantity >= $product.minimal_quantity}1{else}{$product.minimal_quantity}{/if}"
                     ]
                     marginHelper="mb-0"
                   }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Change qty input min and value on product card (miniatures) to match with minimal quantity if filed by merchant.
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/hummingbird/issues/545
| Sponsor company   | @PrestaShopCorp
| How to test?      | BO>Change the Minimum quantity for sale for a product to 3. FO> See the number in homepage / category page / checkout page need to be 3 or 1 if you got already 3 in your cart.
