### PR TITLE
Feat display product brand link

### DIFF
--- a/src/scss/prestashop/pages/_product.scss
+++ b/src/scss/prestashop/pages/_product.scss
@@ -184,6 +184,7 @@ $component-name: product;
 
     // Spacings
     &__name,
+    &__manufacturer,
     &__prices,
     &__description-short,
     &__actions,
@@ -271,6 +272,7 @@ $component-name: product;
 
       // Spacings
       &__name,
+      &__manufacturer,
       &__prices,
       &__description-short,
       &__actions,
@@ -310,6 +312,8 @@ $component-name: product;
       }
 
       // Quickview spacings
+      &__name,
+      &__manufacturer,
       &__prices,
       &__description-short,
       &__actions,

--- a/templates/catalog/_partials/quickview.tpl
+++ b/templates/catalog/_partials/quickview.tpl
@@ -21,7 +21,19 @@
         </div>
 
         <div class="product__right">
-          <p class="product__name h2">{$product.name}</p>
+          <p class="product__name h2 {if !empty($product_manufacturer->name) && !empty($product_brand_url)}mb-1{/if}">
+            {$product.name}
+          </p>
+
+          {block name='product_manufacturer'}
+            {if !empty($product_manufacturer->name) && !empty($product_brand_url)}
+              <div class="product__manufacturer">
+                <a href="{$product_brand_url}" aria-label="{l s='Product brand: %brand_name%' sprintf=['%brand_name%' => $product_manufacturer->name] d='Shop.Theme.Catalog'}">
+                  {$product_manufacturer->name}
+                </a>
+              </div>
+            {/if}
+          {/block}
 
           {block name='product_prices'}
             {include file='catalog/_partials/product-prices.tpl'}

--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -39,7 +39,19 @@
 
     <div class="product__right" data-ps-ref="product-right" tabindex="-1">
       {block name='product_header'}
-        <h1 class="h2 product__name">{block name='page_title'}{$product.name}{/block}</h1>
+        <h1 class="product__name h2 {if !empty($product_manufacturer->name) && !empty($product_brand_url)}mb-1{/if}">
+          {block name='page_title'}{$product.name}{/block}
+        </h1>
+      {/block}
+
+      {block name='product_manufacturer'}
+        {if !empty($product_manufacturer->name) && !empty($product_brand_url)}
+          <div class="product__manufacturer">
+            <a href="{$product_brand_url}" aria-label="{l s='Product brand: %brand_name%' sprintf=['%brand_name%' => $product_manufacturer->name] d='Shop.Theme.Catalog'}">
+              {$product_manufacturer->name}
+            </a>
+          </div>
+        {/if}
       {/block}
 
       {block name='product_prices'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Display product brand link below product name
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | --
| Fixed ticket?     | Fixe https://github.com/PrestaShop/hummingbird/issues/741
| Sponsor company   | @PrestaShopCorp
| How to test?      | Having a brand associate to a product should display it below product title
<img width="1309" height="421" alt="image" src="https://github.com/user-attachments/assets/1c8146fa-fca7-43bc-853b-b3766b761344" />

