### PR TITLE
Remove shipping cost in order details for multi-shipment scenarios

### DIFF
--- a/templates/customer/_partials/order-shipments.tpl
+++ b/templates/customer/_partials/order-shipments.tpl
@@ -11,7 +11,6 @@
         <span class="grid-table__cell" role="columnheader">{l s='Date' d='Shop.Theme.Global'}</span>
         <span class="grid-table__cell" role="columnheader">{l s='Carrier' d='Shop.Theme.Checkout'}</span>
         <span class="grid-table__cell" role="columnheader">{l s='Weight' d='Shop.Theme.Checkout'}</span>
-        <span class="grid-table__cell" role="columnheader">{l s='Shipping cost' d='Shop.Theme.Checkout'}</span>
         <span class="grid-table__cell" role="columnheader">{l s='Tracking number' d='Shop.Theme.Checkout'}</span>
       </div>
 
@@ -25,9 +24,6 @@
           </span>
           <span class="grid-table__cell" role="cell" data-ps-label="{l s='Weight' d='Shop.Theme.Checkout'}">
             {$line.package_weight}
-          </span>
-          <span class="grid-table__cell" role="cell" data-ps-label="{l s='Shipping cost' d='Shop.Theme.Checkout'}">
-            {$line.package_cost}
           </span>
           <span class="grid-table__cell" role="cell" data-ps-label="{l s='Tracking number' d='Shop.Theme.Checkout'}">
             {if $line.carrier_tracking_url}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This can be confusing for the user. What they're interested in is the total shipping cost, which is already included in the totals. Furthermore, after splitting and merging shipments, it's currently impossible to have accurate values ​​in this table.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | -