### PR TITLE
Fix: issue-522

### DIFF
--- a/src/js/components/UseHandleCartAction.ts
+++ b/src/js/components/UseHandleCartAction.ts
@@ -3,6 +3,9 @@
  * file that was distributed with this source code.
  */
 
+import SelectorsMap from '@constants/selectors-map';
+import useAlert from './useAlert';
+
 const handleCartAction = (event: Event): void => {
   event.stopPropagation();
   event.preventDefault();
@@ -33,11 +36,33 @@ const sendCartRefreshRequest = (target: HTMLElement): void => {
     body: formData,
   })
     .then((resp: Response) => {
-    // Refresh cart preview
+      // Refresh cart preview
       prestashop.emit(events.updateCart, {
         reason: dataset,
         resp,
       });
+
+      // Show product removal success alert
+      if (target && target.getAttribute('data-link-action') === SelectorsMap.cart.deleteLinkAction) {
+        const alertPlaceholder = document.querySelector(SelectorsMap.cart.alertPlaceholder);
+        const productUrl = target.getAttribute('data-product-url');
+        const productName = target.getAttribute('data-product-name');
+
+        if (alertPlaceholder && productUrl && productName) {
+          const alertText = alertPlaceholder.getAttribute('data-alert');
+          const productLink = `<a class="alert-link" href="${productUrl}">${productName}</a>`;
+          const alertMessage = `${productLink} ${alertText}`;
+
+          if (alertMessage) {
+            const alert = useAlert(alertMessage, {
+              type: 'success',
+              selector: SelectorsMap.cart.alertPlaceholder,
+            });
+
+            alert.show();
+          }
+        }
+      }
     })
     .catch((err) => {
       const errorData = err as Response;

--- a/src/js/components/UseHandleCartAction.ts
+++ b/src/js/components/UseHandleCartAction.ts
@@ -50,17 +50,27 @@ const sendCartRefreshRequest = (target: HTMLElement): void => {
 
         if (alertPlaceholder && productUrl && productName) {
           const alertText = alertPlaceholder.getAttribute('data-alert');
-          const productLink = `<a class="alert-link" href="${productUrl}">${productName}</a>`;
-          const alertMessage = `${productLink} ${alertText}`;
 
-          if (alertMessage) {
-            const alert = useAlert(alertMessage, {
-              type: 'success',
-              selector: SelectorsMap.cart.alertPlaceholder,
-            });
+          // Create the product link element
+          const productLink = document.createElement('a');
+          productLink.classList.add('alert-link');
+          productLink.setAttribute('href', productUrl);
+          productLink.textContent = productName;
 
-            alert.show();
-          }
+          // Create the alert message container
+          const alertMessage = document.createElement('span');
+          alertMessage.appendChild(productLink);
+          alertMessage.append(` ${alertText}`);
+
+          const alertMessageContainer = document.createElement('div');
+          alertMessageContainer.appendChild(alertMessage);
+
+          const alert = useAlert(alertMessageContainer.innerHTML, {
+            type: 'success',
+            selector: SelectorsMap.cart.alertPlaceholder,
+          });
+
+          alert.show();
         }
       }
     })

--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -40,6 +40,7 @@ export const cart = {
   productQuantity: '.cart__items .js-quantity-button',
   productItem: '.cart__item',
   removeFromCartLink: '.remove-from-cart',
+  alertPlaceholder: '.js-cart-update-alert',
 };
 
 export const blockcart = {

--- a/src/scss/core/components/_alert.scss
+++ b/src/scss/core/components/_alert.scss
@@ -1,8 +1,4 @@
 .alert {
-  &.fade:not(.show) {
-    @extend .visually-hidden;
-  }
-
   p,
   ul,
   ol {

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -175,7 +175,10 @@
       <a class="remove-from-cart" rel="nofollow" href="{$product.remove_from_cart_url}"
         data-link-action="delete-from-cart" data-id-product="{$product.id_product|escape:'javascript'}"
         data-id-product-attribute="{$product.id_product_attribute|escape:'javascript'}"
-        data-id-customization="{$product.id_customization|escape:'javascript'}">
+        data-id-customization="{$product.id_customization|escape:'javascript'}"
+        data-product-url="{$product.url|escape:'javascript'}"
+        data-product-name="{$product.name|escape:'javascript'}"
+        >
         {l s='Remove' d='Shop.Theme.Checkout'}
       </a>
     {/if}

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -177,7 +177,7 @@
         data-id-product-attribute="{$product.id_product_attribute|escape:'javascript'}"
         data-id-customization="{$product.id_customization|escape:'javascript'}"
         data-product-url="{$product.url|escape:'javascript'}"
-        data-product-name="{$product.name|escape:'javascript'}"
+        data-product-name="{$product.name|escape:'htmlall':'UTF-8'}"
         >
         {l s='Remove' d='Shop.Theme.Checkout'}
       </a>

--- a/templates/checkout/cart.tpl
+++ b/templates/checkout/cart.tpl
@@ -12,6 +12,8 @@
 
       <!-- cart products detailed -->
       <div class="cart-container mb-3">
+        <div class="js-cart-update-alert" data-alert="{l s='has been removed from the cart.' d='Shop.Theme.Actions' js=1}"></div>
+        
         {block name='cart_overview'}
           {include file='checkout/_partials/cart-detailed.tpl' cart=$cart}
         {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix https://github.com/PrestaShop/hummingbird/issues/522
| Type?             | bug fix / improvement
| BC breaks?        | no
| Deprecations?     | 
| Fixed ticket?     | Fix https://github.com/PrestaShop/hummingbird/issues/522
| Sponsor company   | @PrestaShopCorp
| How to test?      | ⬇️

This PR introduces a new feature where a closable alert appears when a product is removed from the cart. This alert contains a link to the deleted product, allowing users to navigate back to the product page in case the deletion was unintended.

## Steps to Reproduce

1. Add several products to the cart.
2. Go to the cart page.
3. Click on the remove button for a product.
4. **New:** A closable alert appears with a link to the deleted product, allowing users to go back to the product page in case of an accidental deletion.

**Video:**

https://github.com/PrestaShop/hummingbird/assets/110676325/42a3e0ec-64bb-4e43-96ce-02c6cf6d3adf

