### PR TITLE
Fix: issue-582

### DIFF
--- a/templates/customer/_partials/account-transformation-form.tpl
+++ b/templates/customer/_partials/account-transformation-form.tpl
@@ -14,7 +14,7 @@
       <label class="form-label" for="field-email">
         {l s='Set your password:' d='Shop.Forms.Labels'}
       </label>
-      <input type="password" class="form-control" data-validate="isPasswd" required name="password" value="">
+      <input type="password" class="form-control" data-validate="isPasswd" required name="password" value="" autocomplete="new-password">
     </div>
     <input type="hidden" name="submitTransformGuestToCustomer" value="1">
     <button class="btn btn-primary" type="submit">{l s='Create account' d='Shop.Theme.Actions'}</button>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Just add an attribute "autocomplete" in addition to what has been done here : https://github.com/PrestaShop/hummingbird/pull/591
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | 
| Fixed ticket?     | https://github.com/PrestaShop/hummingbird/issues/582
| Sponsor company   | @PrestaShopCorp
| How to test?      | ⬇️

Check if the attribute autocomplete="new-password" is present on password fields.
The field is located on the order confirmation page when making an order in guest mode.
![image](https://github.com/PrestaShop/hummingbird/assets/110676325/3bc0b0e1-b22c-4f22-b793-10db43ea5f37)
