### PR TITLE
Fix missing add to wishlist button and modals backdrop

### DIFF
--- a/modules/blockwishlist/views/templates/components/modals/add-to-wishlist.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/add-to-wishlist.tpl
@@ -26,8 +26,7 @@
             @click="toggleModal"
             data-dismiss="modal"
             aria-label="{l s='Close' d='Modules.Blockwishlist.Shop'}"
-          >
-          </button>
+          ></button>
         </div>
 
         <div class="modal-body">
@@ -39,8 +38,7 @@
             url="{$url}"
             add-url="{$addUrl}"
             empty-text="{l s='No list found.' d='Modules.Blockwishlist.Shop'}"
-          >
-          </choose-list>
+          ></choose-list>
         </div>
 
         <div class="modal-footer">
@@ -52,11 +50,10 @@
     </div>
   </div>
 
-  <div 
+  <div
     class="modal-backdrop fade"
     {literal}
       :class="{in: !isHidden}"
     {/literal}
-  >
-  </div>
+  ></div>
 </div>

--- a/modules/blockwishlist/views/templates/components/modals/add-to-wishlist.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/add-to-wishlist.tpl
@@ -9,9 +9,7 @@
 >
   <div
     class="wishlist-modal modal fade"
-    {literal}
-      :class="{show: !isHidden}"
-    {/literal}
+    :class="{ldelim}show: !isHidden{rdelim}"
     tabindex="-1"
     role="dialog"
     aria-modal="true"
@@ -52,8 +50,6 @@
 
   <div
     class="modal-backdrop fade"
-    {literal}
-      :class="{in: !isHidden}"
-    {/literal}
+    :class="{ldelim}show: !isHidden{rdelim}"
   ></div>
 </div>

--- a/modules/blockwishlist/views/templates/components/modals/create.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/create.tpl
@@ -32,8 +32,7 @@
             @click="toggleModal"
             data-dismiss="modal"
             aria-label="Close"
-          >
-          </button>
+          ></button>
         </div>
         <div class="modal-body">
           <div class="form-group form-group-lg">
@@ -53,27 +52,22 @@
             class="modal-cancel btn btn-secondary"
             data-dismiss="modal"
             @click="toggleModal"
-          >
-            ((cancelText))
-          </button>
+          >((cancelText))</button>
 
           <button
             type="button"
             class="btn btn-primary"
             @click="createWishlist"
-          >
-            ((createText))
-          </button>
+          >((createText))</button>
         </div>
       </div>
     </div>
   </div>
 
-  <div 
+  <div
     class="modal-backdrop fade"
     {literal}
       :class="{in: !isHidden}"
     {/literal}
-  >
-  </div>
+  ></div>
 </div>

--- a/modules/blockwishlist/views/templates/components/modals/create.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/create.tpl
@@ -15,9 +15,7 @@
 >
   <div
     class="wishlist-modal modal fade"
-    {literal}
-      :class="{show: !isHidden}"
-    {/literal}
+    :class="{ldelim}show: !isHidden{rdelim}"
     tabindex="-1"
     role="dialog"
     aria-modal="true"
@@ -66,8 +64,6 @@
 
   <div
     class="modal-backdrop fade"
-    {literal}
-      :class="{in: !isHidden}"
-    {/literal}
+    :class="{ldelim}show: !isHidden{rdelim}"
   ></div>
 </div>

--- a/modules/blockwishlist/views/templates/components/modals/delete.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/delete.tpl
@@ -37,11 +37,10 @@
             @click="toggleModal"
             data-dismiss="modal"
             aria-label="Close"
-          >
-          </button>
+          ></button>
         </div>
         <div class="modal-body" v-if="productId">
-          <p class="modal-text">((confirmMessage))</p> 
+          <p class="modal-text">((confirmMessage))</p>
         </div>
         <div class="modal-footer">
           <button
@@ -49,27 +48,22 @@
             class="modal-cancel btn btn-secondary"
             data-dismiss="modal"
             @click="toggleModal"
