### PR TITLE
Templates: double quotes => single quote (for Smarty strings)

### DIFF
--- a/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl
+++ b/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl
@@ -4,8 +4,8 @@
  *}
 <section class="best-sellers-products mt-3">
     <div class="container">
-        {include file="components/section-title.tpl" title={l s="Best Sellers" d="Shop.Theme.Catalog"}}
-        {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+        {include file='components/section-title.tpl' title={l s='Best Sellers' d='Shop.Theme.Catalog'}}
+        {include file='catalog/_partials/productlist.tpl' products=$products productClass='col-6 col-lg-4 col-xl-3'}
         <div class="best-sellers-products-footer text-center">
             <a class="all-product-link btn btn-outline-primary" href="{$allBestSellers}">
                 {l s='All best sellers' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip" aria-hidden="true">&#xE315;</i>

--- a/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl
+++ b/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl
@@ -18,7 +18,7 @@
 
     <div>
       {if $brands}
-        {include file="module:ps_brandlist/views/templates/_partials/$brand_display_type.tpl" brands=$brands}
+        {include file='module:ps_brandlist/views/templates/_partials/$brand_display_type.tpl' brands=$brands}
       {else}
         <p class="mb-0">{l s='No brand' d='Shop.Theme.Catalog'}</p>
       {/if}

--- a/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
+++ b/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
@@ -5,11 +5,11 @@
 <section class="category-products mt-3">
   <div class="container">
     {if $products|@count == 1}
-      {include file="components/section-title.tpl" title={l s='%s other product in the same category' sprintf=[$products|@count] d='Shop.Theme.Catalog'}}
+      {include file='components/section-title.tpl' title={l s='%s other product in the same category' sprintf=[$products|@count] d='Shop.Theme.Catalog'}}
     {else}
-      {include file="components/section-title.tpl" title={l s='%s other products in the same category' sprintf=[$products|@count] d='Shop.Theme.Catalog'}}
+      {include file='components/section-title.tpl' title={l s='%s other products in the same category' sprintf=[$products|@count] d='Shop.Theme.Catalog'}}
     {/if}
 
-    {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+    {include file='catalog/_partials/productlist.tpl' products=$products productClass='col-6 col-lg-4 col-xl-3'}
   </div>
 </section>

--- a/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl
+++ b/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl
@@ -5,7 +5,7 @@
 
 <section class="featured-products mt-3">
   <div class="container">
-    {include file="components/section-title.tpl" title={l s='Customers who bought this product also bought:' d='Shop.Theme.Catalog'}}
-    {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+    {include file='components/section-title.tpl' title={l s='Customers who bought this product also bought:' d='Shop.Theme.Catalog'}}
+    {include file='catalog/_partials/productlist.tpl' products=$products productClass='col-6 col-lg-4 col-xl-3'}
   </div>
 </section>

--- a/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
+++ b/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
@@ -34,13 +34,13 @@
       {if $configuration.return_enabled && !$configuration.is_catalog}
         <li><a href="{$urls.pages.order_follow}" title="{l s='Merchandise returns' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Merchandise returns' d='Shop.Theme.Customeraccount'}</a></li>
       {/if}
-      {hook h="displayMyAccountBlock"}
+      {hook h='displayMyAccountBlock'}
       <li><a href="{$urls.actions.logout}" title="{l s='Log me out' d='Shop.Theme.Customeraccount'}" class="logout" rel="nofollow">{l s='Sign out' d='Shop.Theme.Actions'}</a></li>
     {else}
       <li><a href="{$urls.pages.guest_tracking}" title="{l s='Order tracking' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Order tracking' d='Shop.Theme.Customeraccount'}</a></li>
       <li><a href="{$urls.pages.my_account}" title="{l s='Log in to your customer account' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Sign in' d='Shop.Theme.Actions'}</a></li>
       <li><a href="{$urls.pages.register}" title="{l s='Create account' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Create account' d='Shop.Theme.Customeraccount'}</a></li>
-      {hook h="displayMyAccountBlock"}
+      {hook h='displayMyAccountBlock'}
     {/if}
 	</ul>
 </div>

--- a/modules/ps_emailalerts/views/templates/hook/product.tpl
+++ b/modules/ps_emailalerts/views/templates/hook/product.tpl
@@ -25,10 +25,10 @@
 
 <div class="card card-body text-center js-mailalert mb-3 mt-3 bg-light" data-url="{url entity='module' name='ps_emailalerts' controller='actions' params=['process' => 'add']}">
     {if isset($email) AND $email}
-        <p>{l s="Interested in this product? Drop us an email and we will let you know when it's available for order." d='Modules.Emailalerts.Shop'}</p>
+        <p>{l s='Interested in this product? Drop us an email and we will let you know when it\'s available for order.' d='Modules.Emailalerts.Shop'}</p>
         <input class="form-control" type="email" placeholder="{l s='your@email.com' d='Modules.Emailalerts.Shop'}"/>
     {else}
-        <p>{l s="Interested in this product? Click below and we will let you know when it's available for order." d='Modules.Emailalerts.Shop'}</p>
+        <p>{l s='Interested in this product? Click below and we will let you know when it\'s available for order.' d='Modules.Emailalerts.Shop'}</p>
     {/if}
 
     {if !empty($id_module)}

--- a/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
+++ b/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
@@ -4,8 +4,8 @@
  *}
 <section class="featured-products">
   <div class="container">
-    {include file="components/section-title.tpl" title={l s="Popular Products" d="Shop.Theme.Catalog"}}
-    {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+    {include file='components/section-title.tpl' title={l s='Popular Products' d='Shop.Theme.Catalog'}}
+    {include file='catalog/_partials/productlist.tpl' products=$products productClass='col-6 col-lg-4 col-xl-3'}
   </div>
 
   <div class="featured-products-footer text-center">

--- a/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
+++ b/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
@@ -5,8 +5,8 @@
 
 <section class="new-products mt-3">
     <div class="container">
-        {include file="components/section-title.tpl" title={l s="New products" d="Shop.Theme.Catalog"}}
-        {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+        {include file='components/section-title.tpl' title={l s='New products' d='Shop.Theme.Catalog'}}
+        {include file='catalog/_partials/productlist.tpl' products=$products productClass='col-6 col-lg-4 col-xl-3'}
         <div class="new-products-footer text-center">
             <a class="all-product-link btn btn-outline-primary" href="{$allNewProductsLink}">
                 {l s='All new products' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip" aria-hidden="true">&#xE315;</i>

--- a/modules/ps_specials/views/templates/hook/ps_specials.tpl
+++ b/modules/ps_specials/views/templates/hook/ps_specials.tpl
@@ -5,8 +5,8 @@
 
 <section class="sale-products mt-3">
     <div class="container">
-        {include file="components/section-title.tpl" title={l s="On sale" d="Shop.Theme.Catalog"}}
-        {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+        {include file='components/section-title.tpl' title={l s='On sale' d='Shop.Theme.Catalog'}}
+        {include file='catalog/_partials/productlist.tpl' products=$products productClass='col-6 col-lg-4 col-xl-3'}
         <div class="sale-products-footer text-center">
             <a class="all-product-link btn btn-outline-primary" href="{$allSpecialProductsLink}">
                 {l s='All sale products' d='Shop.Theme.Catalog'}<i class="material-icons rtl-flip" aria-hidden="true">&#xE315;</i>

--- a/modules/ps_supplierlist/views/templates/hook/ps_supplierlist.tpl
+++ b/modules/ps_supplierlist/views/templates/hook/ps_supplierlist.tpl
@@ -18,7 +18,7 @@
 
     <div>
       {if $suppliers}
-        {include file="module:ps_supplierlist/views/templates/_partials/$supplier_display_type.tpl" suppliers=$suppliers}
+        {include file='module:ps_supplierlist/views/templates/_partials/$supplier_display_type.tpl' suppliers=$suppliers}
       {else}
         <p>{l s='No supplier' d='Shop.Theme.Catalog'}</p>
       {/if}

--- a/modules/ps_viewedproduct/views/templates/hook/ps_viewedproduct.tpl
+++ b/modules/ps_viewedproduct/views/templates/hook/ps_viewedproduct.tpl
@@ -4,7 +4,7 @@
  *}
 <section class="viewed-products mt-3">
   <div class="container">
-    {include file="components/section-title.tpl" title={l s="Viewed products" d="Shop.Theme.Catalog"}}
-    {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+    {include file='components/section-title.tpl' title={l s='Viewed products' d='Shop.Theme.Catalog'}}
+    {include file='catalog/_partials/productlist.tpl' products=$products productClass='col-6 col-lg-4 col-xl-3'}
   </div>
 </section>

--- a/modules/psgdpr/views/templates/hook/displayGDPRConsent.tpl
+++ b/modules/psgdpr/views/templates/hook/displayGDPRConsent.tpl
@@ -16,7 +16,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  *}
-{extends file="modules/psgdpr/views/templates/hook/displayGDPRConsent.tpl"}
+{extends file='modules/psgdpr/views/templates/hook/displayGDPRConsent.tpl'}
 {block name='gdpr_checkbox'}
   <div id="gdpr_consent" class="mt-2 gdpr_module_{$psgdpr_id_module|escape:'htmlall':'UTF-8'}">
     <span class="form-check">

--- a/templates/_partials/head.tpl
+++ b/templates/_partials/head.tpl
@@ -11,7 +11,7 @@
 
 {block name='head_seo'}
   {block name='head_preload'}
-    {include file="_partials/preload.tpl"}
+    {include file='_partials/preload.tpl'}
   {/block}
 
   <title>{block name='head_seo_title'}{$page.meta.title}{/block}</title>
@@ -33,13 +33,13 @@
   {/block}
 
   {block name='head_microdata'}
-    {include file="_partials/microdata/head-jsonld.tpl"}
+    {include file='_partials/microdata/head-jsonld.tpl'}
   {/block}
 
   {block name='head_microdata_special'}{/block}
 
   {block name='head_pagination_seo'}
-    {include file="_partials/pagination-seo.tpl"}
+    {include file='_partials/pagination-seo.tpl'}
   {/block}
 
   {block name='head_open_graph'}
@@ -61,11 +61,11 @@
 {/block}
 
 {block name='stylesheets'}
-  {include file="_partials/stylesheets.tpl" stylesheets=$stylesheets}
+  {include file='_partials/stylesheets.tpl' stylesheets=$stylesheets}
 {/block}
 
 {block name='javascript_head'}
-  {include file="_partials/javascript.tpl" javascript=$javascript.head vars=$js_custom_vars}
+  {include file='_partials/javascript.tpl' javascript=$javascript.head vars=$js_custom_vars}
 {/block}
 
 {block name='hook_header'}

--- a/templates/catalog/_partials/category-header.tpl
+++ b/templates/catalog/_partials/category-header.tpl
@@ -5,7 +5,7 @@
 <div id="js-product-list-header">
     {if $listing.pagination.items_shown_from == 1}
         <div class="block-category">
-          {include file="components/page-title-section.tpl" title={$category.name}}
+          {include file='components/page-title-section.tpl' title={$category.name}}
             {if $category.description}
               <div id="category-description" class="rich-text mb-4">{$category.description nofilter}</div>
             {/if}

--- a/templates/catalog/_partials/product-accessories.tpl
+++ b/templates/catalog/_partials/product-accessories.tpl
@@ -3,6 +3,6 @@
  * file that was distributed with this source code.
  *}
  <section class="product-accessories mt-3">
-  {include file="components/section-title.tpl" title={l s='You might also like' d='Shop.Theme.Catalog'}}
-  {include file="catalog/_partials/productlist.tpl" products=$accessories productClass="col-6 col-lg-4 col-xl-3"}
+  {include file='components/section-title.tpl' title={l s='You might also like' d='Shop.Theme.Catalog'}}
+  {include file='catalog/_partials/productlist.tpl' products=$accessories productClass='col-6 col-lg-4 col-xl-3'}
 </section>

--- a/templates/catalog/_partials/productlist.tpl
+++ b/templates/catalog/_partials/productlist.tpl
@@ -5,7 +5,7 @@
 {capture assign="productClasses"}{if !empty($productClass)}{$productClass}{else}col-6 col-xl-4{/if}{/capture}
 
 <div class="products{if !empty($cssClass)} {$cssClass}{else} row{/if}">
-  {foreach from=$products item="product" key="position"}
-    {include file="catalog/_partials/miniatures/product.tpl" product=$product position=$position productClasses=$productClasses}
+  {foreach from=$products item='product' key='position'}
+    {include file='catalog/_partials/miniatures/product.tpl' product=$product position=$position productClasses=$productClasses}
   {/foreach}
 </div>

--- a/templates/catalog/_partials/products.tpl
+++ b/templates/catalog/_partials/products.tpl
@@ -3,7 +3,7 @@
  * file that was distributed with this source code.
  *}
 <div id="js-product-list">
-  {include file="catalog/_partials/productlist.tpl" products=$listing.products}
+  {include file='catalog/_partials/productlist.tpl' products=$listing.products}
 
   {block name='pagination'}
     {include file='_partials/pagination.tpl' pagination=$listing.pagination}

--- a/templates/catalog/_partials/quickview.tpl
+++ b/templates/catalog/_partials/quickview.tpl
@@ -25,7 +25,7 @@
           {/block}
           {block name='product_customization'}
             {if $product.is_customizable && count($product.customizations.fields)}
-              {include file="catalog/_partials/product-customization.tpl" customizations=$product.customizations}
+              {include file='catalog/_partials/product-customization.tpl' customizations=$product.customizations}
             {/if}
           {/block}
           {block name='product_buy'}

--- a/templates/catalog/brands.tpl
+++ b/templates/catalog/brands.tpl
@@ -6,7 +6,7 @@
 
 {block name='content'}
   {block name='brand_header'}
-    {include file="components/page-title-section.tpl" title={l s='Brands' d='Shop.Theme.Catalog'}}
+    {include file='components/page-title-section.tpl' title={l s='Brands' d='Shop.Theme.Catalog'}}
   {/block}
 
   {block name='brand_miniature'}

--- a/templates/catalog/listing/manufacturer.tpl
+++ b/templates/catalog/listing/manufacturer.tpl
@@ -5,7 +5,7 @@
 {extends file='catalog/listing/product-list.tpl'}
 
 {block name='product_list_header'}
-  {include file="components/page-title-section.tpl" title={l s='List of products by brand %brand_name%' sprintf=['%brand_name%' => $manufacturer.name] d='Shop.Theme.Catalog'}}
+  {include file='components/page-title-section.tpl' title={l s='List of products by brand %brand_name%' sprintf=['%brand_name%' => $manufacturer.name] d='Shop.Theme.Catalog'}}
   <div id="manufacturer-short_description" class="rich-text">{$manufacturer.short_description nofilter}</div>
   <div id="manufacturer-description" class="rich-text">{$manufacturer.description nofilter}</div>
 {/block}

--- a/templates/catalog/listing/product-list.tpl
+++ b/templates/catalog/listing/product-list.tpl
@@ -14,7 +14,7 @@
       <h1 id="js-product-list-header" class="h2 mb-4">{$listing.label}</h1>
     {/block}
     
-    {hook h="displayHeaderCategory"}
+    {hook h='displayHeaderCategory'}
 
     <section id="products">
       {if $listing.products|count}
@@ -28,7 +28,7 @@
         {/block}
 
         {block name='product_list'}
-          {include file='catalog/_partials/products.tpl' listing=$listing productClass="col-6 col-xl-4"}
+          {include file='catalog/_partials/products.tpl' listing=$listing productClass='col-6 col-xl-4'}
         {/block}
 
         {block name='product_list_bottom'}
@@ -51,8 +51,9 @@
       {/if}
     </section>
 
+
     {block name='product_list_footer'}{/block}
 
-    {hook h="displayFooterCategory"}
 
+    {hook h='displayFooterCategory'}
 {/block}

--- a/templates/catalog/listing/search.tpl
+++ b/templates/catalog/listing/search.tpl
@@ -5,10 +5,10 @@
 {extends file='catalog/listing/product-list.tpl'}
 
 {block name='product_list'}
-  {include file='catalog/_partials/products.tpl' listing=$listing productClass="col-6 col-md-4 col-xl-3"}
+  {include file='catalog/_partials/products.tpl' listing=$listing productClass='col-6 col-md-4 col-xl-3'}
 {/block}
 
-{block name="error_content"}
+{block name='error_content'}
   <p>{l s='Search again what you are looking for.' d='Shop.Theme.Catalog'}</p>
 {/block}
 

--- a/templates/catalog/listing/supplier.tpl
+++ b/templates/catalog/listing/supplier.tpl
@@ -5,6 +5,6 @@
 {extends file='catalog/listing/product-list.tpl'}
 
 {block name='product_list_header'}
-  {include file="components/page-title-section.tpl" title={l s='List of products by supplier %s' sprintf=[$supplier.name] d='Shop.Theme.Catalog'}}
+  {include file='components/page-title-section.tpl' title={l s='List of products by supplier %s' sprintf=[$supplier.name] d='Shop.Theme.Catalog'}}
   <div id="supplier-description" class="rich-text">{$supplier.description nofilter}</div>
 {/block}

--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -51,7 +51,7 @@
 
       {block name='product_customization'}
         {if $product.is_customizable && count($product.customizations.fields)}
-          {include file="catalog/_partials/product-customization.tpl" customizations=$product.customizations}
+          {include file='catalog/_partials/product-customization.tpl' customizations=$product.customizations}
         {/if}
       {/block}
 

--- a/templates/catalog/suppliers.tpl
+++ b/templates/catalog/suppliers.tpl
@@ -5,5 +5,5 @@
 {extends file='catalog/brands.tpl'}
 
 {block name='brand_header'}
-  {include file="components/page-title-section.tpl" title={l s='Suppliers' d='Shop.Theme.Catalog'}}
+  {include file='components/page-title-section.tpl' title={l s='Suppliers' d='Shop.Theme.Catalog'}}
 {/block}

--- a/templates/checkout/_partials/address-form.tpl
+++ b/templates/checkout/_partials/address-form.tpl
@@ -8,7 +8,7 @@
   {/if}
 {/block}
 
-{block name="address_form_url"}
+{block name='address_form_url'}
     <form
       method="POST"
       action="{url entity='order' params=['id_address' => $id_address]}"

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -82,7 +82,7 @@
     </a>
 
     {if is_array($product.customizations) && $product.customizations|count}
-      {include file="catalog/_partials/product-customization-modal.tpl" product=$product}
+      {include file='catalog/_partials/product-customization-modal.tpl' product=$product}
     {/if}
 
     {foreach from=$product.attributes key="attribute" item="value"}

--- a/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/templates/checkout/_partials/order-confirmation-table.tpl
@@ -85,7 +85,7 @@
         {/if}
 
         {if is_array($product.customizations) && $product.customizations|count}
-          {include file="catalog/_partials/product-customization-modal.tpl" product=$product}
+          {include file='catalog/_partials/product-customization-modal.tpl' product=$product}
         {/if}
         
         {hook h='displayProductPriceBlock' product=$product type="unit_price"}

--- a/templates/checkout/_partials/steps/addresses.tpl
+++ b/templates/checkout/_partials/steps/addresses.tpl
@@ -46,7 +46,7 @@
         {if isset($delivery_address_error)}
           <p class="alert alert-danger js-address-error" name="alert-delivery" id="id-failure-address-{$delivery_address_error.id_address}">{$delivery_address_error.exception}</p>
         {else}
-          <p class="alert alert-danger js-address-error" name="alert-delivery" style="display: none">{l s="Your address is incomplete, please update it." d="Shop.Notifications.Error"}</p>
+          <p class="alert alert-danger js-address-error" name="alert-delivery" style="display: none">{l s='Your address is incomplete, please update it.' d='Shop.Notifications.Error'}</p>
         {/if}
 
         <a href="{$new_address_delivery_url}" class="btn btn-outline-primary btn-with-icon w-100 w-md-auto mb-3">
@@ -87,7 +87,7 @@
           {if isset($invoice_address_error)}
             <p class="alert alert-danger js-address-error" name="alert-invoice" id="id-failure-address-{$invoice_address_error.id_address}">{$invoice_address_error.exception}</p>
           {else}
-            <p class="alert alert-danger js-address-error" name="alert-invoice" style="display: none">{l s="Your address is incomplete, please update it." d="Shop.Notifications.Error"}</p>
+            <p class="alert alert-danger js-address-error" name="alert-invoice" style="display: none">{l s='Your address is incomplete, please update it.' d='Shop.Notifications.Error'}</p>
           {/if}
 
           <a href="{$new_address_invoice_url}" class="btn btn-outline-primary btn-with-icon w-100 w-md-auto">

--- a/templates/checkout/checkout-navigation.tpl
+++ b/templates/checkout/checkout-navigation.tpl
@@ -86,7 +86,7 @@
 
     <div class="{$componentName}__mobile mb-0 d-flex align-items-center d-md-none">
       <div class="{$componentName}__left mx-3">
-        {include file="components/progress-circle.tpl" classes="text-success col-4" size=74 stroke=4}
+        {include file='components/progress-circle.tpl' classes="text-success col-4" size=74 stroke=4}
       </div>
 
       <div class="{$componentName}__step d-none" data-step="checkout-personal-information-step">

--- a/templates/checkout/checkout.tpl
+++ b/templates/checkout/checkout.tpl
@@ -11,7 +11,7 @@
 {/block}
 
 {block name='content_columns'}
-  {include file="checkout/checkout-navigation.tpl"}
+  {include file='checkout/checkout-navigation.tpl'}
 
   {block name='checkout_notifications'}
     {include file='_partials/notifications.tpl'}

--- a/templates/contact.tpl
+++ b/templates/contact.tpl
@@ -7,13 +7,13 @@
 {block name='page_header_container'}{/block}
 
 {if $layout === 'layouts/layout-left-column.tpl'}
-  {block name="left_column"}
+  {block name='left_column'}
     <div id="left-column" class="wrapper__left-column col-md-4 col-lg-3">
       {hook h='displayContactLeftColumn'}
     </div>
   {/block}
 {else if $layout === 'layouts/layout-right-column.tpl'}
-  {block name="right_column"}
+  {block name='right_column'}
     <div id="right-column" class="wrapper__right-column col-md-4 col-lg-3">
       {hook h='displayContactRightColumn'}
     </div>

--- a/templates/customer/_partials/address-form.tpl
+++ b/templates/customer/_partials/address-form.tpl
@@ -2,11 +2,11 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
-{block name="address_form"}
+{block name='address_form'}
   <div class="js-address-form">
     {include file='_partials/form-errors.tpl' errors=$errors['']}
 
-    {block name="address_form_url"}
+    {block name='address_form_url'}
     <form
       class="form-validation"
       method="POST"
@@ -17,7 +17,7 @@
     >
     {/block}
 
-      {block name="address_form_fields"}
+      {block name='address_form_fields'}
         <section class="form-fields">
           {block name='form_fields'}
             {foreach from=$formFields item="field"}
@@ -29,7 +29,7 @@
         </section>
       {/block}
 
-      {block name="address_form_footer"}
+      {block name='address_form_footer'}
       <footer class="form-footer">
         <input type="hidden" name="submitAddress" value="1">
         {block name='form_buttons'}

--- a/templates/customer/_partials/customer-form.tpl
+++ b/templates/customer/_partials/customer-form.tpl
@@ -2,12 +2,12 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
-{block name="customer_form"}
-  {block name="customer_form_errors"}
-    {include file="_partials/form-errors.tpl" errors=$errors[""]}
+{block name='customer_form'}
+  {block name='customer_form_errors'}
+    {include file='_partials/form-errors.tpl' errors=$errors['']}
   {/block}
 
-<form action="{block name="customer_form_actionurl"}{$action}{/block}" id="customer-form" class="form-validation js-customer-form" method="post" novalidate>
+<form action="{block name='customer_form_actionurl'}{$action}{/block}" id="customer-form" class="form-validation js-customer-form" method="post" novalidate>
   <section>
     {block "form_fields"}
       {foreach from=$formFields item="field"}

--- a/templates/customer/address.tpl
+++ b/templates/customer/address.tpl
@@ -14,6 +14,6 @@
 
 {block name='page_content'}
   <div class="address-form">
-    {render template="customer/_partials/address-form.tpl" ui=$address_form}
+    {render template='customer/_partials/address-form.tpl' ui=$address_form}
   </div>
 {/block}

--- a/templates/customer/authentication.tpl
+++ b/templates/customer/authentication.tpl
@@ -6,7 +6,7 @@
 
 {extends file='page.tpl'}
 
-{block name="container_class"}container container--limited-sm{/block}
+{block name='container_class'}container container--limited-sm{/block}
 
 {block name='page_title'}
   {l s='Sign in' d='Shop.Theme.Customeraccount'}

--- a/templates/customer/guest-login.tpl
+++ b/templates/customer/guest-login.tpl
@@ -4,7 +4,7 @@
  *}
 {extends file='page.tpl'}
 
-{block name="container_class"}container container--limited-md{/block}
+{block name='container_class'}container container--limited-md{/block}
 
 {block name='page_title'}
   {l s='Guest Order Tracking' d='Shop.Theme.Customeraccount'}

--- a/templates/customer/password-email.tpl
+++ b/templates/customer/password-email.tpl
@@ -4,7 +4,7 @@
  *}
 {extends file='page.tpl'}
 
-{block name="container_class"}container container--limited-sm{/block}
+{block name='container_class'}container container--limited-sm{/block}
 
 {block name='page_title'}
   {l s='Forgot your password?' d='Shop.Theme.Customeraccount'}

--- a/templates/customer/password-infos.tpl
+++ b/templates/customer/password-infos.tpl
@@ -4,7 +4,7 @@
  *}
 {extends file='page.tpl'}
 
-{block name="container_class"}container container--limited-sm{/block}
+{block name='container_class'}container container--limited-sm{/block}
 
 {block name='page_title'}
   {l s='Forgot your password?' d='Shop.Theme.Customeraccount'}

--- a/templates/customer/password-new.tpl
+++ b/templates/customer/password-new.tpl
@@ -4,7 +4,7 @@
  *}
 {extends file='page.tpl'}
 
