### PR TITLE
Fix The WebPack preloadFonts configuration incorrectly resolves font …

### DIFF
--- a/webpack/webpack.parts.js
+++ b/webpack/webpack.parts.js
@@ -193,6 +193,7 @@ exports.preloadFonts = () => ({
       extensions: ['woff2'],
       filter: /(materialicons)/i,
       replaceCallback: ({ indexSource, linksAsString }) => {
+        linksAsString = linksAsString.replace(/null:nullnull/g, '../');
         return indexSource.replace('{{{preloadLinks}}}', linksAsString);
       },
     }),


### PR DESCRIPTION
Fix issue: The WebPack preloadFonts configuration incorrectly resolves font URLs in npm run watch mode.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix issue: The WebPack preloadFonts configuration incorrectly resolves font URLs in npm run watch mode.
| Type?             | bug fix
| BC breaks?        | yes / no
| Deprecations?     | no
| Fixed ticket?     | Fixes #989
| Sponsor company   | Metin EREN
| How to test?      | Steps to reproduce:
1. Open Terminal
2. Change directory to cd /prestashop/themes/hummingbird/
3. run the npm install command
4. run the npm run watch
5. look at the /prestashop/themes/hummingbird/assets/preload.html
