### PR TITLE
[bug fix] cannot run webpack command

### DIFF
--- a/webpack/webpack.parts.js
+++ b/webpack/webpack.parts.js
@@ -34,13 +34,14 @@ exports.configureDevServer = (serverAddress, publicPath, port, siteURL) => ({
     '../../modules/**/*.css',
   ],
   port,
-  proxy: {
-    '**': {
+  proxy: [
+    {
+      context: ['**'],
       target: siteURL,
       secure: false,
       changeOrigin: true,
     },
-  },
+  ],
   static: {
     publicPath,
   },


### PR DESCRIPTION
When taking the `develop` branch I'm not able to do `npm run dev` after `npm install`. Because it says:

```shell
> prestashop-hummingbird-dev-tools@0.1.7 dev
> webpack serve --progress --mode=development

[webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
 - options.proxy should be an array:
   [object { … } | function, ...]
   -> Allows to proxy requests, can be useful when you have a separate API backend development server and you want to send API requests on the same domain.
   -> Read more at https://webpack.js.org/configuration/dev-server/#devserverproxy
```

With my modification it works.