### PR TITLE
Remove col-xs-12 and col-sm-6 from psgdpr link in my account page

### DIFF
--- a/modules/psgdpr/views/templates/front/customerAccount.tpl
+++ b/modules/psgdpr/views/templates/front/customerAccount.tpl
@@ -1,0 +1,24 @@
+{**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *}
+
+<a class="col-md-6 col-lg-4" id="psgdpr-link" href="{$front_controller}">
+    <span class="link-item">
+        <i class="material-icons">account_box</i> {l s='GDPR - Personal data' mod='psgdpr'}
+    </span>
+</a>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Remove col-xs-12 and col-sm-6 from psgdpr link in my acc page
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   |
| How to test?      | Go to my account page and check if all links are the same size on SM breakpoint
<img width="653" height="307" alt="obraz" src="https://github.com/user-attachments/assets/7c84112a-48be-4553-b8fd-1c483aa2a71e" />
