### PR TITLE
Feat: handle scroll offset on anchor links

### DIFF
--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -3,6 +3,10 @@
  * file that was distributed with this source code.
  */
 
+export const layout = {
+  stickyHeader: '.js-sticky-header',
+};
+
 export const facetedsearch = {
   range: '.js-faceted-slider',
   rangeContainer: '.js-faceted-slider-container',
@@ -145,6 +149,7 @@ export const passwordPolicy = {
 };
 
 const selectorsMap = {
+  layout,
   qtyInput,
   alert: {
     selector: '#notifications .container',

--- a/src/js/helpers/scrollPadding.ts
+++ b/src/js/helpers/scrollPadding.ts
@@ -1,0 +1,22 @@
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import SelectorsMap from '@constants/selectors-map';
+
+const setScrollPaddingTop = () => {
+  const header = document.querySelector(SelectorsMap.layout.stickyHeader) as HTMLElement;
+
+  if (header) {
+    const headerHeight = header.offsetHeight;
+    document.documentElement.style.setProperty('scroll-padding-top', `${headerHeight}px`);
+  }
+};
+
+const initScrollPaddingTop = () => {
+  window.addEventListener('load', setScrollPaddingTop);
+  window.addEventListener('resize', setScrollPaddingTop);
+};
+
+export default initScrollPaddingTop;

--- a/src/js/theme.ts
+++ b/src/js/theme.ts
@@ -28,6 +28,7 @@ import './modules/facetedsearch';
 import initDesktopMenu from './modules/ps_mainmenu';
 import initFormValidation from './form-validation';
 import initCategoryTree from './modules/ps_categorytree';
+import initScrollPaddingTop from './helpers/scrollPadding';
 
 initEmitter();
 
@@ -52,6 +53,7 @@ $(() => {
   initErrorHandler();
   usePasswordPolicy('.field-password-policy');
   initCategoryTree();
+  initScrollPaddingTop();
 
   prestashop.on(events.responsiveUpdate, () => {
     initSearchbar();

--- a/templates/layouts/layout-both-columns.tpl
+++ b/templates/layouts/layout-both-columns.tpl
@@ -21,7 +21,7 @@
       {include file='catalog/_partials/product-activation.tpl'}
     {/block}
 
-    <header id="header" class="header">
+    <header id="header" class="header js-sticky-header">
       {block name='header'}
         {include file='_partials/header.tpl'}
       {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add functionality to handle the offset of a sticky header when clicking on anchor links and prevent item overlapping.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     |
| Fixed ticket?     |
| Sponsor company   | @PrestaShopCorp
| How to test?      | This feature is related to an issue find in this PR https://github.com/PrestaShop/hummingbird/pull/640#pullrequestreview-2118549210 (**BUG 1**)

**Before:**

https://github.com/PrestaShop/hummingbird/assets/110676325/fdc98f88-f300-4db6-b203-3e13a72ed6b6

**After:**

https://github.com/PrestaShop/hummingbird/assets/110676325/a6eef3a3-3855-43bf-b142-08456ff6004f
