### PR TITLE
fix: replace deprecated constant() Smarty call in progress-circle.tpl

### DIFF
--- a/templates/components/progress-circle.tpl
+++ b/templates/components/progress-circle.tpl
@@ -4,7 +4,7 @@
  *}
 
 {$radius = $size / 2 - $stroke * 2}
-{$circumference = $radius * 2 * constant('M_PI')}
+{$circumference = $radius * 2 * 3.14159265358979}
 
 {$circumference = $circumference|string_format:"%.4f"}
 


### PR DESCRIPTION
Replace `constant('M_PI')` with its literal value to remove the Smarty deprecation warning about unregistered PHP functions in templates.

Fixes #954

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Replace `constant('M_PI')` with its literal value `3.14159265358979` in `progress-circle.tpl`. Smarty no longer allows calling unregistered PHP functions directly in templates, which triggered a deprecation warning on every render of the component.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #954
| Sponsor company   | PrestaShop SA
| How to test?      | 1. Enable the Hummingbird theme. 2. Navigate to any page that renders the `progress-circle` component. 3. Check PHP error logs and verify the deprecation warning is gone. 4. Visually confirm the SVG circle renders correctly.