-          >
-            ((cancelText))
-          </button>
+          >((cancelText))</button>
 
           <button
             type="button"
             class="btn btn-primary"
             @click="deleteWishlist"
-          >
-            ((modalDeleteText))
-          </button>
+          >((modalDeleteText))</button>
         </div>
       </div>
     </div>
   </div>
 
-  <div 
+  <div
     class="modal-backdrop fade"
     {literal}
       :class="{in: !isHidden}"
     {/literal}
-  >
-  </div>
+  ></div>
 </div>

--- a/modules/blockwishlist/views/templates/components/modals/delete.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/delete.tpl
@@ -20,9 +20,7 @@
 >
   <div
     class="wishlist-modal modal fade"
-    {literal}
-      :class="{show: !isHidden}"
-    {/literal}
+    :class="{ldelim}show: !isHidden{rdelim}"
     tabindex="-1"
     role="dialog"
     aria-modal="true"
@@ -62,8 +60,6 @@
 
   <div
     class="modal-backdrop fade"
-    {literal}
-      :class="{in: !isHidden}"
-    {/literal}
+    :class="{ldelim}show: !isHidden{rdelim}"
   ></div>
 </div>

--- a/modules/blockwishlist/views/templates/components/modals/login.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/login.tpl
@@ -10,9 +10,7 @@
 >
   <div
     class="wishlist-modal modal fade"
-    {literal}
-      :class="{show: !isHidden}"
-    {/literal}
+    :class="{ldelim}show: !isHidden{rdelim}"
     tabindex="-1"
     role="dialog"
     aria-modal="true"
@@ -51,8 +49,6 @@
 
   <div
     class="modal-backdrop fade"
-    {literal}
-      :class="{in: !isHidden}"
-    {/literal}
+    :class="{ldelim}show: !isHidden{rdelim}"
   ></div>
 </div>

--- a/modules/blockwishlist/views/templates/components/modals/login.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/login.tpl
@@ -27,8 +27,7 @@
             @click="toggleModal"
             data-dismiss="modal"
             aria-label="Close"
-          >
-          </button>
+          ></button>
         </div>
         <div class="modal-body">
           <p class="modal-text">{l s='You need to be logged in to save products in your wishlist.' d='Modules.Blockwishlist.Shop'}</p>
@@ -39,16 +38,12 @@
             class="modal-cancel btn btn-secondary"
             data-dismiss="modal"
             @click="toggleModal"
-          >
-            ((cancelText))
-          </button>
+          >((cancelText))</button>
 
           <a
             class="btn btn-primary"
             :href="prestashop.urls.pages.authentication"
-          >
-            ((loginText))
-          </a>
+          >((loginText))</a>
         </div>
       </div>
     </div>
@@ -59,6 +54,5 @@
     {literal}
       :class="{in: !isHidden}"
     {/literal}
-  >
-  </div>
+  ></div>
 </div>

--- a/modules/blockwishlist/views/templates/components/modals/rename.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/rename.tpl
@@ -31,8 +31,7 @@
             @click="toggleModal"
             data-dismiss="modal"
             aria-label="Close"
-          >
-          </button>
+          ></button>
         </div>
         <div class="modal-body">
           <div class="form-group form-group-lg">
@@ -51,26 +50,21 @@
             class="modal-cancel btn btn-secondary"
             data-dismiss="modal"
             @click="toggleModal"
-          >
-            ((cancelText))
-          </button>
+          >((cancelText))</button>
           <button
             type="button"
             class="btn btn-primary"
             @click="renameWishlist"
-          >
-            ((renameText))
-          </button>
+          >((renameText))</button>
         </div>
       </div>
     </div>
   </div>
 
-  <div 
+  <div
     class="modal-backdrop fade"
     {literal}
       :class="{in: !isHidden}"
     {/literal}
-  >
-  </div>
+  ></div>
 </div>

--- a/modules/blockwishlist/views/templates/components/modals/rename.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/rename.tpl
@@ -14,9 +14,7 @@
 >
   <div
     class="wishlist-modal modal fade"
