### PR TITLE
Fix: in the product page, with each selection of a combination creates a new div under this one class="product__images js-images-container

### DIFF
--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -172,8 +172,8 @@
       >
     </picture>
   {/if}
-</div>
 
-{block name='product_images_modal'}
-  {include file='catalog/_partials/product-images-modal.tpl'}
-{/block}
+  {block name='product_images_modal'}
+    {include file='catalog/_partials/product-images-modal.tpl'}
+  {/block}
+</div>


### PR DESCRIPTION
… to prevent duplicate modal after AJAX replace

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing this change. What did you change? Why?
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #749
| Sponsor company   | @Codencode 
| How to test?      | 1. Go to a product page - 2. Select a combination (to trigger AJAX replace of product images) - 3. Check the DOM: there must be only one element with the class `.js-product-images-modal`