### PR TITLE
Usability improvements for search widget

### DIFF
--- a/modules/ps_searchbar/ps_searchbar.tpl
+++ b/modules/ps_searchbar/ps_searchbar.tpl
@@ -27,8 +27,8 @@
   <div id="search_widget" class="search-widgets js-search-widget" data-search-controller-url="{$search_controller_url}">
     <form method="get" action="{$search_controller_url}">
       <input type="hidden" name="controller" value="search">
-      <i class="material-icons search" aria-hidden="true">search</i>
-      <input class="js-search-input" type="text" name="s" value="{$search_string}" placeholder="{l s='Search our catalog' d='Shop.Theme.Catalog'}" aria-label="{l s='Search' d='Shop.Theme.Catalog'}">
+      <i class="material-icons search js-search-icon" aria-hidden="true">search</i>
+      <input class="js-search-input" type="search" name="s" value="{$search_string}" placeholder="{l s='Search our catalog' d='Shop.Theme.Catalog'}" aria-label="{l s='Search' d='Shop.Theme.Catalog'}">
       <i class="material-icons clear" aria-hidden="true">clear</i>
     </form>
 

--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -57,6 +57,7 @@ export const searchBar = {
   searchResults: '.js-search-results',
   searchTemplate: '.js-search-template',
   searchInput: '.js-search-input',
+  searchIcon: '.js-search-icon',
 };
 
 export const checkout = {

--- a/src/js/modules/ps_searchbar.ts
+++ b/src/js/modules/ps_searchbar.ts
@@ -16,7 +16,22 @@ const initSearchbar = () => {
   const searchResults = document.querySelector<HTMLElement>(SearchBarMap.searchResults);
   const searchTemplate = document.querySelector<HTMLTemplateElement>(SearchBarMap.searchTemplate);
   const searchInput = document.querySelector<HTMLInputElement>(SearchBarMap.searchInput);
+  const searchIcon = document.querySelector<HTMLElement>(SearchBarMap.searchIcon);
   const searchUrl = searchWidget?.dataset.searchControllerUrl;
+
+  // focus on the input field when clicking on the widget area
+  // helps to have a larger "area" for touch devices
+  searchWidget?.addEventListener('click', () => {
+    searchInput?.focus();
+  });
+
+  // if input has text then submit search when clicking on the icon
+  // usability for people without "enter" key
+  searchIcon?.addEventListener('click', () => {
+    if(searchInput?.value) {
+      searchInput?.form?.submit();
+    }
+  });
 
   searchCanvas?.addEventListener('hidden.bs.offcanvas', () => {
     if (searchDropdown) {

--- a/src/js/modules/ps_searchbar.ts
+++ b/src/js/modules/ps_searchbar.ts
@@ -28,7 +28,7 @@ const initSearchbar = () => {
   // if input has text then submit search when clicking on the icon
   // usability for people without "enter" key
   searchIcon?.addEventListener('click', () => {
-    if(searchInput?.value) {
+    if (searchInput?.value) {
       searchInput?.form?.submit();
     }
   });

--- a/types/selectors.d.ts
+++ b/types/selectors.d.ts
@@ -57,6 +57,7 @@ declare type searchBar = {
   searchResults: string,
   searchTemplate: string,
   searchInput: string,
+  searchIcon: string,
 };
 
 declare type checkout = {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Usability improvements for search widget. Focus on the input from larger area, Search by clicking on the icon (for people without enter key), use type=search to get "clear" x in the field automagically
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #543 (well at least touches on the subject ;)
| Sponsor company   | 
| How to test?      | Click on the search widget area (but not on the input for example the search icon), focus goes to the input field (better for touch devices to have larger click area). Write something in the field, see the "x" button your browser adds by default (https://caniuse.com/input-search). Click on the icon when there is text in the field, the form is submitted and the search happens.
