### PR TITLE
Fix the page position after submitting email subscription form

### DIFF
--- a/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
+++ b/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl
@@ -5,7 +5,7 @@
 
 {$componentName = 'email-subscription'}
 
-<div class="{$componentName} px-0 py-4">
+<div id="blockEmailSubscription_{$hookName}" class="{$componentName} px-0 py-4">
   <div class="container px-1">
     <div class="{$componentName}__content row">
       <div class="{$componentName}__content__left col-md-5">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When the email subscription form is submitted from the bottom of the page:<br><img width="899" height="114" alt="obraz" src="https://github.com/user-attachments/assets/d55e60a1-0f72-40a8-8565-5f14eaed9e63" /><br>... it tries to return the page at `#blockEmailSubscription_{$hookName}` but such id doesn't exist in the template. This PR fixes it.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      |  1. Subscribe with a valid email<br>  2. Notice the page reloads with specific `#` pointer in the URL, but stays on top nevertheless, preventing the user from seeing the feedback right away.<br>  3. Apply this PR and repeat 1-2. This time page will position itself at the newsletter block with the feedback alert.

