### PR TITLE
Fix duplicate breadcrumb block declaration in partial

### DIFF
--- a/templates/_partials/breadcrumb.tpl
+++ b/templates/_partials/breadcrumb.tpl
@@ -7,19 +7,17 @@
 <nav data-depth="{$breadcrumb.count}" class="{$componentName}__wrapper" aria-label="{$componentName}">
   <div class="container">
     <ol class="{$componentName}">
-      {block name='breadcrumb'}
-        {foreach from=$breadcrumb.links item=path name=breadcrumb}
-          {block name='breadcrumb_item'}
-            <li class="{$componentName}-item">
-              {if not $smarty.foreach.breadcrumb.last}
-                <a href="{$path.url}" class="{$componentName}-link"><span>{$path.title}</span></a>
-              {else}
-                <span>{$path.title}</span>
-              {/if}
-            </li>
-          {/block}
-        {/foreach}
-      {/block}
+      {foreach from=$breadcrumb.links item=path name=breadcrumb}
+        {block name='breadcrumb_item'}
+          <li class="{$componentName}-item">
+            {if not $smarty.foreach.breadcrumb.last}
+              <a href="{$path.url}" class="{$componentName}-link"><span>{$path.title}</span></a>
+            {else}
+              <span>{$path.title}</span>
+            {/if}
+          </li>
+        {/block}
+      {/foreach}
     </ol>
   </div>
 </nav>

--- a/templates/_partials/breadcrumb.tpl
+++ b/templates/_partials/breadcrumb.tpl
@@ -6,18 +6,22 @@
 
 <nav data-depth="{$breadcrumb.count}" class="{$componentName}__wrapper" aria-label="{$componentName}">
   <div class="container">
-    <ol class="{$componentName}">
-      {foreach from=$breadcrumb.links item=path name=breadcrumb}
-        {block name='breadcrumb_item'}
-          <li class="{$componentName}-item">
-            {if not $smarty.foreach.breadcrumb.last}
-              <a href="{$path.url}" class="{$componentName}-link"><span>{$path.title}</span></a>
-            {else}
-              <span>{$path.title}</span>
-            {/if}
-          </li>
+    {block name='breadcrumb_list'}
+      <ol class="{$componentName}">
+        {block name='breadcrumb_items'}
+          {foreach from=$breadcrumb.links item=path name=breadcrumb}
+            {block name='breadcrumb_item'}
+              <li class="{$componentName}-item">
+                {if not $smarty.foreach.breadcrumb.last}
+                  <a href="{$path.url}" class="{$componentName}-link"><span>{$path.title}</span></a>
+                {else}
+                  <span>{$path.title}</span>
+                {/if}
+              </li>
+            {/block}
+          {/foreach}
         {/block}
-      {/foreach}
-    </ol>
+      </ol>
+    {/block}
   </div>
 </nav>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR fixes the breadcrumb block structure to avoid declaring the same` {block name='breadcrumb'}` in both `layout-both-columns.tpl` and `breadcrumb.tpl`.
| Type?             | improvement
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | -
| Sponsor company   | Codencode snc
| How to test?      | 
