### PR TITLE
Don't double escape category name special chars, fixes #775

### DIFF
--- a/templates/catalog/_partials/category-header.tpl
+++ b/templates/catalog/_partials/category-header.tpl
@@ -5,17 +5,17 @@
 <div id="js-product-list-header">
     {if $listing.pagination.items_shown_from == 1}
         <div class="block-category">
-          {include file='components/page-title-section.tpl' title={$category.name}}
+          {include file='components/page-title-section.tpl' title={$category.name nofilter}}
             {if $category.description}
               <div id="category-description" class="rich-text mb-4">{$category.description nofilter}</div>
             {/if}
             {if !empty($category.cover.large.url)}
               <div class="category-cover mb-4">
-                <img src="{$category.cover.large.url}" 
-                  alt="{if !empty($category.cover.legend)}{$category.cover.legend}{else}{$category.name}{/if}" 
-                  fetchpriority="high" 
+                <img src="{$category.cover.large.url}"
+                  alt="{if !empty($category.cover.legend)}{$category.cover.legend}{else}{$category.name}{/if}"
+                  fetchpriority="high"
                   class="img-fluid"
-                  width="{$category.cover.large.width}" 
+                  width="{$category.cover.large.width}"
                   height="{$category.cover.large.height}">
               </div>
             {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | nofilter for category name in product listing
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #775 
| Sponsor company   | me
| How to test?      | Add a category with special characters like `&` and `'` in the name. View the category page and check the name. The name should be the same in breadcrumbs, left nav, and the page title. Before this PR & would be shown as &amp;

<img width="901" height="205" alt="image" src="https://github.com/user-attachments/assets/03fb2aa8-2f53-4f65-84ea-8a2bbd556e12" />

