### PR TITLE
fix: multiple slider update on facetsearch

### DIFF
--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -6,6 +6,7 @@
 export const facetedsearch = {
   range: '.js-faceted-slider',
   rangeContainer: '.js-faceted-slider-container',
+  rangeValues: '.js-faceted-values',
   filterSlider: '.js-faceted-filter-slider',
   offCanvasFaceted: '#offcanvas-faceted',
 };

--- a/src/js/modules/facetedsearch/index.ts
+++ b/src/js/modules/facetedsearch/index.ts
@@ -15,7 +15,6 @@ export const initSliders = () => {
   // Get all slider configurations found in the DOM
   document.querySelectorAll(Theme.selectors.facetedsearch.filterSlider).forEach((filter: HTMLElement) => {
     const container = <target>filter.querySelector(Theme.selectors.facetedsearch.rangeContainer);
-    const facetedValues = document.querySelector('.js-faceted-values') as HTMLElement;
 
     // Init basic slider data
     let unitPosition = 'suffix';
@@ -101,7 +100,9 @@ export const initSliders = () => {
           unitPosition === 'suffix' ? `${value}${unitSymbol}` : `${unitSymbol}${value}`),
         );
 
-        facetedValues.innerHTML = formattedValues.join(' - ');
+        const parentFacet = initiatedSlider.target.closest(Theme.selectors.facetedsearch.filterSlider) as HTMLElement;
+        const showValues = parentFacet.querySelector(Theme.selectors.facetedsearch.rangeValues) as HTMLElement;
+        showValues.innerHTML = formattedValues.join(' - ');
       });
     } else {
       container.noUiSlider.updateOptions({
@@ -125,7 +126,9 @@ export const initSliders = () => {
           unitPosition === 'suffix' ? `${value}${unitSymbol}` : `${unitSymbol}${value}`),
         );
 
-        facetedValues.innerHTML = formattedValues.join(' - ');
+        const parentFacet = initiatedSlider.target.closest(Theme.selectors.facetedsearch.filterSlider) as HTMLElement;
+        const showValues = parentFacet.querySelector(Theme.selectors.facetedsearch.rangeValues) as HTMLElement;
+        showValues.innerHTML = formattedValues.join(' - ');
       });
     }
   });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix an issue when multiple sliders are presents on faceted search ( the price and product weight who show in slider mode )
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | 
| Fixed ticket?     | This fix is related to this previous fix https://github.com/PrestaShop/hummingbird/commit/81e820452d6a7685c1b47ec16a59d20b8e077575
| Sponsor company   | @PrestaShopCorp
| How to test?      | You have to add some weight on few products for example one with 1kg another with 2kg and another with 3kg after that you can go to ps_facetedsearch configuration module click on "Reconstruire l'index intégralement" after that you can access in FO the category that contains the products with different weights and check if the price and weight filter work well :) 
