### PR TITLE
Move displayProductPriceBlock hook position

### DIFF
--- a/src/scss/prestashop/components/cart/_cart-product-line.scss
+++ b/src/scss/prestashop/components/cart/_cart-product-line.scss
@@ -62,6 +62,10 @@ $component-name: product-line;
       font-size: 0.875rem;
     }
 
+    &-price-block {
+      width: 100%;
+    }
+
     &--info {
       display: flex;
       flex-wrap: wrap;

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -96,7 +96,7 @@
       <div class="product-line__item product-line__item--prices">
         <span class="product-line__item-price">{$product.price}</span>
         {if $product.unit_price_full}
-          <div class="product-line__item-unit-price">{$product.unit_price_full}</div>
+          <span class="product-line__item-unit-price">{$product.unit_price_full}</span>
         {/if}
 
         {if $product.has_discount}
@@ -111,6 +111,13 @@
               -{$product.discount_to_display}
             </span>
           {/if}
+        {/if}
+
+        {capture name='product_price_block'}{hook h='displayProductPriceBlock' product=$product type="unit_price"}{/capture}
+        {if $smarty.capture.product_price_block}
+          <div class="product-line__item-price-block">
+            {$smarty.capture.product_price_block}
+          </div>
         {/if}
       </div>
     </div>
@@ -146,8 +153,6 @@
           <div class="product-line__price">{$product.total}</div>
         {/if}
       {/if}
-
-      {hook h='displayProductPriceBlock' product=$product type="unit_price"}
     </div>
 
     <div class="product-line__actions">

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -116,7 +116,7 @@
         {capture name='product_price_block'}{hook h='displayProductPriceBlock' product=$product type="unit_price"}{/capture}
         {if $smarty.capture.product_price_block}
           <div class="product-line__item-price-block">
-            {$smarty.capture.product_price_block}
+            {$smarty.capture.product_price_block nofilter}
           </div>
         {/if}
       </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Move displayProductPriceBlock hook position
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/hummingbird/issues/921
| Sponsor company   | @PrestaShopCorp
| How to test?      | Verify that content is displayed in `displayProductPriceBlock` at the location shown in the image below.

<img width="898" height="276" alt="image" src="https://github.com/user-attachments/assets/544448d5-061a-457e-99fb-0604631c9adc" />
