### PR TITLE
Changed lazyloading with highest fetchpriority in category header

### DIFF
--- a/templates/catalog/_partials/category-header.tpl
+++ b/templates/catalog/_partials/category-header.tpl
@@ -13,7 +13,7 @@
               <div class="category-cover mb-4">
                 <img src="{$category.image.large.url}" 
                   alt="{if !empty($category.image.legend)}{$category.image.legend}{else}{$category.name}{/if}" 
-                  loading="lazy" 
+                  fetchpriority="high" 
                   class="img-fluid"
                   width="{$category.image.large.width}" 
                   height="{$category.image.large.height}">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | I have changed the lazyloading with a more accurate property for this element, the fetchpriority=high.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open Chrome devtools in Performance tab and measure that image is loading first.

# Common scenario

We have to load an header image, the LCP of the page depends on it, so we cannot load it in lazy loading mode but in fetchpriority=high, so in network order load of resources we get an highest priority and a fastest rendering.

## Additional Resources

https://web.dev/articles/fetch-priority