-{block name="container_class"}container container--limited-sm{/block}
+{block name='container_class'}container container--limited-sm{/block}
 
 {block name='page_title'}
   {l s='Reset your password' d='Shop.Theme.Customeraccount'}

--- a/templates/customer/registration.tpl
+++ b/templates/customer/registration.tpl
@@ -4,7 +4,7 @@
  *}
 {extends file='page.tpl'}
 
-{block name="container_class"}container container--limited-md{/block}
+{block name='container_class'}container container--limited-md{/block}
 
 {block name='page_title'}
   {l s='Create an account' d='Shop.Theme.Customeraccount'}
@@ -14,7 +14,7 @@
   {block name='register_form_container'}
     {$hook_create_account_top nofilter}
     <section class="register-form">
-      {render file='customer/_partials/customer-form.tpl' ui=$register_form mode="register"}
+      {render file='customer/_partials/customer-form.tpl' ui=$register_form mode='register'}
       <hr>
       <p class="register-form__login-prompt">{l s='Already have an account?' d='Shop.Theme.Customeraccount'} <a href="{$urls.pages.authentication}">{l s='Sign in' d='Shop.Theme.Customeraccount'}</a></p>
     </section>

--- a/templates/errors/404.tpl
+++ b/templates/errors/404.tpl
@@ -4,9 +4,9 @@
  *}
 {extends file='page.tpl'}
 
