### PR TITLE
Refactor product actions into a block

### DIFF
--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -74,42 +74,44 @@
             {/block}
           </div>
 
-          <div class="{$componentName}__actions">
-            {if $product.add_to_cart_url}
-              <form class="{$componentName}__form" action="{$urls.pages.cart}" method="post">
-                <input type="hidden" value="{$product.id_product}" name="id_product">
-                {if $product.id_product_attribute}
-                    <input type="hidden" value="{$product.id_product_attribute}" name="id_product_attribute">
-                {/if}
-                <input type="hidden" name="token" value="{$static_token}">
-
-                <div class="quantity-button js-quantity-button">
-                  {include file='components/qty-input.tpl'
-                    attributes=[
-                      "id" => "quantity_wanted_{$product.id_product}",
-                      "value" => "{$product.quantity_wanted}",
-                      "min" => "{$product.quantity_required}"
-                    ]
-                  }
-                </div>
-
-                <button 
-                  data-button-action="add-to-cart" 
-                  class="product-miniature__add btn btn-primary btn-square-icon"
-                  aria-label="{l s='Add to cart %product_name%' sprintf=['%product_name%' => $product.name] d='Shop.Theme.Actions'}"
-                  title="{l s='Add to cart %product_name%' sprintf=['%product_name%' => $product.name] d='Shop.Theme.Actions'}"
-                  data-ps-ref="add-to-cart"
-                >
-                  <i class="material-icons" aria-hidden="true">&#xe854;</i>
-                  <span class="product-miniature__add-text">{l s='Add to cart' d='Shop.Theme.Actions'}</span>
-                </button>
-              </form>
-            {else}
-              <a href="{$product.url}" class="product-miniature__details btn btn-outline-primary" aria-label="{l s='View product %product_name%' sprintf=['%product_name%' => $product.name] d='Shop.Theme.Catalog'}">
-                {l s='See details' d='Shop.Theme.Actions'}
-              </a>
-            {/if}
-          </div>
+          {block name='product_actions'}
+            <div class="{$componentName}__actions">
+              {if $product.add_to_cart_url}
+                <form class="{$componentName}__form" action="{$urls.pages.cart}" method="post">
+                  <input type="hidden" value="{$product.id_product}" name="id_product">
+                  {if $product.id_product_attribute}
+                      <input type="hidden" value="{$product.id_product_attribute}" name="id_product_attribute">
+                  {/if}
+                  <input type="hidden" name="token" value="{$static_token}">
+  
+                  <div class="quantity-button js-quantity-button">
+                    {include file='components/qty-input.tpl'
+                      attributes=[
+                        "id" => "quantity_wanted_{$product.id_product}",
+                        "value" => "{$product.quantity_wanted}",
+                        "min" => "{$product.quantity_required}"
+                      ]
+                    }
+                  </div>
+  
+                  <button 
+                    data-button-action="add-to-cart" 
+                    class="product-miniature__add btn btn-primary btn-square-icon"
+                    aria-label="{l s='Add to cart %product_name%' sprintf=['%product_name%' => $product.name] d='Shop.Theme.Actions'}"
+                    title="{l s='Add to cart %product_name%' sprintf=['%product_name%' => $product.name] d='Shop.Theme.Actions'}"
+                    data-ps-ref="add-to-cart"
+                  >
+                    <i class="material-icons" aria-hidden="true">&#xe854;</i>
+                    <span class="product-miniature__add-text">{l s='Add to cart' d='Shop.Theme.Actions'}</span>
+                  </button>
+                </form>
+              {else}
+                <a href="{$product.url}" class="product-miniature__details btn btn-outline-primary" aria-label="{l s='View product %product_name%' sprintf=['%product_name%' => $product.name] d='Shop.Theme.Catalog'}">
+                  {l s='See details' d='Shop.Theme.Actions'}
+                </a>
+              {/if}
+            </div>
+          {/block}
         </div>
       {/block}
     </div>


### PR DESCRIPTION
I wrapped the product actions div in product.tpl within a Smarty block named product_actions. This improvement allows developers to easily override the add-to-cart section in child themes without the need to duplicate the entire template file.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | I wrapped the product actions div in product.tpl within a Smarty block named product_actions. This improvement allows developers to easily override the add-to-cart section in child themes without the need to duplicate the entire template file.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #952
| Sponsor company   | MaoDev
| How to test?      | 1. Create a child theme of Hummingbird.2. Create the file templates/catalog/_partials/miniatures/product.tpl in the child theme.3. Use {extends file='parent:catalog/_partials/miniatures/product.tpl'} and try to override only the {block name='product_actions'}.4. Verify that the changes are correctly applied in the product miniature on the front office.
