### PR TITLE
Use new way to access category images

### DIFF
--- a/templates/catalog/_partials/category-header.tpl
+++ b/templates/catalog/_partials/category-header.tpl
@@ -9,14 +9,14 @@
             {if $category.description}
               <div id="category-description" class="rich-text mb-4">{$category.description nofilter}</div>
             {/if}
-            {if !empty($category.image.large.url)}
+            {if !empty($category.cover.large.url)}
               <div class="category-cover mb-4">
-                <img src="{$category.image.large.url}" 
-                  alt="{if !empty($category.image.legend)}{$category.image.legend}{else}{$category.name}{/if}" 
+                <img src="{$category.cover.large.url}" 
+                  alt="{if !empty($category.cover.legend)}{$category.cover.legend}{else}{$category.name}{/if}" 
                   fetchpriority="high" 
                   class="img-fluid"
-                  width="{$category.image.large.width}" 
-                  height="{$category.image.large.height}">
+                  width="{$category.cover.large.width}" 
+                  height="{$category.cover.large.height}">
               </div>
             {/if}
         </div>

--- a/templates/catalog/_partials/subcategories.tpl
+++ b/templates/catalog/_partials/subcategories.tpl
@@ -11,12 +11,21 @@
         <div class="subcategory__wrapper col-6 col-lg-4 col-xl-3">
           <a class="subcategory" href="{$subcategory.url}" title="{$subcategory.name|escape:'html':'UTF-8'}">
             <div class="subcategory__image">
-              {if !empty($subcategory.image.small.url)}
+              {if !empty($subcategory.thumbnail.small.url)}
                 <img
                   class="img-fluid"
-                  src="{$subcategory.image.small.url}"
-                  width="{$subcategory.image.small.width}"
-                  height="{$subcategory.image.small.height}"
+                  src="{$subcategory.thumbnail.small.url}"
+                  width="{$subcategory.thumbnail.small.width}"
+                  height="{$subcategory.thumbnail.small.height}"
+                  alt="{$subcategory.name|escape:'html':'UTF-8'}"
+                  loading="lazy"
+                >
+              {else}
+                <img
+                  class="img-fluid"
+                  src="{$urls.no_picture_image.small.url}"
+                  width="{$urls.no_picture_image.small.width}"
+                  height="{$urls.no_picture_image.small.height}"
                   alt="{$subcategory.name|escape:'html':'UTF-8'}"
                   loading="lazy"
                 >


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Changes template to use a new way of accessing category images, prepared in https://github.com/PrestaShop/PrestaShop/pull/32653. After this is merged, we can merge the final part https://github.com/PrestaShop/PrestaShop/pull/36877, tests should work.
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   | 
| How to test?      | There should be no visible effect in functionality.

### How to test
- Basically, everything should work the same.
- Check category cover image:
  - Visit a category with a cover image, there should be an image next to category description.
  - Visit a category with NO cover image, there should be NO image next to category description. There should be NO placeholder `Image not found image`.
- Check category thumbnail:
  - Assign thumbnail to `Men` category.
  - Assign NO images to `Women` category.
  - Visit `Clothes`. In the subcategories, `Men` should have an image, `Women` should have placeholder `Image not found image`.