-{block name="breadcrumb"}{/block}
+{block name='breadcrumb'}{/block}
 
-{block name="container_class"}container container--limited-md text-center{/block}
+{block name='container_class'}container container--limited-md text-center{/block}
 
 {block name='page_header_container'}
   {block name='page_title'}
@@ -23,8 +23,8 @@
       s='If this is a recurring problem, please [1]contact us[/1]'
       d='Shop.Theme.Catalog'
       sprintf=[
-        '[1]' => "<a href='{$urls.pages.contact}' class='alert-link'>",
-        '[/1]' => "</a>"
+        '[1]' => '<a href="{$urls.pages.contact}" class="alert-link">',
+        '[/1]' => '</a>'
       ]
     }
   </p>

--- a/templates/errors/410.tpl
+++ b/templates/errors/410.tpl
@@ -4,9 +4,9 @@
  *}
 {extends file='page.tpl'}
 
-{block name="breadcrumb"}{/block}
+{block name='breadcrumb'}{/block}
 
-{block name="container_class"}container container--limited-md text-center{/block}
+{block name='container_class'}container container--limited-md text-center{/block}
 
 {block name='page_header_container'}
   {block name='page_title'}
@@ -23,8 +23,8 @@
       s='If this is a recurring problem, please [1]contact us[/1]'
       d='Shop.Theme.Catalog'
       sprintf=[
-        '[1]' => "<a href='{$urls.pages.contact}' class='alert-link'>",
-        '[/1]' => "</a>"
+        '[1]' => '<a href="{$urls.pages.contact}" class="alert-link">',
+        '[/1]' => '</a>'
       ]
     }
   </p>

