### PR TITLE
On mobile: focus on searchinput on offcanvas open

### DIFF
--- a/src/js/modules/ps_searchbar.ts
+++ b/src/js/modules/ps_searchbar.ts
@@ -98,6 +98,16 @@ const initSearchbar = () => {
     }
   });
 
+  // Focus on searchField on mobile canvas open
+  searchCanvas?.addEventListener('shown.bs.offcanvas', () => {
+    if (searchInput) {
+      // Use a small timeout to ensure the canvas animation is done
+      setTimeout(() => {
+        searchInput.focus();
+      }, 100);
+    }
+  });
+
   // Reset search on mobile canvas close
   searchCanvas?.addEventListener('hidden.bs.offcanvas', () => {
     if (searchDropdown && searchResults && searchInput) {
@@ -105,6 +115,7 @@ const initSearchbar = () => {
       searchDropdown.classList.add('d-none');
       searchInput.setAttribute('aria-expanded', 'false');
     }
+    clearSearch();
   });
 
   // Handle search results display


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | On mobile view focus on the searchinput when the offcanvas search is shown. Also clear the search when the offcanvas is hidden
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Touches on issue https://github.com/PrestaShop/hummingbird/issues/734 (the actual issue was already fixed before but when testing I noticed that this could be improved a bit)
| Sponsor company   | 
| How to test?      | On mobile view click on the search icon to get the offcanvas search to show, the focus should be on the input field and if a mobile phone is used the keyboard is shown. If input field contains text when closing the view then reopening the view should have the old search cleared and the focus again for a new search.

this replaces pr #796 . trying to rebase that thing was a nightmare
