### PR TITLE
feat(opc): Initialize one page checkout feature

### DIFF
--- a/src/js/constants/mocks/onePageCheckout-data.ts
+++ b/src/js/constants/mocks/onePageCheckout-data.ts
@@ -1,0 +1,44 @@
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+export const FormWithRequiredFields = `
+  <form class="one-page-checkout" method="POST">
+    <input type="email" name="email" id="field-email" required>
+    <input type="text" name="firstname" id="field-firstname" required>
+    <input type="text" name="lastname" id="field-lastname" required>
+    <select name="id_country" id="field-id_country" required>
+      <option value="" disabled selected>-- please choose --</option>
+      <option value="8">France</option>
+    </select>
+
+    <div class="form-check">
+      <input class="form-check-input js-opc-use-same-address" type="checkbox" id="opc-use-same-address" name="use_same_address" value="1" checked>
+    </div>
+
+    <section id="opc-billing-section" style="display: none;">
+      <input type="text" name="invoice_firstname" id="field-invoice_firstname" required>
+      <input type="text" name="invoice_lastname" id="field-invoice_lastname" required>
+    </section>
+
+    <div class="form-check">
+      <input type="checkbox" name="conditions_to_approve[terms-and-conditions]" id="conditions" required class="form-check-input">
+    </div>
+
+    <button type="submit" id="opc-pay-button" disabled>Pay</button>
+  </form>
+`;
+
+export const FormWithoutRequiredFields = `
+  <form class="one-page-checkout" method="POST">
+    <input type="text" name="phone" id="field-phone">
+    <button type="submit" id="opc-pay-button" disabled>Pay</button>
+  </form>
+`;
+
+export const FormEmpty = `
+  <form class="one-page-checkout" method="POST">
+    <button type="submit" id="opc-pay-button" disabled>Pay</button>
+  </form>
+`;

--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -127,6 +127,13 @@ export const visiblePassword = {
   visiblePassword: '[data-ps-action="toggle-password"]',
 };
 