--- a/templates/errors/not-found.tpl
+++ b/templates/errors/not-found.tpl
@@ -4,7 +4,7 @@
  *}
 <section id="content" class="page-content page-not-found">
   {block name='page_content'}
-    {block name="error_content"}
+    {block name='error_content'}
       {if isset($errorContent)}
           {$errorContent nofilter}
           <a href="{$urls.pages.index}" class="btn btn-primary back-to-index">

--- a/templates/index.tpl
+++ b/templates/index.tpl
@@ -6,12 +6,12 @@
 
 {block name='breadcrumb'}{/block}
 
-{block name="content_columns"}
-  {block name="left_column"}{/block}
+{block name='content_columns'}
+  {block name='left_column'}{/block}
 
-  {block name="content_wrapper"}
+  {block name='content_wrapper'}
     <div id="content-wrapper" class="wrapper__content">
-      {hook h="displayContentWrapperTop"}
+      {hook h='displayContentWrapperTop'}
       {block name='content'}
         <!-- TODO INSIDE -->
           {block name='page_header_container'}
@@ -43,9 +43,9 @@
           {/block}
         <!-- TODO INSIDE -->
       {/block}
-      {hook h="displayContentWrapperBottom"}
+      {hook h='displayContentWrapperBottom'}
     </div>
   {/block}
 
