### PR TITLE
Add 'Back to Home page' button on not-found page, fixes #554

### DIFF
--- a/templates/errors/not-found.tpl
+++ b/templates/errors/not-found.tpl
@@ -7,6 +7,10 @@
     {block name="error_content"}
       {if isset($errorContent)}
           {$errorContent nofilter}
+          <a href="{$urls.pages.index}" class="btn btn-primary back-to-index">
+            {l s='Back to Home page' d='Shop.Theme.Catalog'}
+            <i class="material-icons rtl-flip" aria-hidden="true">&#xE315;</i>
+          </a>
       {else}
         <h1 class="h4">{l s='The page you are looking for is no longer available' d='Shop.Theme.Catalog'}</h1>
         <p>{l s='It can not be reached anymore. Can we still attract you into our shop?' d='Shop.Theme.Catalog'}</p>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add "Back to Home page" button to `not-found` when `errorContent` is defined
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #554
| Sponsor company   | 
| How to test?      | Go to a page that is not available, see 404 page and the new "Back to Home page" button, click on the button to get back to home page
