### PR TITLE
Fix checkout step hook navigation

### DIFF
--- a/templates/checkout/_partials/checkout-navigation-step.tpl
+++ b/templates/checkout/_partials/checkout-navigation-step.tpl
@@ -18,9 +18,6 @@
     data-bs-target="#{$step}"
     role="tab"
     data-ps-ref="step-button"
-    {if isset($virtual) && $virtual}
-      disabled
-    {/if}
   >
     {$title}
   </button>

--- a/templates/checkout/_partials/checkout-step-buttons.tpl
+++ b/templates/checkout/_partials/checkout-step-buttons.tpl
@@ -5,7 +5,7 @@
 
 {if isset($previous_step) && (!isset($show_back_button) || $show_back_button)}
   <button class="btn btn-outline-primary js-back" type="button" data-step="{$previous_step.identifier}">
-    <i class="material-icons rtl-flip" aria-hidden="true">&#xE5C4;</div>
+    <i class="material-icons rtl-flip" aria-hidden="true">&#xE5C4;</i>
     {l s='Back to %step_title%' d='Shop.Theme.Actions' sprintf=['%step_title%' => $previous_step.title]}
   </button>
 {/if}
@@ -13,6 +13,6 @@
 {if isset($next_step) && (!isset($show_next_button) || $show_next_button)}
   <button type="{if isset($submit_type)}{$submit_type}{else}submit{/if}" class="btn btn-primary" {if isset($submit_name)}name="{$submit_name}"{/if} {if isset($submit_value)}value="{$submit_value}"{/if}>
     {l s='Continue to %step_title%' d='Shop.Theme.Actions' sprintf=['%step_title%' => $next_step.title]}
-    <i class="material-icons rtl-flip" aria-hidden="true">&#xE5C8;</div>
+    <i class="material-icons rtl-flip" aria-hidden="true">&#xE5C8;</i>
   </button>
 {/if}

--- a/templates/checkout/_partials/checkout-step-buttons.tpl
+++ b/templates/checkout/_partials/checkout-step-buttons.tpl
@@ -5,14 +5,14 @@
 
 {if isset($previous_step) && (!isset($show_back_button) || $show_back_button)}
   <button class="btn btn-outline-primary js-back" type="button" data-step="{$previous_step.identifier}">
-    <div class="material-icons rtl-flip" aria-hidden="true">&#xE5C4;</div>
-    {l s='Back to %step_title%' d='Shop.Theme.Checkout' sprintf=['%step_title%' => $previous_step.title]}
+    <i class="material-icons rtl-flip" aria-hidden="true">&#xE5C4;</div>
+    {l s='Back to %step_title%' d='Shop.Theme.Actions' sprintf=['%step_title%' => $previous_step.title]}
   </button>
 {/if}
 
 {if isset($next_step) && (!isset($show_next_button) || $show_next_button)}
   <button type="{if isset($submit_type)}{$submit_type}{else}submit{/if}" class="btn btn-primary" {if isset($submit_name)}name="{$submit_name}"{/if} {if isset($submit_value)}value="{$submit_value}"{/if}>
-    {l s='Continue to %step_title%' d='Shop.Theme.Checkout' sprintf=['%step_title%' => $next_step.title]}
-    <div class="material-icons rtl-flip" aria-hidden="true">&#xE5C8;</div>
+    {l s='Continue to %step_title%' d='Shop.Theme.Actions' sprintf=['%step_title%' => $next_step.title]}
+    <i class="material-icons rtl-flip" aria-hidden="true">&#xE5C8;</div>
   </button>
 {/if}

--- a/templates/checkout/_partials/checkout-step-navigation.tpl
+++ b/templates/checkout/_partials/checkout-step-navigation.tpl
@@ -1,0 +1,18 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{if isset($previous_step) && (!isset($show_back_button) || $show_back_button)}
+  <button class="btn btn-outline-primary js-back" type="button" data-step="{$previous_step.identifier}">
+    <div class="material-icons rtl-flip" aria-hidden="true">&#xE5C4;</div>
+    {l s='Back to %step_title%' d='Shop.Theme.Checkout' sprintf=['%step_title%' => $previous_step.title]}
+  </button>
+{/if}
+
+{if isset($next_step) && (!isset($show_next_button) || $show_next_button)}
+  <button type="{if isset($submit_type)}{$submit_type}{else}submit{/if}" class="btn btn-primary" {if isset($submit_name)}name="{$submit_name}"{/if} {if isset($submit_value)}value="{$submit_value}"{/if}>
+    {l s='Continue to %step_title%' d='Shop.Theme.Checkout' sprintf=['%step_title%' => $next_step.title]}
+    <div class="material-icons rtl-flip" aria-hidden="true">&#xE5C8;</div>
+  </button>
+{/if}