-  {block name="right_column"}{/block}
+  {block name='right_column'}{/block}
 {/block}

--- a/templates/layouts/layout-both-columns.tpl
+++ b/templates/layouts/layout-both-columns.tpl
@@ -29,7 +29,7 @@
     </header>
 
     <main id="wrapper" class="wrapper">
-      {hook h="displayWrapperTop"}
+      {hook h='displayWrapperTop'}
       
       {block name='breadcrumb'}
         {include file='_partials/breadcrumb.tpl'}
@@ -39,35 +39,35 @@
         {include file='_partials/notifications.tpl'}
       {/block}
 
-      {block name="content_columns"}
-        <div class="{block name="container_class"}container{/block}">
+      {block name='content_columns'}
+        <div class="{block name='container_class'}container{/block}">
           <div class="row">
-            {block name="left_column"}
+            {block name='left_column'}
               <div id="left-column" class="wrapper__left-column col-md-4 col-lg-3">
-                {if $page.page_name == 'product'}
+                {if $page.page_name === 'product'}
                   {hook h='displayLeftColumnProduct'}
                 {else}
-                  {hook h="displayLeftColumn"}
+                  {hook h='displayLeftColumn'}
                 {/if}
               </div>
             {/block}
 
-            {block name="content_wrapper"}
+            {block name='content_wrapper'}
               <section id="content-wrapper" class="wrapper__content col-md-4 col-lg-6">