+export const onePageCheckout = {
+  form: '.one-page-checkout',
+  useSameAddress: '.js-opc-use-same-address',
+  billingSection: '#opc-billing-section',
+  payButton: '#opc-pay-button',
+};
+
 export const gdpr = {
   consent: '[data-ps-ref="gdpr-consent"]',
   consentWrapper: '[data-ps-component="gdpr"]',
@@ -260,6 +267,7 @@ const selectorsMap = {
   formValidation,
   passwordPolicy,
   emailAlerts,
+  onePageCheckout,
   gdpr,
 };
 

--- a/src/js/pages/one-page-checkout.test.ts
+++ b/src/js/pages/one-page-checkout.test.ts
@@ -1,0 +1,187 @@
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+import initEmitter from '@js/prestashop';
+import resetHTMLBodyContent from '@helpers/resetBody';
+import {FormWithRequiredFields, FormWithoutRequiredFields, FormEmpty} from '@constants/mocks/onePageCheckout-data';
+import initOnePageCheckout from '@js/pages/one-page-checkout';
+import {onePageCheckout} from '@constants/selectors-map';
+
+const getPayButton = (): HTMLButtonElement => document.querySelector<HTMLButtonElement>(onePageCheckout.payButton)!;
+
+const getBillingSection = (): HTMLElement => document.querySelector<HTMLElement>(onePageCheckout.billingSection)!;
+
+const fillField = (selector: string, value: string) => {
+  const field = document.querySelector<HTMLInputElement | HTMLSelectElement>(selector)!;
+  field.value = value;
+  field.dispatchEvent(new Event('input', {bubbles: true}));
+};
+
+const toggleCheckbox = (selector: string, checked: boolean) => {
+  const cb = document.querySelector<HTMLInputElement>(selector)!;
+  cb.checked = checked;
+  cb.dispatchEvent(new Event('change', {bubbles: true}));
+};
+
+const TEST_EMAIL = 'test@example.com';
+const TEST_FIRSTNAME = 'John';
+const TEST_LASTNAME = 'Doe';
+const TEST_COUNTRY_ID = '8';
+const TEST_INVOICE_FIRSTNAME = 'Jane';
+
+describe('One Page Checkout', () => {
+  beforeAll(() => {
+    window.prestashop = {} as any;
+    initEmitter();
+  });
+
+  afterEach(() => {
+    window.prestashop.removeAllListeners('updatedOpcAddressForm');
+  });
+
+  describe('validateForm', () => {
+    describe('with required fields', () => {
+      beforeEach(() => {
+        resetHTMLBodyContent(FormWithRequiredFields);
+        initOnePageCheckout();
+      });
+
+      it('should disable pay button when required fields are empty', () => {
+        expect(getPayButton().disabled).toBe(true);
+      });
+
+      it('should enable pay button when all visible required fields are filled', () => {
+        fillField('#field-email', TEST_EMAIL);
+        fillField('#field-firstname', TEST_FIRSTNAME);
+        fillField('#field-lastname', TEST_LASTNAME);
+        fillField('#field-id_country', TEST_COUNTRY_ID);
+        toggleCheckbox('#conditions', true);
+
+        expect(getPayButton().disabled).toBe(false);
+      });
+
+      it('should disable pay button when one required field is empty', () => {
+        fillField('#field-email', TEST_EMAIL);
+        fillField('#field-firstname', TEST_FIRSTNAME);
+        // lastname left empty
+        fillField('#field-id_country', TEST_COUNTRY_ID);
+        toggleCheckbox('#conditions', true);
+
+        expect(getPayButton().disabled).toBe(true);
+      });
+
+      it('should disable pay button when terms checkbox is unchecked', () => {
+        fillField('#field-email', TEST_EMAIL);
+        fillField('#field-firstname', TEST_FIRSTNAME);
+        fillField('#field-lastname', TEST_LASTNAME);
+        fillField('#field-id_country', TEST_COUNTRY_ID);
+        // conditions left unchecked
+
+        expect(getPayButton().disabled).toBe(true);
+      });
+
+      it('should ignore required fields inside hidden billing section', () => {
+        // billing section is hidden by default, so invoice_firstname/invoice_lastname are skipped
+        fillField('#field-email', TEST_EMAIL);
+        fillField('#field-firstname', TEST_FIRSTNAME);
+        fillField('#field-lastname', TEST_LASTNAME);
+        fillField('#field-id_country', TEST_COUNTRY_ID);
+        toggleCheckbox('#conditions', true);
+
+        expect(getPayButton().disabled).toBe(false);
+      });
+
+      it('should require billing fields when billing section is visible', () => {
+        // Uncheck "use same address" to show billing section
+        toggleCheckbox('.js-opc-use-same-address', false);
+
+        fillField('#field-email', TEST_EMAIL);
+        fillField('#field-firstname', TEST_FIRSTNAME);
+        fillField('#field-lastname', TEST_LASTNAME);
+        fillField('#field-id_country', TEST_COUNTRY_ID);
+        toggleCheckbox('#conditions', true);
+        // invoice fields left empty
+
+        expect(getPayButton().disabled).toBe(true);
+      });
+
+      it('should enable pay button when billing fields are also filled', () => {
+        toggleCheckbox('.js-opc-use-same-address', false);
+
+        fillField('#field-email', TEST_EMAIL);
+        fillField('#field-firstname', TEST_FIRSTNAME);
+        fillField('#field-lastname', TEST_LASTNAME);
+        fillField('#field-id_country', TEST_COUNTRY_ID);
+        fillField('#field-invoice_firstname', TEST_INVOICE_FIRSTNAME);
+        fillField('#field-invoice_lastname', TEST_LASTNAME);
+        toggleCheckbox('#conditions', true);
+
+        expect(getPayButton().disabled).toBe(false);
+      });
+    });
+
+    describe('without required fields', () => {
+      beforeEach(() => {
+        resetHTMLBodyContent(FormWithoutRequiredFields);
+        initOnePageCheckout();
+      });
+
+      it('should enable pay button when there are no required fields', () => {
+        expect(getPayButton().disabled).toBe(false);
+      });
+    });
+
+    describe('empty form', () => {
+      beforeEach(() => {
+        resetHTMLBodyContent(FormEmpty);
+        initOnePageCheckout();
+      });
+
+      it('should enable pay button when form has no fields at all', () => {
+        expect(getPayButton().disabled).toBe(false);
+      });
+    });
+  });
+
+  describe('initBillingToggle', () => {
+    beforeEach(() => {
+      resetHTMLBodyContent(FormWithRequiredFields);
+      initOnePageCheckout();
+    });
+
+    it('should hide billing section when checkbox is checked', () => {
+      expect(getBillingSection().style.display).toBe('none');
+    });
+
+    it('should show billing section when checkbox is unchecked', () => {
+      toggleCheckbox('.js-opc-use-same-address', false);
+      expect(getBillingSection().style.display).toBe('');
+    });
+
+    it('should hide billing section again when checkbox is re-checked', () => {
+      toggleCheckbox('.js-opc-use-same-address', false);
+      toggleCheckbox('.js-opc-use-same-address', true);
+      expect(getBillingSection().style.display).toBe('none');
+    });
+
+    it('should re-validate form after toggling billing section', () => {
+      // Fill all delivery fields + terms
+      fillField('#field-email', TEST_EMAIL);
+      fillField('#field-firstname', TEST_FIRSTNAME);
+      fillField('#field-lastname', TEST_LASTNAME);
+      fillField('#field-id_country', TEST_COUNTRY_ID);
+      toggleCheckbox('#conditions', true);
+
+      expect(getPayButton().disabled).toBe(false);
+
+      // Show billing section -> billing fields are empty -> should disable
+      toggleCheckbox('.js-opc-use-same-address', false);
+      expect(getPayButton().disabled).toBe(true);
+
+      // Hide billing section again -> should re-enable
+      toggleCheckbox('.js-opc-use-same-address', true);
+      expect(getPayButton().disabled).toBe(false);
+    });
+  });
+});

--- a/src/js/pages/one-page-checkout.ts
+++ b/src/js/pages/one-page-checkout.ts
@@ -1,0 +1,92 @@
+/**
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+import {onePageCheckout as OpcMap} from '@constants/selectors-map';
+
+let billingToggleHandler: ((e: Event) => void) | null = null;
+
+const initOnePageCheckout = () => {
+  const form = document.querySelector<HTMLFormElement>(OpcMap.form);
+
+  if (!form) {
+    return;
+  }
+
+  // Delegated listeners on the form (added once, survives DOM refreshes)
+  form.addEventListener('input', () => validateForm());
+  form.addEventListener('change', () => validateForm());
+
+  initBillingToggle();
+  validateForm();
+
+  const {prestashop} = window;
+
+  // Re-init after any address form refresh (country change or other)
+  prestashop.on('updatedOpcAddressForm', () => {
+    initBillingToggle();
+    validateForm();
+  });
+};
+
+/**
+ * Toggle billing address section visibility
+ */
+const initBillingToggle = () => {
+  const checkbox = document.querySelector<HTMLInputElement>(OpcMap.useSameAddress);
+  const billingSection = document.querySelector<HTMLElement>(OpcMap.billingSection);
+
+  if (!checkbox || !billingSection) {
+    return;
+  }
+
+  // Remove previous handler to avoid duplicates after DOM refresh
+  if (billingToggleHandler) {
+    checkbox.removeEventListener('change', billingToggleHandler);
+  }
+
+  billingToggleHandler = () => {
+    billingSection.style.display = checkbox.checked ? 'none' : '';
+    validateForm();
+  };
+
+  checkbox.addEventListener('change', billingToggleHandler);
+};
+
+/**
+ * Check all visible required fields and toggle pay button
+ */
+const validateForm = () => {
+  const form = document.querySelector<HTMLFormElement>(OpcMap.form);
+  const payButton = document.querySelector<HTMLButtonElement>(OpcMap.payButton);
+
+  if (!form || !payButton) {
+    return;
+  }
+
+  const requiredFields = form.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>(
+    '[required]',
+  );
+
+  let isValid = true;
+
+  requiredFields.forEach((field) => {
+    // Skip fields inside hidden billing section
+    const billingSection = field.closest(OpcMap.billingSection) as HTMLElement | null;
+
+    if (billingSection?.style.display === 'none') {
+      return;
+    }
+
+    const isCheckbox = field instanceof HTMLInputElement && field.type === 'checkbox';
+    const fieldIsValid = isCheckbox ? field.checked : Boolean(field.value?.trim());
+
+    if (!fieldIsValid) {
+      isValid = false;
+    }
+  });
+
+  payButton.disabled = !isValid;
+};
+
+export default initOnePageCheckout;

--- a/src/js/theme.ts
+++ b/src/js/theme.ts
@@ -9,6 +9,7 @@ import initResponsiveToggler from '@js/responsive-toggler';
 import initQuickview from '@js/quickview';
 import initCart from '@js/pages/cart';
 import initCheckout from '@js/pages/checkout';
+import initOnePageCheckout from '@js/pages/one-page-checkout';
 import initCustomer from '@js/pages/customer';
 import initProductBehavior from '@js/product';
 import initMobileMenu from '@js/mobile-menu';
@@ -44,6 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initProductBehavior();
   initQuickview();
   initCheckout();
+  initOnePageCheckout();
   initCustomer();
   initResponsiveToggler();
   initCart();
@@ -75,6 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initDesktopMenu();
   });
 });
