### PR TITLE
fix missing brand miniature image

### DIFF
--- a/templates/catalog/_partials/miniatures/brand.tpl
+++ b/templates/catalog/_partials/miniatures/brand.tpl
@@ -6,7 +6,7 @@
   <li class="brand card col-6 col-md-4 col-lg-3">
     <div class="brand__img">
       <a href="{$brand.url}">
-        <img src="{$brand.image}" alt="{$brand.name}" loading="lazy">
+        <img src="{$brand.image.bySize.small_default.url}" alt="{$brand.name}" loading="lazy">
       </a>
     </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Brand image not showing in its miniature template because the wrong variable was called
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #740
| Sponsor company   | Agence Off
| How to test?      | Navigate to the native brand listing and see if images are here