--- a/templates/checkout/_partials/steps/addresses.tpl
+++ b/templates/checkout/_partials/steps/addresses.tpl
@@ -101,10 +101,10 @@
       {/if}
 
       <div class="buttons-wrapper buttons-wrapper--split buttons-wrapper--invert-mobile mt-3">
-        {include file='checkout/_partials/checkout-step-navigation.tpl' show_next_button=false}
+        {include file='checkout/_partials/checkout-step-buttons.tpl' show_next_button=false}
 
         {if !$form_has_continue_button}
-          {include file='checkout/_partials/checkout-step-navigation.tpl' show_back_button=false submit_name='confirm-addresses' submit_value='1'}
+          {include file='checkout/_partials/checkout-step-buttons.tpl' show_back_button=false submit_name='confirm-addresses' submit_value='1'}
           <input type="hidden" id="not-valid-addresses" class="js-not-valid-addresses" value="{$not_valid_addresses}">
         {/if}
       </div>

--- a/templates/checkout/_partials/steps/addresses.tpl
+++ b/templates/checkout/_partials/steps/addresses.tpl
@@ -101,24 +101,10 @@
       {/if}
 
       <div class="buttons-wrapper buttons-wrapper--split buttons-wrapper--invert-mobile mt-3">
-        <button class="btn btn-outline-primary js-back" type="button" data-step="checkout-personal-information-step">
-          <i class="material-icons rtl-flip" aria-hidden="true">&#xE5C4;</i>
-          {l s='Back to Personal Information' d='Shop.Theme.Actions'}
-        </button>
+        {include file='checkout/_partials/checkout-step-navigation.tpl' show_next_button=false}
 
         {if !$form_has_continue_button}
-          {if !$cart.is_virtual}
-            <button type="submit" class="btn btn-primary" name="confirm-addresses" value="1">
-              {l s='Continue to Shipping' d='Shop.Theme.Actions'}
-              <div class="material-icons rtl-flip" aria-hidden="true">&#xE5C8;</div>
-            </button>
-          {else}
-            <button type="submit" class="btn btn-primary" name="confirm-addresses" value="1">
-              {l s='Continue to Payment' d='Shop.Theme.Actions'}
-              <div class="material-icons rtl-flip" aria-hidden="true">&#xE5C8;</div>
-            </button>
-          {/if}
-
+          {include file='checkout/_partials/checkout-step-navigation.tpl' show_back_button=false submit_name='confirm-addresses' submit_value='1'}
           <input type="hidden" id="not-valid-addresses" class="js-not-valid-addresses" value="{$not_valid_addresses}">
         {/if}
       </div>

--- a/templates/checkout/_partials/steps/checkout-step.tpl
+++ b/templates/checkout/_partials/steps/checkout-step.tpl
@@ -3,6 +3,21 @@
  * LICENSE.md file that was distributed with this source code.
  *}
 {block name='step'}
+  {$previous_step = null}
+  {$next_step = null}
+  {if isset($checkout_steps)}
+    {foreach from=$checkout_steps item="step" key="index"}
+      {if $step.identifier == $identifier}
+        {if isset($checkout_steps[$index - 1])}
+          {$previous_step = $checkout_steps[$index - 1]}
+        {/if}
+        {if isset($checkout_steps[$index + 1])}
+          {$next_step = $checkout_steps[$index + 1]}
+        {/if}
+        {break}
+      {/if}
+    {/foreach}
+  {/if}
   <section 
     id="{$identifier}" 
     class="{[

--- a/templates/checkout/_partials/steps/payment.tpl
+++ b/templates/checkout/_partials/steps/payment.tpl
@@ -156,17 +156,7 @@
   {/if}
 
   <div class="buttons-wrapper buttons-wrapper--split buttons-wrapper--invert-mobile mt-3">
-    {if !$cart.is_virtual}
-      <button class="btn btn-outline-primary js-back" type="button" data-step="checkout-delivery-step">
-        <div class="material-icons rtl-flip" aria-hidden="true">&#xE5C4;</div>
-        {l s='Back to Shipping' d='Shop.Theme.Actions'}
-      </button>
-    {else}
-      <button class="btn btn-outline-primary js-back" type="button" data-step="checkout-addresses-step">
-        <div class="material-icons rtl-flip" aria-hidden="true">&#xE5C4;</div>
-        {l s='Back to Addresses' d='Shop.Theme.Actions'}
-      </button>
-    {/if}
+    {include file='checkout/_partials/checkout-step-navigation.tpl' show_next_button=false}
 
     <div id="payment-confirmation" class="js-payment-confirmation">
       <div class="ps-shown-by-js">

