### PR TITLE
Allow footer blocks to be closed with keyboard on small devices

### DIFF
--- a/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -16,7 +16,7 @@
       type="button"
       data-bs-toggle="collapse"
       data-bs-target="#footer_contactinfo"
-      aria-expanded="true"
+      aria-expanded="false"
       aria-controls="footer_contactinfo"
     >
       <span class="visually-hidden">

--- a/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -22,7 +22,7 @@
       <span class="visually-hidden">
         {l s='Toggle store information' d='Shop.Theme.Global'}
       </span>
-      <i class="material-icons" role="presentation" aria-hidden="true">&#xE313;</i>
+      <i class="material-icons" aria-hidden="true">&#xE313;</i>
     </button>
   </p>
 

--- a/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -2,24 +2,37 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
-<div class="ps-contactinfo footer-block col-md-6 col-lg-3">
-  <p class="footer-block__title footer-block__title--toggle">
+<section
+  class="ps-contactinfo footer-block col-md-6 col-lg-3"
+  aria-labelledby="footer_contactinfo_title"
+>
+  <p
+    id="footer_contactinfo_title"
+    class="footer-block__title footer-block__title--toggle"
+  >
     {l s='Store information' d='Shop.Theme.Global'}
-    <span
+    <button
       class="stretched-link collapsed d-md-none"
-      aria-expanded="true"
-      data-bs-target="#footer_contactinfo"
+      type="button"
       data-bs-toggle="collapse"
-      role="button"
+      data-bs-target="#footer_contactinfo"
+      aria-expanded="true"
+      aria-controls="footer_contactinfo"
     >
-      <i class="material-icons" aria-hidden="true">&#xE313;</i>
-    </span>
+      <span class="visually-hidden">
+        {l s='Toggle Store information' d='Shop.Theme.Global'}
+      </span>
+      <i class="material-icons" role="presentation" aria-hidden="true">&#xE313;</i>
+    </button>
   </p>
 
   <div class="footer-block__content collapse" id="footer_contactinfo">
-    <address class="ps-contactinfo__infos">
-      {$contact_infos.address.formatted nofilter}
-    </address>
+
+    {if $contact_infos.address.formatted}
+      <address class="ps-contactinfo__infos">
+        {$contact_infos.address.formatted nofilter}
+      </address>
+    {/if}
 
     {if $contact_infos.phone}
       <div class="ps-contactinfo__phone">
@@ -50,5 +63,6 @@
         </a>
       </div>
     {/if}
+
   </div>
-</div>
+</section>

--- a/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -20,7 +20,7 @@
       aria-controls="footer_contactinfo"
     >
       <span class="visually-hidden">
-        {l s='Toggle Store information' d='Shop.Theme.Global'}
+        {l s='Toggle store information' d='Shop.Theme.Global'}
       </span>
       <i class="material-icons" role="presentation" aria-hidden="true">&#xE313;</i>
     </button>

--- a/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
+++ b/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
@@ -22,7 +22,7 @@
       data-bs-toggle="collapse"
     >
       <span class="visually-hidden">
-        {l s='Toggle Your account links' d='Shop.Theme.Customeraccount'}
+        {l s='Toggle your account links' d='Shop.Theme.Customeraccount'}
       </span>
       <i class="material-icons" role="presentation" aria-hidden="true">&#xE313;</i>
     </button>

--- a/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
+++ b/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
@@ -24,7 +24,7 @@
       <span class="visually-hidden">
         {l s='Toggle your account links' d='Shop.Theme.Customeraccount'}
       </span>
-      <i class="material-icons" role="presentation" aria-hidden="true">&#xE313;</i>
+      <i class="material-icons" aria-hidden="true">&#xE313;</i>
     </button>
   </p>
 

--- a/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
+++ b/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
@@ -16,7 +16,7 @@
     <button
       class="stretched-link collapsed d-md-none"
       type="button"
