### PR TITLE
Update qty-input.tpl

### DIFF
--- a/templates/components/qty-input.tpl
+++ b/templates/components/qty-input.tpl
@@ -25,21 +25,19 @@
     <div class="spinner-border spinner-border-sm align-middle d-none" role="status"></div>
   </button>
 
-  <input
+<input
     {foreach $attributes as $key=>$value}
-      {$key}="{$value}"
+        {$key}="{$value}"
     {/foreach}
-    {* The default attributes, will be used if not defined *}
-      class="form-control"
-      name="qty"
-      aria-label="{l s='Quantity' d='Shop.Theme.Actions'}"
-      type="text"
-      inputmode="numeric"
-      pattern="[0-9]*"
-      value="1"
-      min="1"
-    {* End of default attributes *}
-  />
+    {if !isset($attributes.class)}class="form-control"{/if}
+    {if !isset($attributes.name)}name="qty"{/if}
+    {if !isset($attributes['aria-label'])}aria-label="{l s='Quantity' d='Shop.Theme.Actions'}"{/if}
+    {if !isset($attributes.type)}type="text"{/if}
+    {if !isset($attributes.inputmode)}inputmode="numeric"{/if}
+    {if !isset($attributes.pattern)}pattern="[0-9]*"{/if}
+    {if !isset($attributes.value)}value="1"{/if}
+    {if !isset($attributes.min)}min="1"{/if}
+/>
 
   <button role="button" aria-label="{$append.button}" class="btn {$append.button} js-{$append.button}-button" type="button">
     <i class="material-icons" aria-hidden="true">&#x{$append.icon};</i>


### PR DESCRIPTION
fix: Ensure provided input attributes take precedence over defaults

This commit modifies the Smarty template to prevent default input attributes (e.g., class, name, value) from duplicating attributes that are already defined in the $attributes array.

Previously, default attributes were appended after the loop that applied provided attributes, resulting in double values which is break HTML standart.

Now, conditional checks are used to only apply default attributes when the corresponding attribute is not already set in the $attributes array.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing this change. What did you change? Why?
| Type?             | bug fix / improvement / new feature / refactor
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes #{issue URL here}, Fixes #{another issue URL here}
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | Indicate how to verify that this change works as expected.
