### PR TITLE
Use scrollIntoView when paging, fixes #562

### DIFF
--- a/src/js/modules/facetedsearch/update.ts
+++ b/src/js/modules/facetedsearch/update.ts
@@ -99,6 +99,7 @@ export default () => {
   prestashop.on(events.updateProductList, (data: Record<string, never>) => {
     updateProductListDOM(data);
     useQuantityInput();
-    window.scrollTo(0, 0);
+    // list was updated, scroll back up to to start of the list
+    document.getElementById('products')?.scrollIntoView(true);
   });
 };


### PR DESCRIPTION




<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Instead of doing scrollTo(0,0) use scrollIntoView to get the `section#products` start to be visible.
| Type?             | bug fix && improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #562
| Sponsor company   | 
| How to test?      | See issue for steps for trying to replicate the original issue with firefox

WIP, still requires a css rule