### PR TITLE
WIP: Accessibility: Add skip to content button

### DIFF
--- a/src/scss/custom/layout/_header-top.scss
+++ b/src/scss/custom/layout/_header-top.scss
@@ -25,3 +25,16 @@ $component-name: header-top;
     }
   }
 }
+
+.skip-link {
+  &__wrapper {
+      @include visually-hidden-focusable;
+  }
+
+  &__btn {
+      position: absolute;
+      top: 1em;
+      left: 1em;
+      z-index: 200;
+  }
+}

--- a/templates/layouts/layout-both-columns.tpl
+++ b/templates/layouts/layout-both-columns.tpl
@@ -18,6 +18,14 @@
       {hook h='displayAfterBodyOpeningTag'}
     {/block}
 
+    {block name='skip_link'}
+      <div class="skip-link__wrapper">
+        <a href="#wrapper" class="btn btn-primary skip-link__btn">
+          {l s='Skip to content' d='Shop.Theme.Actions'}
+        </a>
+      </div>
+    {/block}
+
     {block name='product_activation'}
       {include file='catalog/_partials/product-activation.tpl'}
     {/block}


### PR DESCRIPTION
Don't push it as it is: firstly, I don't know if the naming is right. Secondly, on some pages, like the category page for example, clicking on the link redirects to `/[object History]`. I haven't yet been able to find out why, so if anyone has any ideas, I'd be grateful for any help.

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a "Skip to content" button for accessibility.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | No, but help #251
| Sponsor company   | N/A
| How to test?      | Load a page and press "tab"

Screenshot:
![image](https://github.com/PrestaShop/hummingbird/assets/22885898/94f29c5a-668f-467c-876f-e46d95665c3d)