-                {hook h="displayContentWrapperTop"}
-                {block name="content"}
+                {hook h='displayContentWrapperTop'}
+                {block name='content'}
                   <p>Hello world! This is HTML5 Boilerplate.</p>
                 {/block}
-                {hook h="displayContentWrapperBottom"}
+                {hook h='displayContentWrapperBottom'}
               </section>
             {/block}
 
-            {block name="right_column"}
+            {block name='right_column'}
               <div id="right-column" class="wrapper__right-column col-md-4 col-lg-3">
-                {if $page.page_name == 'product'}
+                {if $page.page_name === 'product'}
                   {hook h='displayRightColumnProduct'}
                 {else}
-                  {hook h="displayRightColumn"}
+                  {hook h='displayRightColumn'}
                 {/if}
               </div>
             {/block}
@@ -75,21 +75,21 @@
         </div>
       {/block}
 
-      {hook h="displayWrapperBottom"}
+      {hook h='displayWrapperBottom'}
     </main>
 
     <footer id="footer" class="footer">
-      {block name="footer"}
-        {include file="_partials/footer.tpl"}
+      {block name='footer'}
+        {include file='_partials/footer.tpl'}
       {/block}
     </footer>
 
     {block name='javascript_bottom'}
-      {include file="_partials/javascript.tpl" javascript=$javascript.bottom}
+      {include file='_partials/javascript.tpl' javascript=$javascript.bottom}
     {/block}
 
     {block name='bottom_elements'}
