### PR TITLE
fix: allow default message to be displayed if psData is not set in usePasswordPolicy

### DIFF
--- a/src/js/components/usePasswordPolicy.ts
+++ b/src/js/components/usePasswordPolicy.ts
@@ -95,10 +95,10 @@ const buildValidationMessage = (
   // Get base message
   if (!lengthValid) {
     const invalidElement = feedbackContainer.querySelector(PasswordPolicyMap.lengthMessage) as HTMLElement;
-    message = `${invalidElement?.dataset?.psData}\n` || 'Your password length is invalid \n';
+    message = `${invalidElement?.dataset?.psData || 'Your password length is invalid'}\n`;
   } else if (!strengthValid) {
     const invalidElement = feedbackContainer.querySelector(PasswordPolicyMap.invalidMessage) as HTMLElement;
-    message = `${invalidElement?.dataset?.psData}\n` || 'Your password is too weak \n';
+    message = `${invalidElement?.dataset?.psData || 'Your password is too weak'}\n`;
   }
 
   // Get hints suggestions


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | An OR operator was used, but with the left side expression being always true, so the default message could never be displayed.
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | na