### PR TITLE
Product page : can't change the quantity via input, the quantity 1 is always displayed

### DIFF
--- a/src/js/product.ts
+++ b/src/js/product.ts
@@ -53,9 +53,7 @@ export default () => {
       };
 
       // Attach event listener for input changes
-      quantityInput.addEventListener('input', triggerEmit);
-      quantityInput.addEventListener('keyup', triggerEmit);
-      quantityInput.addEventListener('keydown', triggerEmit);
+      quantityInput.addEventListener('change', triggerEmit);
 
       // Attach event listener for increment / decrement button click
       incrementButton.addEventListener('click', triggerEmit);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The way of listening quantity input in product page is a problem.<br>In fact, we need to check quantity min not when we are typing but only on change. If we do this check on keyup or keydown, we can't type a `backspace` to empty the input before typing our new value, and also, if the min quantity of the product is set at 5, if we want to type `10` after a `backspace`, we force to `5` when the `1` key is typed and before the `0` of `10`. 
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#36456](https://github.com/PrestaShop/PrestaShop/issues/36456)
| Sponsor company   | PrestaShop SA
| How to test?      | See [#36456](https://github.com/PrestaShop/PrestaShop/issues/36456)
