### PR TITLE
Search: fix string for translation

### DIFF
--- a/templates/catalog/listing/search.tpl
+++ b/templates/catalog/listing/search.tpl
@@ -18,10 +18,10 @@
       {l s='Nothing to search for' d='Shop.Theme.Catalog'}
     {else}
       {if $listing.products|count}
-        {l s='Search results for' d='Shop.Theme.Catalog'}
+        {l s='Search results for "%search_term%"' sprintf=['%search_term%' => $smarty.get.s] d='Shop.Theme.Catalog'}
       {else}
-        {l s='No search results for' d='Shop.Theme.Catalog'}
-      {/if} "{$smarty.get.s}"
+        {l s='No search results for "%search_term%"' sprintf=['%search_term%' => $smarty.get.s] d='Shop.Theme.Catalog'}
+      {/if}
     {/if}
   </h1>
 {/block}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Chunk of #593. At present, the search string cannot be translated. With this PR this is now the case.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | N/A
| How to test?      | Install the theme and do a search.