-      aria-expanded="true"
+      aria-expanded="false"
       aria-controls="footer_customeraccountlinks"
       data-bs-target="#footer_customeraccountlinks"
       data-bs-toggle="collapse"

--- a/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
+++ b/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
@@ -2,15 +2,30 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *}
-<div class="ps-customeraccountlinks footer-block col-md-6 col-lg-3">
-  <p class="footer-block__title footer-block__title--toggle">
+<nav
+  class="ps-customeraccountlinks footer-block col-md-6 col-lg-3"
+  role="navigation"
+  aria-labelledby="footer_customeraccount_title">
+  <p
+    id="footer_customeraccount_title"
+    class="footer-block__title footer-block__title--toggle"
+  >
     <a href="{$urls.pages.my_account}" rel="nofollow">
       {l s='Your account' d='Shop.Theme.Customeraccount'}
     </a>
-    <span class="stretched-link collapsed d-md-none" role="button" aria-expanded="true"
-      data-bs-target="#footer_customeraccountlinks" data-bs-toggle="collapse">
-      <i class="material-icons" aria-hidden="true">&#xE313;</i>
-    </span>
+    <button
+      class="stretched-link collapsed d-md-none"
+      type="button"
+      aria-expanded="true"
+      aria-controls="footer_customeraccountlinks"
+      data-bs-target="#footer_customeraccountlinks"
+      data-bs-toggle="collapse"
+    >
+      <span class="visually-hidden">
+        {l s='Toggle Your account links' d='Shop.Theme.Customeraccount'}
+      </span>
+      <i class="material-icons" role="presentation" aria-hidden="true">&#xE313;</i>
+    </button>
   </p>
 
   <div class="footer-block__content collapse" id="footer_customeraccountlinks">
@@ -97,4 +112,4 @@
       {/if}
     </ul>
   </div>
-</div>
+</nav>

--- a/modules/ps_linklist/views/templates/hook/linkblock.tpl
+++ b/modules/ps_linklist/views/templates/hook/linkblock.tpl
@@ -17,7 +17,7 @@
         <button
           class="stretched-link collapsed d-md-none"
           type="button"
-          aria-expanded="true"
+          aria-expanded="false"
           aria-controls="footer_linklist_{$linkBlock.id}"
           data-bs-target="#footer_linklist_{$linkBlock.id}"
           data-bs-toggle="collapse"

--- a/modules/ps_linklist/views/templates/hook/linkblock.tpl
+++ b/modules/ps_linklist/views/templates/hook/linkblock.tpl
@@ -23,7 +23,7 @@
           data-bs-toggle="collapse"
         >
           <span class="visually-hidden">
-            {l s='Toggle %s links' sprintf=[$linkBlock.title] d='Shop.Theme.Global'}
+            {l s='Toggle %s links' sprintf=[$linkBlock.title|lower] d='Shop.Theme.Global'}
           </span>
           <i class="material-icons" role="presentation" aria-hidden="true">&#xE313;</i>
         </button>

--- a/modules/ps_linklist/views/templates/hook/linkblock.tpl
+++ b/modules/ps_linklist/views/templates/hook/linkblock.tpl
@@ -4,26 +4,53 @@
  *}
 {if !empty($linkBlocks)}
   {foreach $linkBlocks as $linkBlock}
-    <div class="ps-linklist footer-block col-md-6 col-lg-3">
-      <p class="footer-block__title footer-block__title--toggle">
+    <nav
+      class="ps-linklist footer-block col-md-6 col-lg-3"
+      role="navigation"
+      aria-labelledby="footer_title_{$linkBlock.id}"
+    >
+      <p
+        id="footer_title_{$linkBlock.id}"
+        class="footer-block__title footer-block__title--toggle"
+      >
         {$linkBlock.title}
