### PR TITLE
Use proper, standardized values in quantity input

### DIFF
--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -84,8 +84,8 @@
                   {include file='components/qty-input.tpl'
                     attributes=[
                       "id" => "quantity_wanted_{$product.id_product}",
-                      "value" => "{$product.minimal_quantity}",
-                      "min" => "{$product.minimal_quantity}"
+                      "value" => "{$product.quantity_required}",
+                      "min" => "{$product.quantity_required}"
                     ]
                   }
                 </div>

--- a/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/templates/catalog/_partials/product-add-to-cart.tpl
@@ -64,8 +64,8 @@
             attributes=[
               "id" => "quantity_wanted",
               "class" => "form-control js-quantity-wanted",
-              "value" => "{$product.minimal_quantity}",
-              "min" => "{$product.minimal_quantity}"
+              "value" => "{$product.quantity_wanted}",
+              "min" => "{$product.quantity_required}"
             ]
           }
         </div>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In order to fix all of the issues with product quantities, we cannot use minimum quantity. This fixes all issues and unifies both themes. Required for https://github.com/PrestaShop/PrestaShop/pull/40538.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | TRENDO s.r.o.
| How to test?      | See steps in original issue
