### PR TITLE
fix: show green success alert for available products instead of yello…

### DIFF
--- a/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/templates/catalog/_partials/product-add-to-cart.tpl
@@ -10,12 +10,9 @@
           {if $product.show_availability && $product.availability_message}
 
             {** First, we prepare the icons and colors we want to use *}
-            {if $product.availability == 'in_stock'}
+            {if $product.availability == 'available'}
               {assign 'availability_icon' 'E5CA'}
               {assign 'availability_color' 'success'}
-            {elseif $product.availability == 'available'}
-              {assign 'availability_icon' 'E002'}
-              {assign 'availability_color' 'warning'}
             {elseif $product.availability == 'last_remaining_items'}
               {assign 'availability_icon' 'E002'}
               {assign 'availability_color' 'warning'}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixed availability alert color for in-stock products. Previously, products with 'available' status displayed a yellow warning alert. Now they correctly display a green success alert. The template was checking for a non-existent 'in_stock' value, causing 'available' products to fall through to the warning condition.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | Axel Paillaud
| How to test?      | 1. Go to Back Office → Catalog → Products<br>2. Edit a product that is in stock<br>3. In the "Options/Combinations" tab, set a custom availability label (e.g., "In Stock")<br>4. Check "Display availability label"<br>5. Save and view the product on front office<br>**Before fix:** Yellow warning alert appears<br>**After fix:** Green success alert appears

## Screenshots

### Before (incorrect - yellow warning)

<img width="718" height="758" alt="Screenshot_2025-10-10_19-57-08" src="https://github.com/user-attachments/assets/26d7af59-14aa-43a8-8547-c335ee678b89" />

### After (correct - green success)

<img width="696" height="748" alt="Screenshot_2025-10-10_19-57-22" src="https://github.com/user-attachments/assets/da620c3d-1bd3-4e3d-968e-8cabfec20600" />

## Technical Details

The code was checking for `$product.availability == 'in_stock'`, but, after some research, this value seems not to exist at all? The correct value is `'available'`, which should display with the success color (green) instead of warning (yellow).

