### PR TITLE
Add dynamic fragment hooks to Hummingbird product templates

### DIFF
--- a/templates/_partials/notifications.tpl
+++ b/templates/_partials/notifications.tpl
@@ -3,6 +3,13 @@
  * LICENSE.md file that was distributed with this source code.
  *}
 
+{hook h='displayDynamicFragmentBefore'
+  name='notifications'
+  template='_partials/notifications.tpl'
+  notifications=$notifications|default:false
+  page=$page|default:false
+  product=$product|default:false
+}
 {if isset($notifications)}
 <div id="notifications">
   <div class="container">
@@ -76,3 +83,10 @@
   </div>
 </div>
 {/if}
+{hook h='displayDynamicFragmentAfter'
+  name='notifications'
+  template='_partials/notifications.tpl'
+  notifications=$notifications|default:false
+  page=$page|default:false
+  product=$product|default:false
+}

--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -88,7 +88,17 @@
             {/block}
 
             {block name='product_add_to_cart'}
+              {hook h='displayDynamicFragmentBefore'
+                name='product_add_to_cart'
+                template='catalog/_partials/product-add-to-cart.tpl'
+                product=$product
+              }
               {include file='catalog/_partials/product-add-to-cart.tpl'}
+              {hook h='displayDynamicFragmentAfter'
+                name='product_add_to_cart'
+                template='catalog/_partials/product-add-to-cart.tpl'
+                product=$product
+              }
             {/block}
 
             {block name='product_additional_info'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR adds two generic hooks around dynamic product page fragments in the Hummingbird theme:<br/>- `displayDynamicFragmentBefore`<br/>- `displayDynamicFragmentAfter`<br/><br/>The hooks are added around the product add-to-cart block and the notifications block, allowing modules to handle context-dependent markup without overriding full templates or modifying controllers.| Type?             | bug fix / improvement / new feature / refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/41310
| Sponsor company   | Codencode snc
| How to test?      | 