-        <span class="stretched-link collapsed d-md-none" role="button" aria-expanded="true"
-          data-bs-target="#footer_linklist_{$linkBlock.id}" data-bs-toggle="collapse">
-          <i class="material-icons" aria-hidden="true">&#xE313;</i>
-        </span>
+        <button
+          class="stretched-link collapsed d-md-none"
+          type="button"
+          aria-expanded="true"
+          aria-controls="footer_linklist_{$linkBlock.id}"
+          data-bs-target="#footer_linklist_{$linkBlock.id}"
+          data-bs-toggle="collapse"
+        >
+          <span class="visually-hidden">
+            {l s='Toggle %s links' sprintf=[$linkBlock.title] d='Shop.Theme.Global'}
+          </span>
+          <i class="material-icons" role="presentation" aria-hidden="true">&#xE313;</i>
+        </button>
       </p>
-  
+
       <div class="footer-block__content collapse" id="footer_linklist_{$linkBlock.id}">
         <ul class="footer-block__list">
           {foreach $linkBlock.links as $link}
             <li>
-              <a id="{$link.id}-{$linkBlock.id}" class="{$link.class}" href="{$link.url}" title="{$link.description}" {if !empty($link.target)} target="{$link.target}" {/if}>
+              <a
+                id="{$link.id}-{$linkBlock.id}"
+                class="{$link.class}"
+                href="{$link.url}"
+                {if !empty($link.target)} target="{$link.target}" {/if}
+                {if !empty($link.description)} aria-describedby="desc-{$link.id}-{$linkBlock.id}" {/if}
+              >
                 {$link.title}
               </a>
+              {if !empty($link.description)}
+                <span id="desc-{$link.id}-{$linkBlock.id}" class="visually-hidden">
+                  {$link.description}
+                </span>
+              {/if}
             </li>
           {/foreach}
         </ul>
       </div>
-    </div>
-  {/foreach}  
+    </nav>
+  {/foreach}
 {/if}

--- a/modules/ps_linklist/views/templates/hook/linkblock.tpl
+++ b/modules/ps_linklist/views/templates/hook/linkblock.tpl
@@ -25,7 +25,7 @@
           <span class="visually-hidden">
             {l s='Toggle %s links' sprintf=[$linkBlock.title|lower] d='Shop.Theme.Global'}
           </span>
-          <i class="material-icons" role="presentation" aria-hidden="true">&#xE313;</i>
+          <i class="material-icons" aria-hidden="true">&#xE313;</i>
         </button>
       </p>
 

--- a/src/scss/prestashop/layout/_footer.scss
+++ b/src/scss/prestashop/layout/_footer.scss
@@ -3,6 +3,8 @@ $sub-component-name: "footer-block";
 
 // Footer main
 .#{$component-name} {
+  padding-left: 0.25rem;
+
   &__main {
     padding-block: 1.5rem;
     color: var(--bs-gray-300);
@@ -37,6 +39,11 @@ $sub-component-name: "footer-block";
       justify-content: space-between;
 
       .stretched-link {
+        padding: 0;
+        color: inherit;
+        background-color: inherit;
+        border: none;
+
         &:not(.collapsed) {
           i {
             transform: rotate(0.5turn);

--- a/src/scss/prestashop/layout/_footer.scss
+++ b/src/scss/prestashop/layout/_footer.scss
@@ -3,7 +3,6 @@ $sub-component-name: "footer-block";
 
 // Footer main
 .#{$component-name} {
-  padding-left: 0.25rem;
 
   &__main {
     padding-block: 1.5rem;

--- a/src/scss/prestashop/layout/_footer.scss
+++ b/src/scss/prestashop/layout/_footer.scss
@@ -3,7 +3,6 @@ $sub-component-name: "footer-block";
 
 // Footer main
 .#{$component-name} {
-
   &__main {
     padding-block: 1.5rem;
     color: var(--bs-gray-300);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | improve tag semantic, keyboard handling, add aria tags, refacto style to prevent button default agent style
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     |no
| Fixed jira ticket?     | SCE-824
| Sponsor company   | @PrestaShopCorp
| How to test?      |