-      {include file="components/page-loader.tpl"}
+      {include file='components/page-loader.tpl'}
       {include file='components/toast-container.tpl'}
       {include file='components/password-policy-template.tpl'}
     {/block}

--- a/templates/layouts/layout-content-only.tpl
+++ b/templates/layouts/layout-content-only.tpl
@@ -6,18 +6,18 @@
 
 {block name='header'}{/block}
 
-{block name="content_columns"}
-  {block name="left_column"}{/block}
-  {block name="content_wrapper"}
+{block name='content_columns'}
+  {block name='left_column'}{/block}
+  {block name='content_wrapper'}
     <div id="content-wrapper" class="wrapper__content wrapper__content-content-only">
-      {hook h="displayContentWrapperTop"}
-      {block name="content"}
+      {hook h='displayContentWrapperTop'}
+      {block name='content'}
         <p>Hello world! This is HTML5 Boilerplate.</p>
       {/block}
-      {hook h="displayContentWrapperBottom"}
+      {hook h='displayContentWrapperBottom'}
     </div>
   {/block}
-  {block name="right_column"}{/block}
+  {block name='right_column'}{/block}
 {/block}
 
 {block name='footer'}{/block}

--- a/templates/layouts/layout-error.tpl
+++ b/templates/layouts/layout-error.tpl
@@ -17,7 +17,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {block name='stylesheets'}
-      {include file="_partials/stylesheets.tpl" stylesheets=$stylesheets}
+      {include file='_partials/stylesheets.tpl' stylesheets=$stylesheets}
     {/block}
 
   </head>

