### PR TITLE
Fix: Bug: Redirect to [object History] when using Back button after category filters

### DIFF
--- a/src/js/modules/facetedsearch/update.ts
+++ b/src/js/modules/facetedsearch/update.ts
@@ -95,7 +95,7 @@ export default () => {
   if ($(Theme.selectors.listing.list).length) {
     window.addEventListener('popstate', (e) => {
       const {state} = e;
-      window.location.href = state && state.current_url ? state.current_url : history;
+      window.location.href = state?.current_url ?? window.location.href;
     });
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When applying a filter on the category page and then using the browser back button, the user was redirected to an invalid URL ending with "[object History]". This happened because the popstate event handler assigned `window.location.href = history` when no state.current_url was available, causing the History object to be coerced into a string ("[object History]").
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #751
|Related PRs | https://github.com/PrestaShop/hummingbird/pull/586
| Sponsor company   | @Codencode 
| How to test?      | 1. Go to a category page in the front-office. - 2. Apply a filter (e.g. Availability = Yes) - 3. Click the browser Back button.