### PR TITLE
Fix: issue-567

### DIFF
--- a/src/scss/custom/pages/product/_product.scss
+++ b/src/scss/custom/pages/product/_product.scss
@@ -35,6 +35,7 @@
         width: 2.5rem;
         min-width: 2.5rem;
         height: 2.5rem;
+        cursor: pointer;
         background-color: #fff;
         border: none;
         border-radius: 50%;
@@ -137,6 +138,15 @@
 
     &.active img {
       border: 2px solid $primary;
+    }
+  }
+}
+
+// Hide product image zoom on quickview modal
+body.modal-open {
+  .quickview {
+    .product__images__modal-opener {
+      display: none;
     }
   }
 }

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -173,3 +173,7 @@
     </picture>
   {/if}
 </div>
+
+{block name='product_images_modal'}
+  {include file='catalog/_partials/product-images-modal.tpl'}
+{/block}

--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -188,10 +188,6 @@
     {hook h='displayFooterProduct' product=$product category=$category}
   {/block}
 
-  {block name='product_images_modal'}
-    {include file='catalog/_partials/product-images-modal.tpl'}
-  {/block}
-
   {block name='page_footer_container'}
     {block name='page_footer'}
     {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix https://github.com/PrestaShop/hummingbird/issues/567
| Type?             | bug fix / improvement
| BC breaks?        | no
| Deprecations?     |
| Fixed ticket?     | Fix https://github.com/PrestaShop/hummingbird/issues/567
| Sponsor company   | @PrestaShopCorp
| How to test?      | You can follow the steps described in the issue

- I have hidden the zoom icon on the quick view as this functionality was not present in the classic theme. Due to the conception of Hummingbird, it seems complicated to implement it.
- On the product page, an improvement has been made to the zoom functionality because the section that handles the images was not being updated on combination change.

**Before :**

https://github.com/PrestaShop/hummingbird/assets/110676325/f6b9199f-a382-4bfa-a563-904b69719766

**After :**

https://github.com/PrestaShop/hummingbird/assets/110676325/889e4e5a-b44d-4a97-8f9d-e5c70195b448