### PR TITLE
add psgdpr displayCustomerAccount, fixes #525

### DIFF
--- a/config/theme.yml
+++ b/config/theme.yml
@@ -59,6 +59,7 @@ global_settings:
         - blockwishlist
       displayCustomerAccount:
         - blockwishlist
+        - psgdpr
       displayMyAccountBlock:
         - blockwishlist
       displayNav1:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Hook registration for psgdpr was missing thus no GDPR in "my account"
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #525
| Sponsor company   | 
| How to test?      | Reactivate the theme (and maybe remove the `config/themes/hummingbird/shop1.json` first (not sure, I always remove it when changing the theme config as it is sometimes required). Check "My Account" page that GDPR section is there. 
