### PR TITLE
Fix: incorrect address call

### DIFF
--- a/templates/checkout/_partials/order-final-summary.tpl
+++ b/templates/checkout/_partials/order-final-summary.tpl
@@ -51,7 +51,7 @@
             <div class="address__content col-10">
               <p class="address__alias h6 card-title">{l s='Your Invoice Address' d='Shop.Theme.Checkout'}</p>
 
-              <address class="address__content">{$customer.addresses[$cart.id_address_delivery]['formatted'] nofilter}</address>
+              <address class="address__content">{$customer.addresses[$cart.id_address_invoice]['formatted'] nofilter}</address>
 
               <div class="address__actions">
                 <a


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Update invoice address call in order final summary
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |
| Fixed ticket?     | 
| Sponsor company   | @PrestaShopCorp
| How to test?      |  ⬇️
- In the BO, activate **Enable final summary** located in Shop Parameters -> Order Settings.
- In FO, create an account.
- Create 2 different addresses in your account.
- Add a product to the cart and proceed to the checkout process.
- On the "Addresses" step, ensure you have a **Shipping address** and a different one for the **Invoice address**.
- Continue to the payment step.
- You should see 2 different addresses in the summary (before the fix, the delivery address was used for both address blocks).


