### PR TITLE
Accessibility: add "autocomplete" to the email/password fields on the forgotten password screens

### DIFF
--- a/templates/customer/password-email.tpl
+++ b/templates/customer/password-email.tpl
@@ -27,7 +27,7 @@
     <section class="form-fields">
       <div class="mb-3">
         <label class="form-label required">{l s='Email address' d='Shop.Forms.Labels'}</label>
-        <input type="email" name="email" id="email" value="{if isset($smarty.post.email)}{stripslashes($smarty.post.email)}{/if}" class="form-control" required>
+        <input type="email" name="email" id="email" value="{if isset($smarty.post.email)}{stripslashes($smarty.post.email)}{/if}" class="form-control" autocomplete="email" required>
       </div>
       <button id="send-reset-link" class="form-control-submit btn btn-primary" name="submit" type="submit">
         {l s='Send reset link' d='Shop.Theme.Actions'}

--- a/templates/customer/password-new.tpl
+++ b/templates/customer/password-new.tpl
@@ -32,7 +32,7 @@
       <div class="mb-3">
         <label class="form-label">{l s='New password' d='Shop.Forms.Labels'}</label>
         <div class="input-group password-field js-parent-focus">
-          <input class="form-control js-child-focus js-visible-password" type="password" data-validate="isPasswd" name="passwd" value="">
+          <input class="form-control js-child-focus js-visible-password" type="password" data-validate="isPasswd" name="passwd" value="" autocomplete="new-password">
           <button
             class="btn btn-primary"
             type="button"
@@ -49,7 +49,7 @@
       <div class="mb-3">
         <label class="form-label">{l s='Confirmation' d='Shop.Forms.Labels'}</label>
         <div class="input-group password-field js-parent-focus">
-        <input class="form-control js-child-focus js-visible-password" type="password" data-validate="isPasswd" name="confirmation" value="">
+        <input class="form-control js-child-focus js-visible-password" type="password" data-validate="isPasswd" name="confirmation" value="" autocomplete="new-password">
           <button
             class="btn btn-primary"
             type="button"


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add "autocomplete" to the email/password fields on the forgotten password screens to improve accessibility.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | No, but help #251 and #582
| Sponsor company   | N/A
| How to test?      | Check fields on the forgotten password screens
