### PR TITLE
In productlist: if price is not shown don't show add to cart either

### DIFF
--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -176,7 +176,7 @@
               {/block}
             </div>
 
-            {if $product.add_to_cart_url}
+            {if $product.show_price && $product.add_to_cart_url}
               <form action="{$urls.pages.cart}" method="post" class="d-flex flex-wrap flex-md-nowrap gap-3 align-items-center mt-3">
                 <input type="hidden" value="{$product.id_product}" name="id_product">
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If customer group has "show prices: no" the product listing still shows the add to cart button. This adds the price check to the check if "add to cart" should be shown in the product listing
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #661 
| Sponsor company   | 
| How to test?      | Change "guest" and "visitor" to "show prices: no". Check shop product listings that prices are not shown anymore and no "add to cart" button is shown. Login with a customer that belongs to a group that sees prices and check that the add to cart button is shown.