-    {literal}
-      :class="{show: !isHidden}"
-    {/literal}
+    :class="{ldelim}show: !isHidden{rdelim}"
     tabindex="-1"
     role="dialog"
     aria-modal="true"
@@ -63,8 +61,6 @@
 
   <div
     class="modal-backdrop fade"
-    {literal}
-      :class="{in: !isHidden}"
-    {/literal}
+    :class="{ldelim}show: !isHidden{rdelim}"
   ></div>
 </div>

--- a/modules/blockwishlist/views/templates/components/modals/share.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/share.tpl
@@ -14,9 +14,7 @@
 >
   <div
     class="wishlist-modal modal fade"
-    {literal}
-      :class="{show: !isHidden}"
-    {/literal}
+    :class="{ldelim}show: !isHidden{rdelim}"
     tabindex="-1"
     role="dialog"
     aria-modal="true"
@@ -65,8 +63,6 @@
 
   <div
     class="modal-backdrop fade"
-    {literal}
-      :class="{in: !isHidden}"
-    {/literal}
+    :class="{ldelim}show: !isHidden{rdelim}"
   ></div>
 </div>

--- a/modules/blockwishlist/views/templates/components/modals/share.tpl
+++ b/modules/blockwishlist/views/templates/components/modals/share.tpl
@@ -31,8 +31,7 @@
             @click="toggleModal"
             data-dismiss="modal"
             aria-label="Close"
-          >
-          </button>
+          ></button>
         </div>
         <div class="modal-body">
           <div class="form-group form-group-lg">
@@ -52,27 +51,22 @@
             class="modal-cancel btn btn-secondary"
             data-dismiss="modal"
             @click="toggleModal"
-          >
-            ((cancelText))
-          </button>
+          >((cancelText))</button>
 
           <button
             type="button"
             class="btn btn-primary"
             @click="copyLink"
-          >
-            (( actionText ))
-          </button>
+          >(( actionText ))</button>
         </div>
       </div>
     </div>
   </div>
 
-  <div 
+  <div
     class="modal-backdrop fade"
     {literal}
       :class="{in: !isHidden}"
     {/literal}
-  >
-  </div>
+  ></div>
 </div>

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -5,13 +5,17 @@
 {$componentName = 'product-miniature'}
 
 {block name='product_miniature_item'}
-  <article class="{$componentName} js-{$componentName} thumbnail-container {if !empty($productClasses)} {$productClasses}{/if}" data-id-product="{$product.id_product}" data-id-product-attribute="{$product.id_product_attribute}">
+  <article
+    class="{$componentName} js-{$componentName}{if !empty($productClasses)} {$productClasses}{/if}"
+    data-id-product="{$product.id_product}"
+    data-id-product-attribute="{$product.id_product_attribute}"
+  >
     <div class="card">
       <a href="{$product.url}" class="{$componentName}__link">
         {include file='catalog/_partials/product-flags.tpl'}
 
         {block name='product_miniature_image'}
-          <div class="{$componentName}__image-container">
+          <div class="{$componentName}__image-container thumbnail-container">
             {if $product.cover}
               <picture>
                 {if isset($product.cover.bySize.default_md.sources.avif)}
@@ -102,7 +106,7 @@
 
             {block name='quick_view_touch'}
               <button class="{$componentName}__quickview_touch btn js-quickview" data-link-action="quickview">
-                  <i class="material-icons">&#xE417;</i>
+                <i class="material-icons">&#xE417;</i>
               </button>
             {/block}
           </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | #568 prevented Add to wishlist button from loading on product list and caused error thrown in the console. `thumbnail-container` needs to be back in its original place.<br>It temporary breaks the product rating, but this needs to be fixed in the productcomments module, where wrong selector is being used in js (fix: https://github.com/PrestaShop/productcomments/pull/198)
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | -

### Before
![obraz](https://github.com/PrestaShop/hummingbird/assets/5007456/910c009c-8ece-43e2-a125-530814f53091)

### After
![obraz](https://github.com/PrestaShop/hummingbird/assets/5007456/f6a0eea8-bcee-401f-b554-5b2a290d502b)
