### PR TITLE
[ISSUE-555] Add old hooks from classic theme

### DIFF
--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -135,6 +135,10 @@
               </div>
             {/block}
 
+            {block name='product_reviews'}
+              {hook h='displayProductListReviews' product=$product}
+            {/block}
+
             <div class="{$componentName}__prices">
               {block name='product_price'}
                 {if $product.show_price}

--- a/templates/checkout/_partials/steps/payment.tpl
+++ b/templates/checkout/_partials/steps/payment.tpl
@@ -109,6 +109,8 @@
     </form>
   {/if}
 
+  {hook h='displayCheckoutBeforeConfirmation'}
+
   {if $show_final_summary}
     {include file='checkout/_partials/order-final-summary.tpl'}
   {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add old classic theme hooks. The **displaySearch** hook has not been added because in classic theme he was only used on 404 error page and if we add it on this page this will generate duplicate ID on the page. https://github.com/PrestaShop/hummingbird/issues/555
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | 
| Fixed ticket?     | Fixes https://github.com/PrestaShop/hummingbird/issues/555
| Sponsor company   | @PrestaShopCorp
| How to test?      | These hooks are just called in the code
