### PR TITLE
Fix display additional_delivery_times

### DIFF
--- a/src/scss/prestashop/pages/_product.scss
+++ b/src/scss/prestashop/pages/_product.scss
@@ -119,7 +119,10 @@ $component-name: product;
     &__availability {
       display: flex;
       flex-direction: column;
-      gap: 0.25rem;
+
+      &:has(+ .#{$component-name}__delivery-infos) {
+        margin-block-end: 0.25rem;
+      }
     }
 
     &__availability-status {
@@ -190,6 +193,7 @@ $component-name: product;
     &__actions,
     &__variants,
     &__availability,
+    &__delivery-infos,
     &__add-to-cart-container,
     &__minimal-quantity,
     &__customization,
@@ -278,6 +282,7 @@ $component-name: product;
       &__actions,
       &__variants,
       &__availability,
+      &__delivery-infos,
       &__add-to-cart-container,
       &__minimal-quantity,
       &__customization,

--- a/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/templates/catalog/_partials/product-add-to-cart.tpl
@@ -5,12 +5,11 @@
 {if !$configuration.is_catalog}
   <div class="product__add-to-cart-container product-add-to-cart js-product-add-to-cart">
     {block name='product_availability'}
-      <div
-        id="product-availability"
-        class="product__availability js-product-availability"
-        {if !$product.show_availability || !$product.availability_message}hidden{/if}
-      >
-        {if $product.show_availability && $product.availability_message}
+      {if $product.show_availability && $product.availability_message}
+        <div
+          id="product-availability"
+          class="product__availability js-product-availability"
+        >
           {** First, we prepare the icons and colors we want to use *}
           {if $product.availability == 'in_stock'}
             {assign 'availability_icon' 'E5CA'}
@@ -39,25 +38,23 @@
               {/if}
             </div>
           </div>
+        </div>
+      {/if}
 
-          {block name='product_delivery_times'}
-            {if !$product.is_virtual}
-              {if $product.additional_delivery_times == 1}
-                {if $product.delivery_information}
-                  <div class="product__delivery-infos">{$product.delivery_information}</div>
-                {/if}
-              {elseif $product.additional_delivery_times == 2}
-                {if $product.quantity > 0}
-                  <div class="product__delivery-infos">{$product.delivery_in_stock}</div>
-                {* Out of stock message should not be displayed if customer can't order the product. *}
-                {elseif $product.quantity <= 0 && $product.add_to_cart_url}
-                  <div class="product__delivery-infos">{$product.delivery_out_stock}</div>
-                {/if}
-              {/if}
+      {block name='product_delivery_times'}
+        {if !$product.is_virtual}
+          {if $product.additional_delivery_times == 1 && $product.delivery_information}
+            <div class="product__delivery-infos">{$product.delivery_information}</div>
+          {elseif $product.additional_delivery_times == 2}
+            {if $product.quantity > 0 && $product.delivery_in_stock}
+              <div class="product__delivery-infos">{$product.delivery_in_stock}</div>
+            {* Out of stock message should not be displayed if customer can't order the product. *}
+            {elseif $product.quantity <= 0 && $product.add_to_cart_url && $product.delivery_out_stock}
+              <div class="product__delivery-infos">{$product.delivery_out_stock}</div>
             {/if}
-          {/block}
+          {/if}
         {/if}
-      </div>
+      {/block}
     {/block}
 
     {block name='product_quantity'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Display additional_delivery_times information even if availability_message is missing.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/hummingbird/issues/850 - https://github.com/PrestaShop/hummingbird/issues/851
| Sponsor company   | @PrestaShopCorp
| How to test?      | Follow steps on the issues