--- a/templates/layouts/layout-full-width.tpl
+++ b/templates/layouts/layout-full-width.tpl
@@ -5,17 +5,17 @@
 {extends file='layouts/layout-both-columns.tpl'}
 
 {block name='content_columns'}
-  <div class="{block name="container_class"}container{/block}">
-  {block name="left_column"}{/block}
-  {block name="content_wrapper"}
+  <div class="{block name='container_class'}container{/block}">
+  {block name='left_column'}{/block}
+  {block name='content_wrapper'}
     <div id="content-wrapper" class="wrapper__content wrapper__content-full-width">
-      {hook h="displayContentWrapperTop"}
-      {block name="content"}
+      {hook h='displayContentWrapperTop'}
+      {block name='content'}
         <p>Hello world! This is HTML5 Boilerplate.</p>
       {/block}
-      {hook h="displayContentWrapperBottom"}
+      {hook h='displayContentWrapperBottom'}
     </div>
   {/block}
-  {block name="right_column"}{/block}
+  {block name='right_column'}{/block}
   </div>
 {/block}

--- a/templates/layouts/layout-left-column.tpl
+++ b/templates/layouts/layout-left-column.tpl
@@ -12,22 +12,22 @@
           {if $page.page_name == 'product'}
             {hook h='displayLeftColumnProduct'}
           {else}
-            {hook h="displayLeftColumn"}
+            {hook h='displayLeftColumn'}
           {/if}
         </div>
       {/block}
 
       {block name="content_wrapper"}
         <div id="content-wrapper" class="wrapper__content col-md-8 col-lg-9">
-          {hook h="displayContentWrapperTop"}
+          {hook h='displayContentWrapperTop'}
           {block name="content"}
             <p>Hello world! This is HTML5 Boilerplate.</p>
           {/block}
-          {hook h="displayContentWrapperBottom"}
+          {hook h='displayContentWrapperBottom'}
         </div>
       {/block}
 
-      {block name="right_column"}{/block}
+      {block name='right_column'}{/block}
     </div>
   </div>
 {/block}

--- a/templates/layouts/layout-right-column.tpl
+++ b/templates/layouts/layout-right-column.tpl
@@ -4,27 +4,27 @@
  *}
 {extends file='layouts/layout-both-columns.tpl'}
 
-{block name="content_columns"}
-  <div class="{block name="container_class"}container{/block}">
+{block name='content_columns'}
+  <div class="{block name='container_class'}container{/block}">
     <div class="row">
       {block name='left_column'}{/block}
 
-      {block name="content_wrapper"}
+      {block name='content_wrapper'}
         <div id="content-wrapper" class="wrapper__content col-md-8 col-lg-9">
-          {hook h="displayContentWrapperTop"}
-          {block name="content"}
+          {hook h='displayContentWrapperTop'}
+          {block name='content'}
             <p>Hello world! This is HTML5 Boilerplate.</p>
           {/block}
-          {hook h="displayContentWrapperBottom"}
+          {hook h='displayContentWrapperBottom'}
         </div>
       {/block}
 
-      {block name="right_column"}
+      {block name='right_column'}
         <div id="right-column" class="wrapper__right-column col-md-4 col-lg-3">
           {if $page.page_name == 'product'}
             {hook h='displayRightColumnProduct'}
           {else}
-            {hook h="displayRightColumn"}
+            {hook h='displayRightColumn'}
           {/if}
         </div>
       {/block}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Chunk of #593. Strings in Smarty templates all (or almost all) use single quotes instead of double quotes.
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | N/A
| How to test?      | Install the theme and browse the website.
