### PR TITLE
Fix: Separate product reference and manufacturer

### DIFF
--- a/templates/catalog/_partials/product-details.tpl
+++ b/templates/catalog/_partials/product-details.tpl
@@ -13,7 +13,7 @@
   <div id="product-details-collapse" class="info__content accordion-collapse collapse {if !$product.description}show{/if}" data-bs-parent="#product-details-heading" aria-labelledby="product-details-heading">
     <div class="accordion-body">
       <ul class="product__details">
-        {block name='product_reference'}
+        {block name='product_manufacturer'}
           {if isset($product_manufacturer->id)}
             <li class="detail">
               <div class="detail__left">
@@ -29,17 +29,19 @@
                 {/if}
               </div>
             </li>
+          {/if}
+        {/block}
 
-            {if isset($product.reference_to_display) && $product.reference_to_display neq ''}
-              <li class="detail">
-                <div class="detail__left">
-                  <span class="detail__title">{l s='Reference' d='Shop.Theme.Catalog'}</span>
-                </div>
-                <div class="detail__right">
-                  <span>{$product.reference_to_display}</span>
-                </div>
-              </li>
-            {/if}
+        {block name='product_reference'}
+          {if isset($product.reference_to_display) && $product.reference_to_display neq ''}
+            <li class="detail">
+              <div class="detail__left">
+                <span class="detail__title">{l s='Reference' d='Shop.Theme.Catalog'}</span>
+              </div>
+              <div class="detail__right">
+                <span>{$product.reference_to_display}</span>
+              </div>
+            </li>
           {/if}
         {/block}
 

--- a/templates/catalog/_partials/product-details.tpl
+++ b/templates/catalog/_partials/product-details.tpl
@@ -33,7 +33,7 @@
         {/block}
 
         {block name='product_reference'}
-          {if isset($product.reference_to_display) && $product.reference_to_display neq ''}
+          {if !empty($product.reference_to_display)}
             <li class="detail">
               <div class="detail__left">
                 <span class="detail__title">{l s='Reference' d='Shop.Theme.Catalog'}</span>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Separates product reference and manufacturer information to different blocks and if statements.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #569
