### PR TITLE
fix: add id_product_attribute when adding to cart from product list

### DIFF
--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -78,6 +78,9 @@
             {if $product.add_to_cart_url}
               <form class="{$componentName}__form" action="{$urls.pages.cart}" method="post">
                 <input type="hidden" value="{$product.id_product}" name="id_product">
+                {if $product.id_product_attribute}
+                    <input type="hidden" value="{$product.id_product_attribute}" name="id_product_attribute">
+                {/if}
                 <input type="hidden" name="token" value="{$static_token}">
 
                 <div class="quantity-button js-quantity-button">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add missing id_product_attribute information to the product add to cart form (catalog listing)
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/hummingbird/issues/946
| Sponsor company   | VersusVenture (PrestaModule / BusinessTech)
| How to test?      | Install our module "Products by Attributes", try to add to cart a product that is using a specific `id_product_attribute` other than the default one. This value can also be changed using `actionGetProductPropertiesBefore` for example.
