### PR TITLE
Add stock informations on cart page

### DIFF
--- a/src/scss/prestashop/components/cart/_cart-product-line.scss
+++ b/src/scss/prestashop/components/cart/_cart-product-line.scss
@@ -42,6 +42,24 @@ $component-name: product-line;
   }
 
   &__item {
+    &-availability-icon {
+      flex-shrink: 0;
+      font-size: 0.875rem;
+    }
+
+    &-availability-message {
+      display: inline-flex;
+      gap: 0.25rem;
+      align-items: center;
+      font-size: 0.75rem;
+    }
+
+    &-availability-submessage {
+      display: block;
+      font-size: 0.75rem;
+      color: var(--bs-tertiary-color);
+    }
+
     &-price {
       width: 100%;
       font-weight: 600;
@@ -67,6 +85,12 @@ $component-name: product-line;
       flex-wrap: wrap;
       gap: 0.25rem;
       align-items: center;
+    }
+
+    &--availability {
+      display: flex;
+      flex-direction: column;
+      gap: 0.125rem;
     }
 
     &--prices {

--- a/src/scss/prestashop/components/cart/_cart-product-line.scss
+++ b/src/scss/prestashop/components/cart/_cart-product-line.scss
@@ -54,12 +54,6 @@ $component-name: product-line;
       font-size: 0.75rem;
     }
 
-    &-availability-delivery-information {
-      display: block;
-      font-size: 0.75rem;
-      color: var(--bs-tertiary-color);
-    }
-
     &-price {
       width: 100%;
       font-weight: 600;
@@ -85,6 +79,11 @@ $component-name: product-line;
       flex-wrap: wrap;
       gap: 0.25rem;
       align-items: center;
+    }
+
+    &--small-info {
+      font-size: 0.75rem;
+      color: var(--bs-tertiary-color);
     }
 
     &--availability {

--- a/src/scss/prestashop/components/cart/_cart-product-line.scss
+++ b/src/scss/prestashop/components/cart/_cart-product-line.scss
@@ -54,7 +54,7 @@ $component-name: product-line;
       font-size: 0.75rem;
     }
 
-    &-availability-submessage {
+    &-availability-delivery-information {
       display: block;
       font-size: 0.75rem;
       color: var(--bs-tertiary-color);

--- a/src/scss/prestashop/pages/_product.scss
+++ b/src/scss/prestashop/pages/_product.scss
@@ -123,10 +123,7 @@ $component-name: product;
     &__availability {
       display: flex;
       flex-direction: column;
-
-      &:has(+ .#{$component-name}__delivery-infos) {
-        margin-block-end: 0.25rem;
-      }
+      gap: 0.25rem;
     }
 
     &__availability-status {
@@ -203,7 +200,6 @@ $component-name: product;
     &__actions,
     &__variants,
     &__availability,
-    &__delivery-infos,
     &__add-to-cart-container,
     &__minimal-quantity,
     &__customization,
@@ -296,7 +292,6 @@ $component-name: product;
       &__actions,
       &__variants,
       &__availability,
-      &__delivery-infos,
       &__add-to-cart-container,
       &__minimal-quantity,
       &__customization,

--- a/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/templates/catalog/_partials/product-add-to-cart.tpl
@@ -41,7 +41,6 @@
               {/if}
             </div>
           </div>
-
         {/if}
 
         {block name='product_delivery_times'}

--- a/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/templates/catalog/_partials/product-add-to-cart.tpl
@@ -12,7 +12,7 @@
           hidden
         {/if}
       >
-        {if $product.show_availability && $product.availability_message}
+        {if !empty($product.availability_message)}
           {** First, we prepare the icons and colors we want to use *}
           {if $product.availability == 'in_stock'}
             {assign 'availability_icon' 'E5CA'}

--- a/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/templates/catalog/_partials/product-add-to-cart.tpl
@@ -5,11 +5,14 @@
 {if !$configuration.is_catalog}
   <div class="product__add-to-cart-container product-add-to-cart js-product-add-to-cart">
     {block name='product_availability'}
-      {if $product.show_availability && $product.availability_message}
-        <div
-          id="product-availability"
-          class="product__availability js-product-availability"
-        >
+      <div
+        id="product-availability"
+        class="product__availability js-product-availability"
+        {if empty($product.availability_message) && empty($product.delivery_information)}
+          hidden
+        {/if}
+      >
+        {if $product.show_availability && $product.availability_message}
           {** First, we prepare the icons and colors we want to use *}
           {if $product.availability == 'in_stock'}
             {assign 'availability_icon' 'E5CA'}
@@ -38,23 +41,15 @@
               {/if}
             </div>
           </div>
-        </div>
-      {/if}
 
-      {block name='product_delivery_times'}
-        {if !$product.is_virtual}
-          {if $product.additional_delivery_times == 1 && $product.delivery_information}
-            <div class="product__delivery-infos">{$product.delivery_information}</div>
-          {elseif $product.additional_delivery_times == 2}
-            {if $product.quantity > 0 && $product.delivery_in_stock}
-              <div class="product__delivery-infos">{$product.delivery_in_stock}</div>
-            {* Out of stock message should not be displayed if customer can't order the product. *}
-            {elseif $product.quantity <= 0 && $product.add_to_cart_url && $product.delivery_out_stock}
-              <div class="product__delivery-infos">{$product.delivery_out_stock}</div>
-            {/if}
-          {/if}
         {/if}
-      {/block}
+
+        {block name='product_delivery_times'}
+          {if !empty($product.delivery_information)}
+            <div class="product__delivery-infos">{$product.delivery_information}</div>
+          {/if}
+        {/block}
+      </div>
     {/block}
 
     {block name='product_quantity'}

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -112,10 +112,8 @@
             {$product.availability_message}
           </div>
 
-          {if !$product.is_virtual}
-            {if !empty($product.delivery_information)}
-              <small class="product-line__item-availability-submessage">{$product.delivery_information}</small>
-            {/if}
+          {if !empty($product.delivery_information)}
+            <small class="product-line__item-availability-delivery-information">{$product.delivery_information}</small>
           {/if}
         </div>
       {/if}

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -91,21 +91,21 @@
         </div>
       {/foreach}
 
-      {if $product.availability == 'in_stock'}
-        {assign 'availability_icon' 'E5CA'}
-        {assign 'availability_class' 'text-success'}
-      {elseif $product.availability == 'available'}
-        {assign 'availability_icon' 'E002'}
-        {assign 'availability_class' 'text-warning'}
-      {elseif $product.availability == 'last_remaining_items'}
-        {assign 'availability_icon' 'E002'}
-        {assign 'availability_class' 'text-warning'}
-      {else}
-        {assign 'availability_icon' 'E14B'}
-        {assign 'availability_class' 'text-danger'}
-      {/if}
+      {if !empty($product.availability_message)}
+        {if $product.availability == 'in_stock'}
+          {assign 'availability_icon' 'E5CA'}
+          {assign 'availability_class' 'text-success'}
+        {elseif $product.availability == 'available'}
+          {assign 'availability_icon' 'E002'}
+          {assign 'availability_class' 'text-warning'}
+        {elseif $product.availability == 'last_remaining_items'}
+          {assign 'availability_icon' 'E002'}
+          {assign 'availability_class' 'text-warning'}
+        {else}
+          {assign 'availability_icon' 'E14B'}
+          {assign 'availability_class' 'text-danger'}
+        {/if}
 
-      {if $product.show_availability && $product.availability_message}
         <div class="product-line__item product-line__item--availability">
           <div class="product-line__item-availability-message {$availability_class}">
             <i class="product-line__item-availability-icon material-icons rtl-no-flip">&#x{$availability_icon};</i>

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -112,8 +112,16 @@
             {$product.availability_message}
           </div>
 
-          {if !empty($product.availability_submessage)}
-            <small class="product-line__item-availability-submessage">{$product.availability_submessage}</small>
+          {if !$product.is_virtual}
+            {if $product.additional_delivery_times == 1 && $product.delivery_information}
+              <small class="product-line__item-availability-submessage">{$product.delivery_information}</small>
+            {elseif $product.additional_delivery_times == 2}
+              {if $product.quantity > 0 && $product.delivery_in_stock}
+                <small class="product-line__item-availability-submessage">{$product.delivery_in_stock}</small>
+              {elseif $product.quantity <= 0 && $product.add_to_cart_url && $product.delivery_out_stock}
+                <small class="product-line__item-availability-submessage">{$product.delivery_out_stock}</small>
+              {/if}
+            {/if}
           {/if}
         </div>
       {/if}

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -91,6 +91,33 @@
         </div>
       {/foreach}
 
+      {if $product.availability == 'in_stock'}
+        {assign 'availability_icon' 'E5CA'}
+        {assign 'availability_class' 'text-success'}
+      {elseif $product.availability == 'available'}
+        {assign 'availability_icon' 'E002'}
+        {assign 'availability_class' 'text-warning'}
+      {elseif $product.availability == 'last_remaining_items'}
+        {assign 'availability_icon' 'E002'}
+        {assign 'availability_class' 'text-warning'}
+      {else}
+        {assign 'availability_icon' 'E14B'}
+        {assign 'availability_class' 'text-danger'}
+      {/if}
+
+      {if $product.show_availability && $product.availability_message}
+        <div class="product-line__item product-line__item--availability">
+          <div class="product-line__item-availability-message {$availability_class}">
+            <i class="product-line__item-availability-icon material-icons rtl-no-flip">&#x{$availability_icon};</i>
+            {$product.availability_message}
+          </div>
+
+          {if !empty($product.availability_submessage)}
+            <small class="product-line__item-availability-submessage">{$product.availability_submessage}</small>
+          {/if}
+        </div>
+      {/if}
+
       {hook h='displayCartExtraProductInfo' product=$product}
 
       <div class="product-line__item product-line__item--prices">

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -113,14 +113,8 @@
           </div>
 
           {if !$product.is_virtual}
-            {if $product.additional_delivery_times == 1 && $product.delivery_information}
+            {if !empty($product.delivery_information)}
               <small class="product-line__item-availability-submessage">{$product.delivery_information}</small>
-            {elseif $product.additional_delivery_times == 2}
-              {if $product.quantity > 0 && $product.delivery_in_stock}
-                <small class="product-line__item-availability-submessage">{$product.delivery_in_stock}</small>
-              {elseif $product.quantity <= 0 && $product.add_to_cart_url && $product.delivery_out_stock}
-                <small class="product-line__item-availability-submessage">{$product.delivery_out_stock}</small>
-              {/if}
             {/if}
           {/if}
         </div>

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -111,10 +111,12 @@
             <i class="product-line__item-availability-icon material-icons rtl-no-flip">&#x{$availability_icon};</i>
             {$product.availability_message}
           </div>
+        </div>
+      {/if}
 
-          {if !empty($product.delivery_information)}
-            <small class="product-line__item-availability-delivery-information">{$product.delivery_information}</small>
-          {/if}
+      {if !empty($product.delivery_information)}
+        <div class="product-line__item product-line__item--small-info">
+          {$product.delivery_information}
         </div>
       {/if}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add stock informations on cart page + refactor delivery informations 
| Type?             | improvement
| BC breaks?        | --
| Deprecations?     | --
| Fixed ticket?     | https://github.com/PrestaShop/hummingbird/issues/839
| Sponsor company   | @PrestaShopCorp
| How to test?      | --

**NOTE:** this PR should be test with https://github.com/PrestaShop/PrestaShop/pull/40653 and https://github.com/PrestaShop/PrestaShop/pull/40673 and https://github.com/PrestaShop/PrestaShop/pull/40662

This PR is only a POC to display stock information on the cart page. Core-side changes will be required to properly implement it.

This is a preview of what could be achieved if the core is adapted. I have identified some issues with error messages returned by the core. For example, when a product in the cart is no longer in stock, the current message is something like:
"You can only add 0 qty of this product."

A more appropriate message would be something like:
"Please remove the product (XXX) from the cart." when the available quantity is ≤ 0.

<img width="1326" height="959" alt="Capture d’écran 2026-01-30 à 11 30 45" src="https://github.com/user-attachments/assets/a1727a74-2865-43d3-876d-3a75830e8d49" />