### PR TITLE
fix ps_customersignin.tpl Sign in url

### DIFF
--- a/modules/ps_customersignin/ps_customersignin.tpl
+++ b/modules/ps_customersignin/ps_customersignin.tpl
@@ -119,7 +119,7 @@
 
           <div class="dropdown-divider"></div>
 
-          <a 
+          <a
             href="{$logout_url}"
             class="dropdown-item"
             rel="nofollow"
@@ -132,7 +132,11 @@
     {else}
       <div class="header-block">
         <a
-          href="{$urls.pages.authentication}?back={$urls.current_url|urlencode}"
+          {if $page.page_name == 'authentication'}
+            href="{$urls.pages.authentication}?back={$urls.pages.my_account|urlencode}"
+          {else}
+            href="{$urls.pages.authentication}?back={$urls.current_url|urlencode}"
+          {/if}
           class="header-block__action-btn"
           rel="nofollow"
           aria-label="{l s='Sign in' d='Shop.Theme.Actions'}"


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | While logged out, if you click on the Sign in button the first time, you'll be redirected to the authentication page. You'll see that the url is correct, but if you click on that button again while staying in the authentication page, you will see that the current_url ( /login?back=http... ) will be appended to the "back" query parameter, so it will grow everytime you click on the Sign in button while staying in the authentication page.
| Type?             | improvement
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes [973](https://github.com/PrestaShop/hummingbird/issues/973)
| Sponsor company   | www.hostinato.it
| How to test?      | check if the href in the Sign in button stays the same if you're currently in the authentication page