+
 
 export const components = {
   useToast,

--- a/src/scss/prestashop/components/_form-fields-row.scss
+++ b/src/scss/prestashop/components/_form-fields-row.scss
@@ -1,0 +1,14 @@
+.form-fields-row {
+  display: grid;
+  gap: 1rem;
+
+  @include media-breakpoint-up(md) {
+    &--2 {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    &--3 {
+      grid-template-columns: 1fr 1fr 1fr;
+    }
+  }
+}

--- a/src/scss/prestashop/components/_index.scss
+++ b/src/scss/prestashop/components/_index.scss
@@ -1,4 +1,5 @@
 @import "buttons-wrapper";
+@import "form-fields-row";
 @import "currency-selector";
 @import "columns-block";
 @import "language-selector";

--- a/src/scss/prestashop/components/checkout/_index.scss
+++ b/src/scss/prestashop/components/checkout/_index.scss
@@ -2,3 +2,4 @@
 @import "checkout-final-summary";
 @import "checkout-payment-option";
 @import "checkout-steps";
+@import "one-page-checkout";

--- a/src/scss/prestashop/components/checkout/_one-page-checkout.scss
+++ b/src/scss/prestashop/components/checkout/_one-page-checkout.scss
@@ -1,0 +1,35 @@
+$component-name: one-page-checkout;
+
+.#{$component-name} {
+  @include media-breakpoint-up(lg) {
+    padding-right: 2em;
+  }
+
+  &__section {
+    padding-bottom: 2em;
+
+    & + &,
+    .js-opc-address-form + & {
+      border-top: 1px solid var(--bs-border-color);
+      padding-top: 2em;
+    }
+  }
+
+  &__links {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+  }
+
+  &__field {
+    margin-bottom: 1rem;
+  }
+
+  &__footer {
+    padding-top: 2em;
+
+    .form-check {
+      margin-bottom: 1rem;
+    }
+  }
+}

--- a/templates/_partials/form-fields-row.tpl
+++ b/templates/_partials/form-fields-row.tpl
@@ -1,0 +1,20 @@
+{**
+ * Multi-column form field row
+ *
+ * Renders an explicit set of form fields side by side on desktop, stacked on
+ * mobile. The grid column count is derived from the number of fields passed.
+ *
+ * This partial is intentionally "dumb": it only handles layout. The caller is
+ * responsible for deciding which fields belong together in the same row and for
+ * ensuring all passed fields actually exist before including this template.
+ *
+ *
+ * @param array $fields - Explicit list of form field objects to render in a row
+ *                        (2 or 3 items — matches CSS modifiers --2 and --3)
+ *}
+
+<div class="form-fields-row form-fields-row--{$fields|count}">
+  {foreach from=$fields item="field"}
+    {form_field field=$field}
+  {/foreach}
+</div>

--- a/templates/checkout/_partials/one-page-checkout-form.tpl
+++ b/templates/checkout/_partials/one-page-checkout-form.tpl
@@ -1,0 +1,81 @@
+{**
+ * One Page Checkout Form - All sections
+ * Rendered via {render ui=$opc_form}, provides $formFields from OnePageCheckoutForm.
+ * Contains: contact info, delivery address, billing address.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *}
+
+{hook h='displayPersonalInformationTop' customer=$customer}
+
+{include file='_partials/form-errors.tpl' errors=$errors['']}
+
+{* ===== Contact information ===== *}
+<section class="one-page-checkout__section">
+  <h2 class="one-page-checkout__title">{l s='Contact information' d='Shop.Theme.Checkout'}</h2>
+
+  <div class="one-page-checkout__links">
+    <a class="one-page-checkout__link" href="{$urls.pages.authentication}?back={$urls.pages.order}">
+      {l s='Already have an account? Sign in' d='Shop.Theme.Checkout'}
+    </a>
+    <a class="one-page-checkout__link" href="{$urls.pages.registration}">
+      {l s='Create account' d='Shop.Theme.Checkout'}
+    </a>
+  </div>
+
+  {if isset($formFields['email'])}
+    <div class="one-page-checkout__field">
+      <label class="form-label" for="field-email">{l s='Continue as guest' d='Shop.Theme.Checkout'}</label>
+      <input class="form-control" type="email" name="email" id="field-email" value="{$formFields['email']['value']}" required>
+    </div>
+  {/if}
+
+  {if isset($formFields['optin'])}
+    <div class="one-page-checkout__field">
+      {form_field field=$formFields['optin']}
+    </div>
+  {/if}
+</section>
+
+{* ===== Delivery address fields ===== *}
+<section class="one-page-checkout__section">
+  <h2 class="one-page-checkout__title">{l s='Delivery address' d='Shop.Theme.Checkout'}</h2>
+
+  <section class="form-fields">
+    {include file='checkout/_partials/one-page-checkout/address-fields.tpl'
+      formFields=$formFields
+      prefix=''
+    }
+
+    <input type="hidden" name="saveAddress" value="delivery">
+
+    <div class="form-check">
+      <input class="form-check-input js-opc-use-same-address" type="checkbox" id="opc-use-same-address" name="use_same_address" value="1" checked>
+      <label class="form-check-label" for="opc-use-same-address">
+        {l s='Use this address for invoice too' d='Shop.Theme.Checkout'}
+      </label>
+    </div>
+  </section>
+</section>
+
+{* ===== Billing address fields (hidden by default, JS manages visibility) ===== *}
+<section class="one-page-checkout__section" id="opc-billing-section" style="display: none;">
+  <h2 class="one-page-checkout__title">{l s='Billing address' d='Shop.Theme.Checkout'}</h2>
+
+  <section class="form-fields">
+    {include file='checkout/_partials/one-page-checkout/address-fields.tpl'
+      formFields=$formFields
+      prefix='invoice_'
+    }
+  </section>
+</section>
+
+{capture name="address_selector_bottom"}{hook h='displayAddressSelectorBottom'}{/capture}
+{if $smarty.capture.address_selector_bottom}
+  {block name='address_selector_bottom'}
+    <div class="address-selector-bottom mt-3">
+      {$smarty.capture.address_selector_bottom nofilter}
+    </div>
+  {/block}
+{/if}

--- a/templates/checkout/_partials/one-page-checkout/address-fields.tpl
+++ b/templates/checkout/_partials/one-page-checkout/address-fields.tpl
@@ -1,0 +1,106 @@
+{**
+ * One Page Checkout - Address fields partial
+ *
+ * Renders address fields from $formFields filtered by $prefix.
+ * Reused for both delivery (prefix='') and billing (prefix='invoice_').
+ *
+ * @param array  $formFields - All form fields from OnePageCheckoutForm
+ * @param string $prefix     - Field name prefix ('' or 'invoice_')
+ *
+ * --- Why is this template more complex than a simple foreach? ---
+ *
+ * PrestaShop provides form fields as a flat associative array. The field list
+ * and their presence depend on country configuration and shop settings, so we
+ * cannot assume any specific field will always exist.
+ *
+ * The design requires certain fields to be rendered side-by-side in multi-column
+ * rows (firstname+lastname, city+postcode+state). Smarty has no lookahead in a
+ * foreach loop, so we cannot "peek" at the next field to decide whether to open
+ * a row wrapper around it.
+ *
+ * The solution is a two-pass approach:
+ *   1. Pre-compute which grouped rows are possible (all required fields present).
+ *   2. Iterate the flat array; when the first field of a group is encountered,
+ *      render the whole row at once and skip the other fields of that group when
+ *      they appear later in the loop.
+ *
+ * This is intentionally verbose — any CSS-only alternative would require all
+ * fields to always be present in the DOM, which is not guaranteed here.
+ *}
+
+{* ===== Prefix length for stripping ===== *}
+{assign var="_prefix_len" value=$prefix|strlen}
+
+{* ===== Build prefixed key names ===== *}
+{assign var="_key_firstname" value="{$prefix}firstname"}
+{assign var="_key_lastname" value="{$prefix}lastname"}
+{assign var="_key_city" value="{$prefix}city"}
+{assign var="_key_postcode" value="{$prefix}postcode"}
+{assign var="_key_id_state" value="{$prefix}id_state"}
+
+{*
+  Pass 1 — pre-compute which grouped rows are available.
+  A row is only rendered if ALL its required fields exist; otherwise each field
+  falls back to the default single-column rendering.
+*}
+{assign var="_has_name_row" value=isset($formFields[$_key_firstname]) && isset($formFields[$_key_lastname])}
+{assign var="_has_city_row" value=isset($formFields[$_key_city]) && isset($formFields[$_key_postcode])}
+{assign var="_has_state" value=isset($formFields[$_key_id_state])}
+
+{* Pass 2 — render each field, grouping into multi-column rows where applicable *}
+{foreach from=$formFields item="field"}
+  {* Only render fields matching our prefix *}
+  {if $prefix && strpos($field.name, $prefix) !== 0}{continue}{/if}
+  {if !$prefix && strpos($field.name, 'invoice_') === 0}{continue}{/if}
+
+  {* Strip prefix to get the base field name used in comparisons below *}
+  {if $prefix}
+    {assign var="_base" value=$field.name|substr:$_prefix_len}
+  {else}
+    {assign var="_base" value=$field.name}
+  {/if}
+
+  {* ----- alias: always present but never displayed — emit as hidden input ----- *}
+  {if $_base === 'alias'}
+    <input type="hidden" name="{$field.name}" value="My address">
+
+  {* ----- Fields handled outside this partial (contact section, billing toggle) ----- *}
+  {elseif $_base === 'email' || $_base === 'optin' || $_base === 'use_same_address' || $_base === 'id_address_invoice'}
+    {* noop — rendered by the parent template *}
+
+  {* ----- Name row: firstname + lastname rendered together in 2 columns ----- *}
+  {* When firstname is encountered first, the whole row (both fields) is output.  *}
+  {* lastname is then skipped below to avoid a duplicate render.                  *}
+  {elseif $_base === 'firstname' && $_has_name_row}
+    {include file='_partials/form-fields-row.tpl'
+      fields=[$formFields[$_key_firstname], $formFields[$_key_lastname]]
+    }
+
+  {elseif $_base === 'lastname' && $_has_name_row}
+    {* Already rendered with firstname above *}
+
+  {* ----- Location row: city + postcode (+ state if present) in 2 or 3 columns ----- *}
+  {* Same pattern: city triggers the full row; postcode and id_state are skipped.      *}
+  {elseif $_base === 'city' && $_has_city_row}
+    {if $_has_state}
+      {include file='_partials/form-fields-row.tpl'
+        fields=[$formFields[$_key_city], $formFields[$_key_id_state], $formFields[$_key_postcode]]
+      }
+    {else}
+      {include file='_partials/form-fields-row.tpl'
+        fields=[$formFields[$_key_city], $formFields[$_key_postcode]]
+      }
+    {/if}
+
+  {elseif $_base === 'postcode' && $_has_city_row}
+    {* Already rendered with city above *}
+
+  {elseif $_base === 'id_state' && $_has_city_row}
+    {* Already rendered with city above *}
+
+  {* ----- Default: any other field renders in a single full-width column ----- *}
+  {else}
+    {form_field field=$field}
+
+  {/if}
+{/foreach}

--- a/templates/checkout/_partials/steps/one-page-checkout.tpl
+++ b/templates/checkout/_partials/steps/one-page-checkout.tpl
@@ -1,0 +1,88 @@
+{**
+ * One Page Checkout - Layout
+ * Thin wrapper: <form> + {render} + submit button.
+ * All sections are rendered inside one-page-checkout-form.tpl via {render ui=$opc_form}.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *}
+
+<form class="one-page-checkout" method="POST" action="{$urls.pages.order}" data-ps-action="form-validation">
+  <input type="hidden" name="submitOnePageCheckout" value="1">
+
+  <div class="js-opc-address-form">
+    {render ui=$opc_form}
+  </div>
+
+  {* ===== Delivery method ===== *}
+  <section class="one-page-checkout__section">
+    <h2 class="one-page-checkout__title">{l s='Delivery method' d='Shop.Theme.Checkout'}</h2>
+
+    <div id="delivery-options__hook">
+      {if isset($hookDisplayBeforeCarrier)}
+        {$hookDisplayBeforeCarrier nofilter}
+      {else}
+        {hook h='displayBeforeCarrier'}
+      {/if}
+    </div>
+
+    <div class="one-page-checkout__placeholder" id="opc-delivery-methods">
+      <div class="card card-body bg-light">
+        {l s='You will see the available delivery methods once you\'ve entered your delivery address.' d='Shop.Theme.Checkout'}
+      </div>
+    </div>
+
+    <div class="delivery-options__display-after-carrier" id="hook-display-after-carrier">
+      {if isset($hookDisplayAfterCarrier)}
+        {$hookDisplayAfterCarrier nofilter}
+      {else}
+        {hook h='displayAfterCarrier'}
+      {/if}
+    </div>
+
+    <div class="delivery-options__extra-carrier" id="extra_carrier"></div>
+  </section>
+
+  {* ===== Payment method ===== *}
+  <section class="one-page-checkout__section">
+    <h2 class="one-page-checkout__title">{l s='Payment method' d='Shop.Theme.Checkout'}</h2>
+
+    {hook h='displayPaymentTop'}
+
+    <div class="one-page-checkout__placeholder" id="opc-payment-methods">
+      <div class="card card-body bg-light">
+        {l s='You will see the available payment methods once you\'ve entered your delivery address.' d='Shop.Theme.Checkout'}
+      </div>
+    </div>
+  </section>
+
+  <div class="one-page-checkout__footer">
+    {* ===== Terms & conditions ===== *}
+    {if $conditions_to_approve|count}
+      {foreach from=$conditions_to_approve item="condition" key="condition_name"}
+        <div class="form-check">
+          <input id="conditions_to_approve[{$condition_name}]"
+                 name="conditions_to_approve[{$condition_name}]"
+                 required
+                 type="checkbox"
+                 value="1"
+                 class="form-check-input"
+          >
+          <label class="js-terms form-check-label" for="conditions_to_approve[{$condition_name}]">
+            {$condition nofilter}
+          </label>
+        </div>
+      {/foreach}
+    {/if}
+
+    {hook h='displayCheckoutBeforeConfirmation'}
+
+    {* ===== Pay button ===== *}
+    <button class="one-page-checkout__submit btn btn-primary btn-lg w-100" type="submit" id="opc-pay-button" disabled>
+      {l s='Pay' d='Shop.Theme.Checkout'} {$cart.totals.total.value}
+    </button>
+
+    {hook h='displayPaymentByBinaries'}
+  </div>
+
+</form>

--- a/templates/checkout/checkout.tpl
+++ b/templates/checkout/checkout.tpl
@@ -11,7 +11,9 @@
 {/block}
 
 {block name='content_columns'}
-  {include file='checkout/checkout-navigation.tpl'}
+  {if isset($is_one_page_checkout_enabled) && !$is_one_page_checkout_enabled}
+    {include file='checkout/checkout-navigation.tpl'}
+  {/if}
 
   {block name='checkout_notifications'}
     {include file='_partials/notifications.tpl'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Context | https://github.com/PrestaShop/PrestaShop/discussions/40913
| Description?      | Initialize new form for OPC feature.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Related PR?    |  https://github.com/PrestaShop/PrestaShop/pull/40864
| Sponsor company   | PrestaShop
| How to test?      | Activate OPC feature flag, and go to the checkout.

# Integrate the One-Page form skeleton with field validation
## Context:
OPC mode should allow a Guest visitor to place an order by providing only their email address + newsletter opt-in. Field validation should be done in real time (or on blur) without completely reloading the page.

## Objective:
Create the HTML/CSS/JS integration of the complete OPC form with real-time front-end validation for the Guest journey.

## Expected result:

OPC form visually integrated according to the mockups

Functional email and newsletter opt-in fields

Real-time validation (on blur or on input) of fields

No complete page reload during data entry

Inline display of validation errors
