### PR TITLE
Be consistent in mobile view for product listing 

### DIFF
--- a/templates/catalog/_partials/productlist.tpl
+++ b/templates/catalog/_partials/productlist.tpl
@@ -2,7 +2,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
-{capture assign="productClasses"}{if !empty($productClass)}{$productClass}{else}col-xs-6 col-xl-4{/if}{/capture}
+{capture assign="productClasses"}{if !empty($productClass)}{$productClass}{else}col-6 col-xl-4{/if}{/capture}
 
 <div class="products{if !empty($cssClass)} {$cssClass}{else} row{/if}">
   {foreach from=$products item="product" key="position"}


### PR DESCRIPTION
one by line / two by line. Fixes #564

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Mobile product listing shows consistently two products per line when paging and when loading the page.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #564
| Sponsor company   | 
| How to test?      | Open product list, go to page X note how products are shown. Reload the page, check that the listing looks the same.
