### PR TITLE
ContactForm: Hide subject dropdown when only one contact is available

### DIFF
--- a/modules/contactform/views/templates/widget/contactform.tpl
+++ b/modules/contactform/views/templates/widget/contactform.tpl
@@ -19,16 +19,21 @@
       <section class="form-fields">
         {include file='components/page-title-section.tpl' title={l s='Contact us' d='Shop.Theme.Global'}}
 
-        <div class="mb-3">
-          <label class="form-label" for="contact-us-subject-select">
-            {l s='Subject' d='Shop.Forms.Labels'}
-          </label>
-          <select id="contact-us-subject-select" name="id_contact" class="form-select">
-            {foreach from=$contact.contacts item=contact_elt}
-              <option value="{$contact_elt.id_contact}">{$contact_elt.name}</option>
-            {/foreach}
-          </select>
-        </div>
+        {if $contact.contacts|count === 1}
+          {assign var=firstContact value=current($contact.contacts)}
+          <input type="hidden" name="id_contact" value="{$firstContact.id_contact|escape:'htmlall':'UTF-8'}"/>
+        {else}
+          <div class="mb-3">
+            <label class="form-label" for="contact-us-subject-select">
+              {l s='Subject' d='Shop.Forms.Labels'}
+            </label>
+            <select id="contact-us-subject-select" name="id_contact" class="form-select">
+              {foreach from=$contact.contacts item=contact_elt}
+                <option value="{$contact_elt.id_contact}">{$contact_elt.name}</option>
+              {/foreach}
+            </select>
+          </div>
+        {/if}
 
         <div class="mb-3">
           <label class="form-label required" for="contact-us-email-input">

--- a/modules/contactform/views/templates/widget/contactform.tpl
+++ b/modules/contactform/views/templates/widget/contactform.tpl
@@ -29,7 +29,7 @@
             </label>
             <select id="contact-us-subject-select" name="id_contact" class="form-select">
               {foreach from=$contact.contacts item=contact_elt}
-                <option value="{$contact_elt.id_contact}">{$contact_elt.name}</option>
+                <option value="{$contact_elt.id_contact|escape:'htmlall':'UTF-8'}">{$contact_elt.name|escape:'htmlall':'UTF-8'}</option>
               {/foreach}
             </select>
           </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When only one contact is available in the Contact Form module, the subject dropdown is no longer displayed.<br/>Instead of rendering a `<select>` with a single option, the module now automatically sets the `id_contact` value using a hidden input.<br/>This improves the user experience by removing an unnecessary selection while preserving the expected form behavior.
| Type?         | improvement 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | - In the admin panel, go to **Shop Parameters > Contact**<br/> - Delete the contacts, leaving only one<br/> - In the front office, go to the **Contact** page<br/> - The `Subject Heading` label and its related select dropdown should not be displayed
| Related PRs       | https://github.com/PrestaShop/contactform/pull/88
---
### Before
<img width="950" height="454" alt="Hummingbird-before" src="https://github.com/user-attachments/assets/66939e70-d010-473e-beb1-245bbc2b4e9b" />


### After
<img width="950" height="368" alt="Hummingbird-after" src="https://github.com/user-attachments/assets/85d51645-b94a-4bc6-8c0b-3465781b1572" />

