### PR TITLE
Address Card: add border

### DIFF
--- a/src/scss/custom/components/_address.scss
+++ b/src/scss/custom/components/_address.scss
@@ -2,6 +2,7 @@ $component-name: address;
 
 .#{$component-name} {
   background: lighten($gray-100, 2%);
+  border: 1px solid $gray-200;
 
   &__content {
     margin: 0;

--- a/src/scss/custom/pages/_checkout.scss
+++ b/src/scss/custom/pages/_checkout.scss
@@ -2,6 +2,7 @@ $component-name: step;
 
 .#{$component-name} {
   .address {
+    margin: 1px;
     border: 1px solid $gray-300;
 
     &,
@@ -10,6 +11,7 @@ $component-name: step;
     }
 
     &.selected {
+      margin: 0;
       border: 2px solid $primary;
     }
   }

--- a/src/scss/custom/pages/_checkout.scss
+++ b/src/scss/custom/pages/_checkout.scss
@@ -3,7 +3,7 @@ $component-name: step;
 .#{$component-name} {
   .address {
     margin: 1px;
-    border: 1px solid $gray-300;
+    border: 1px solid $gray-200;
 
     &,
     &__content {


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add border on address card (on My Account) and have the same border on checkout address card.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #527
| Sponsor company   | N/A
| How to test?      | Go to "Addresses" and "Checkout"

Before:
![Screenshot_20240202_222705](https://github.com/PrestaShop/hummingbird/assets/22885898/77f07385-5f69-469b-8f70-6012d3deecf8)
![Screenshot_20240202_223706](https://github.com/PrestaShop/hummingbird/assets/22885898/06fc3567-0db7-4ee6-b1b4-4f28378da4b4)

After:
![Screenshot_20240202_222724](https://github.com/PrestaShop/hummingbird/assets/22885898/729dc22c-3318-48f8-8aa1-ef15c541e17b)
![Screenshot_20240202_223751](https://github.com/PrestaShop/hummingbird/assets/22885898/ff6153ae-98e2-46ee-9713-279b2fed5fc2)