--- a/templates/checkout/_partials/steps/payment.tpl
+++ b/templates/checkout/_partials/steps/payment.tpl
@@ -156,7 +156,7 @@
   {/if}
 
   <div class="buttons-wrapper buttons-wrapper--split buttons-wrapper--invert-mobile mt-3">
-    {include file='checkout/_partials/checkout-step-navigation.tpl' show_next_button=false}
+    {include file='checkout/_partials/checkout-step-buttons.tpl' show_next_button=false}
 
     <div id="payment-confirmation" class="js-payment-confirmation">
       <div class="ps-shown-by-js">

--- a/templates/checkout/_partials/steps/personal-information.tpl
+++ b/templates/checkout/_partials/steps/personal-information.tpl
@@ -45,7 +45,7 @@
 
     <form id="checkout-continue-form" method="GET" action="{$urls.pages.order}">
       <div class="buttons-wrapper buttons-wrapper--end mt-3">
-        {include file='checkout/_partials/checkout-step-navigation.tpl' submit_name='controller' submit_value='order'}
+        {include file='checkout/_partials/checkout-step-buttons.tpl' submit_name='controller' submit_value='order'}
       </div>
     </form>
   {else}

--- a/templates/checkout/_partials/steps/personal-information.tpl
+++ b/templates/checkout/_partials/steps/personal-information.tpl
@@ -45,15 +45,7 @@
 
     <form id="checkout-continue-form" method="GET" action="{$urls.pages.order}">
       <div class="buttons-wrapper buttons-wrapper--end mt-3">
-        <button
-          class="btn btn-primary"
-          name="controller"
-          type="submit"
-          value="order"
-        >
-          {l s='Continue to Addresses' d='Shop.Theme.Actions'}
-          <i class="material-icons rtl-flip" aria-hidden="true">&#xE5C8;</i>
-        </button>
+        {include file='checkout/_partials/checkout-step-navigation.tpl' submit_name='controller' submit_value='order'}
       </div>
     </form>
   {else}

--- a/templates/checkout/_partials/steps/shipping.tpl
+++ b/templates/checkout/_partials/steps/shipping.tpl
@@ -89,15 +89,7 @@
         </div>
 
         <div class="buttons-wrapper buttons-wrapper--split buttons-wrapper--invert-mobile mt-3">
-          <button class="btn btn-outline-primary js-back" type="button" data-step="checkout-addresses-step">
-            <div class="material-icons rtl-flip" aria-hidden="true">&#xE5C4;</div>
-            {l s='Back to Addresses' d='Shop.Theme.Actions'}
-          </button>
-
-          <button type="submit" class="btn btn-primary" name="confirmDeliveryOption" value="1">
-            {l s='Continue to Payment' d='Shop.Theme.Actions'}
-            <div class="material-icons rtl-flip" aria-hidden="true">&#xE5C8;</div>
-          </button>
+          {include file='checkout/_partials/checkout-step-navigation.tpl' submit_name='confirmDeliveryOption' submit_value='1'}
         </div>
       </form>
     {else}

--- a/templates/checkout/_partials/steps/shipping.tpl
+++ b/templates/checkout/_partials/steps/shipping.tpl
@@ -89,7 +89,7 @@
         </div>
 
         <div class="buttons-wrapper buttons-wrapper--split buttons-wrapper--invert-mobile mt-3">
-          {include file='checkout/_partials/checkout-step-navigation.tpl' submit_name='confirmDeliveryOption' submit_value='1'}
+          {include file='checkout/_partials/checkout-step-buttons.tpl' submit_name='confirmDeliveryOption' submit_value='1'}
         </div>
       </form>
     {else}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR makes the checkout step buttons dynamic. It introduces accessibility labels that automatically adapt to the next or previous step, whether it's a native step or injected via a Hook.
| Type?             | bug fix / improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #719
| Sponsor company   | @PrestaShopCorp
| How to test?      | You can test with this module [ps_testcheckouthook_2.zip](https://github.com/user-attachments/files/26542118/ps_testcheckouthook_2.zip). Need to be on PS 9.1.x branche to make this test. Now you have dynamic button to continue and back included next en previous step name inside it. The module use the hook to test it well.

> [!NOTE]
> A final PR will be required on the Core side. Currently, the "next step" behavior is unpredictable, as it redirects users to the furthest possible page based on the submitted data rather than following a linear flow.