### PR TITLE
[FIX] Trigger updateProduct after product add to cart modal is closed

### DIFF
--- a/src/js/modules/blockcart.ts
+++ b/src/js/modules/blockcart.ts
@@ -58,7 +58,16 @@ export default function initBlockCart() {
       }
     });
 
-    modalElement.addEventListener('hidden.bs.modal', () => {
+    modalElement.addEventListener('hidden.bs.modal', (event: Event) => {
+      const target = event.currentTarget as HTMLElement;
+
+      if (target) {
+        prestashop.emit(events.updateProduct, {
+          reason: target.dataset,
+          event,
+        });
+      }
+
       document.removeEventListener('keydown', onKeyDown, {capture: true});
       document.removeEventListener('pointerdown', onPointerDown, {capture: true});
 

--- a/src/js/product.ts
+++ b/src/js/product.ts
@@ -84,6 +84,8 @@ export default () => {
         if (input.value !== clampedValue.toString()) {
           input.value = clampedValue.toString();
         }
+
+        triggerEmit();
       });
 
       quantityInput.addEventListener('blur', () => {
@@ -93,9 +95,9 @@ export default () => {
 
         if (quantityInput.value !== clampedValue.toString()) {
           quantityInput.value = clampedValue.toString();
-          // Trigger change event to ensure triggerEmit() is called after auto-correction
-          quantityInput.dispatchEvent(new Event('change', {bubbles: true}));
         }
+
+        triggerEmit();
       });
 
       quantityInput.addEventListener('change', triggerEmit);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix trigger updateProduct after product add to cart modal is closed
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | --
| Sponsor company   | @PrestaShopCorp
| How to test?      | --
