### PR TITLE
Fix jsonld error when no manufacturer / brand is set

### DIFF
--- a/templates/_partials/microdata/product-jsonld.tpl
+++ b/templates/_partials/microdata/product-jsonld.tpl
@@ -37,7 +37,7 @@
     {if $product.ean13},"gtin13": "{$product.ean13}"
     {elseif $product.upc},"gtin13": "{$product.upc}"
     {/if}
-    {if $product_manufacturer->name},
+    {if isset($product_manufacturer) && $product_manufacturer->name},
     "brand": {
       "@type": "Brand",
       "name": "{$product_manufacturer->name|escape:'html':'UTF-8'}"


### PR DESCRIPTION
Fixes #870

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix error in product jsonld template when no manufacturer / brand is set
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #870
| Sponsor company   | @friends-of-presta
| How to test?      | Follow issue https://github.com/PrestaShop/hummingbird/issues/870
