### PR TITLE
Poweruser search, use / to focus on searchinput

### DIFF
--- a/src/js/modules/ps_searchbar.ts
+++ b/src/js/modules/ps_searchbar.ts
@@ -29,9 +29,9 @@ const initSearchbar = () => {
   const searchClear = document.querySelector<HTMLElement>(SearchBarMap.searchClear);
   const searchUrl = searchWidget?.dataset.searchControllerUrl;
 
-  // For powerusers `/` goes to search :)
-  // TODO: this should probably be in a totally new "shortcuts" module that does
-  // other shortcuts and even a `?` to show a small cheatsheet on the screen :)
+  // For powerusers `ctrl+k` goes to search :)
+  // TODO: this should probably be in a totally new "shortcuts" module that does this
+  // and other shortcuts with a `?` to show a small cheatsheet on the screen :)
   document.addEventListener('keydown', (e: KeyboardEvent) => {
     // Ignore if user is already typing in an input, textarea, or contenteditable element
     const active = document.activeElement as HTMLElement | null;
@@ -40,7 +40,7 @@ const initSearchbar = () => {
         || active.tagName === 'TEXTAREA'
         || active.isContentEditable);
 
-    if (!isTyping && e.key === '/') {
+    if (!isTyping && e.ctrlKey && e.key === 'k') {
       e.preventDefault();
       if (searchCanvas && !searchCanvas.classList.contains('show')) {
         const offcanvas = Offcanvas.getOrCreateInstance(searchCanvas);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Poweruser search. Use / to focus on the searchInput field
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | 
| How to test?      | Open a page and type / , check that search input is focused (and on mobile the offCanvas is open) and ready for searching. Check that the / can still be typed on input fields elsewhere (the search focus should only happen if you are not in a input field already)

this replaces pr #797