### PR TITLE
Fix logo size

### DIFF
--- a/src/scss/custom/layout/_header-bottom.scss
+++ b/src/scss/custom/layout/_header-bottom.scss
@@ -8,7 +8,14 @@ $component-name: header-bottom;
   border-bottom: var(--header-bottom-border-bottom);
 
   .navbar-brand {
+    max-width: 250px;
+    max-height: max(50px, 10vh);
     padding: 0;
+
+    .logo {
+      width: auto;
+      max-height: inherit;
+    }
   }
 
   .nav-link {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | After tests review for https://github.com/PrestaShop/hummingbird/pull/600#pullrequestreview-1898190625,<br>we need to fix the logo size when the uploaded image is taller than longer.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Not yet.
| Sponsor company   | PrestaShop SA
| How to test?      | See @florine2623 review in https://github.com/PrestaShop/hummingbird/pull/600#pullrequestreview-1898190625

-- 
### Additional info issue from the release tests

- Related to https://github.com/PrestaShop/hummingbird/issues/546
Tested with this file :
<img width="190" alt="Screenshot 2024-02-23 at 14 59 44" src="https://github.com/PrestaShop/hummingbird/assets/16019289/042a1a94-1b18-44fa-a909-3ed7443904a9">

Here's the result :x:

https://github.com/PrestaShop/hummingbird/assets/16019289/c8d1d6ad-7f02-4b0f-9c68-51f09b7b150c

