### PR TITLE
Delete product in cart when we set zero qty and submit with Enter key

### DIFF
--- a/src/js/components/useQuantityInput.ts
+++ b/src/js/components/useQuantityInput.ts
@@ -64,7 +64,19 @@ const useQuantityInput: Theme.QuantityInput.Function = (
             }
 
             if (event.key === ENTER_KEY) {
-              updateQuantity(qtyInputGroup, 1);
+              if (qtyInput.value === '0') {
+                const targetItem = qtyInput.closest(cartSelectorMap.productItem);
+                const removeButton = targetItem?.querySelector(cartSelectorMap.removeFromCartLink) as HTMLElement
+                    | null;
+
+                if (removeButton) {
+                  removeButton.click();
+                } else {
+                  updateQuantity(qtyInputGroup, 1);
+                }
+              } else {
+                updateQuantity(qtyInputGroup, 1);
+              }
             }
 
             if (event.key === ESCAPE_KEY) {

--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -38,6 +38,8 @@ export const cart = {
   promoCode: '#promo-code',
   deleteLinkAction: 'delete-from-cart',
   productQuantity: '.cart__items .js-quantity-button',
+  productItem: '.cart__item',
+  removeFromCartLink: '.remove-from-cart',
 };
 
 export const blockcart = {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | After tests review for https://github.com/PrestaShop/hummingbird/pull/600#pullrequestreview-1898190625,<br>we need to delete the product in cart when we set zero and type Enter to submit.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Not yet.
| Sponsor company   | PrestaShop SA
| How to test?      | See @florine2623 review in https://github.com/PrestaShop/hummingbird/pull/600#pullrequestreview-1898190625

--
### Additional info issue from the release tests

- Related to https://github.com/PrestaShop/hummingbird/pull/541
In Shopping cart page, when you put 0 on the quantity and press Enter, the product won't be removed :x:
The product is removed only when you click on the Checkmark.

https://github.com/PrestaShop/hummingbird/assets/16019289/19d3732f-d39b-421c-a267-727ad491b159
