### PR TITLE
Feat: enhance checkout experience with one-page checkout

### DIFF
--- a/modules/ps_shoppingcart/modal.tpl
+++ b/modules/ps_shoppingcart/modal.tpl
@@ -103,9 +103,7 @@
         <button type="button" class="btn btn-outline-primary btn-with-icon" data-bs-dismiss="modal">
           {l s='Continue shopping' d='Shop.Theme.Actions'}
         </button>
-
         <a href="{$cart_url|escape:'htmlall':'UTF-8'}" class="btn btn-primary">{l s='Proceed to checkout' d='Shop.Theme.Actions'}</a>
-
         {capture name='cart_modal_footer'}{hook h='displayCartModalFooter' product=$product}{/capture}
         {if $smarty.capture.cart_modal_footer}
           <div class="blockcart-modal__cart-footer-extra">

--- a/src/js/constants/mocks/onePageCheckout-data.ts
+++ b/src/js/constants/mocks/onePageCheckout-data.ts
@@ -1,0 +1,89 @@
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+export const FormWithRequiredFields = `
+  <form id="opc-form" class="one-page-checkout" method="POST">
+    <input type="email" name="email" id="field-email" required>
+    <input type="text" name="firstname" id="field-firstname" required>
+    <input type="text" name="lastname" id="field-lastname" required>
+    <select name="id_country" id="field-id_country" required>
+      <option value="" disabled selected>-- please choose --</option>
+      <option value="8">France</option>
+    </select>
+
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" id="opc-use-same-address" name="use_same_address" value="1" checked>
+    </div>
+
+    <section id="opc-billing-section" style="display: none;">
+      <input type="text" name="invoice_firstname" id="field-invoice_firstname" required>
+      <input type="text" name="invoice_lastname" id="field-invoice_lastname" required>
+    </section>
+
+    <div class="form-check">
+      <input type="checkbox" name="conditions_to_approve[terms-and-conditions]" id="conditions" required class="form-check-input">
+    </div>
+
+    <button type="submit" id="opc-pay-button" disabled>Pay</button>
+  </form>
+`;
+
+export const FormWithoutRequiredFields = `
+  <form id="opc-form" class="one-page-checkout" method="POST">
+    <input type="text" name="phone" id="field-phone">
+    <button type="submit" id="opc-pay-button" disabled>Pay</button>
+  </form>
+`;
+
+export const FormEmpty = `
+  <form id="opc-form" class="one-page-checkout" method="POST">
+    <button type="submit" id="opc-pay-button" disabled>Pay</button>
+  </form>
+`;
+
+export const FormWithCarriersContainer = `
+  <form id="opc-form" class="one-page-checkout" method="POST" action="/order">
+    <select name="id_country" id="field-id_country">
+      <option value="" disabled selected>-- choose --</option>
+      <option value="8">France</option>
+    </select>
+    <input type="text" name="postcode" id="field-postcode">
+    <input type="text" name="city" id="field-city">
+    <div id="opc-delivery-methods">
+      <div class="card card-body bg-light">Enter your address to see carriers.</div>
+    </div>
+    <button type="submit" id="opc-pay-button" disabled>Pay</button>
+  </form>
+`;
+
+export const mockCarriersResponse = {
+  // eslint-disable-next-line max-len
+  carriers_html: '<div class="delivery-options__list"><input type="radio" name="delivery_option" value="1,">Colissimo<input type="radio" name="delivery_option" value="2,">Chronopost</div>',
+  delivery_options: {
+    '1,': {
+      id: 1,
+      name: 'Colissimo',
+      delay: '2-3 days',
+      price: '€5.00',
+      logo: null,
+    },
+    '2,': {
+      id: 2,
+      name: 'Chronopost',
+      delay: '1 day',
+      price: '€10.00',
+      logo: null,
+    },
+  },
+  selected_delivery_option: '1,',
+  carrier_was_reset: false,
+};
+
+export const mockEmptyCarriersResponse = {
+  carriers_html: '<p class="alert alert-warning mb-0">Unfortunately, there are no carriers available.</p>',
+  delivery_options: {},
+  selected_delivery_option: null,
+  carrier_was_reset: false,
+};

--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -127,6 +127,14 @@ export const visiblePassword = {
   visiblePassword: '[data-ps-action="toggle-password"]',
 };
 
+export const onePageCheckout = {
+  form: '#opc-form',
+  useSameAddress: '#opc-use-same-address',
+  billingSection: '#opc-billing-section',
+  payButton: '#opc-pay-button',
+  deliveryMethods: '#opc-delivery-methods',
+};
+
 export const gdpr = {
   consent: '[data-ps-ref="gdpr-consent"]',
   consentWrapper: '[data-ps-component="gdpr"]',
@@ -260,6 +268,7 @@ const selectorsMap = {
   formValidation,
   passwordPolicy,
   emailAlerts,
+  onePageCheckout,
   gdpr,
 };
 

--- a/src/js/pages/one-page-checkout.test.ts
+++ b/src/js/pages/one-page-checkout.test.ts
@@ -1,0 +1,59 @@
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+import initEmitter from '@js/prestashop';
+import initOnePageCheckout from '@js/pages/one-page-checkout';
+
+const SUMMARY_SELECTOR = '#cart-summary';
+const COLLAPSE_ID = 'cart-summary-product-list';
+
+const buildSummaryHTML = (open: boolean): string => `
+  <div id="cart-summary">
+    <button data-bs-target="#${COLLAPSE_ID}" aria-expanded="${open ? 'true' : 'false'}" class="${open ? '' : 'collapsed'}">
+      Show details
+    </button>
+    <div id="${COLLAPSE_ID}" class="accordion-collapse${open ? ' show' : ''}"></div>
+  </div>
+`;
+
+describe('One Page Checkout — accordion state preservation', () => {
+  beforeAll(() => {
+    window.prestashop = {};
+    initEmitter();
+    window.prestashop.selectors = {
+      checkout: {summarySelector: SUMMARY_SELECTOR},
+    };
+    initOnePageCheckout();
+  });
+
+  it('restores open accordion after cart summary DOM replacement', () => {
+    document.body.innerHTML = buildSummaryHTML(true);
+
+    window.prestashop.emit('opcCartSummaryBeforeUpdate', {selector: SUMMARY_SELECTOR});
+
+    // Replace the DOM as updateCartSummary would
+    document.body.innerHTML = buildSummaryHTML(false);
+
+    window.prestashop.emit('opcCartSummaryUpdated', {selector: SUMMARY_SELECTOR});
+
+    const collapse = document.getElementById(COLLAPSE_ID)!;
+    const btn = document.querySelector(`[data-bs-target="#${COLLAPSE_ID}"]`)!;
+
+    expect(collapse.classList.contains('show')).toBe(true);
+    expect(btn.classList.contains('collapsed')).toBe(false);
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('does not restore closed accordion after DOM replacement', () => {
+    document.body.innerHTML = buildSummaryHTML(false);
+
+    window.prestashop.emit('opcCartSummaryBeforeUpdate', {selector: SUMMARY_SELECTOR});
+    document.body.innerHTML = buildSummaryHTML(false);
+    window.prestashop.emit('opcCartSummaryUpdated', {selector: SUMMARY_SELECTOR});
+
+    const collapse = document.getElementById(COLLAPSE_ID)!;
+
+    expect(collapse.classList.contains('show')).toBe(false);
+  });
+});

--- a/src/js/pages/one-page-checkout.ts
+++ b/src/js/pages/one-page-checkout.ts
@@ -1,0 +1,59 @@
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+/**
+ * One Page Checkout — theme entry point
+ *
+ * The core (opc-form.js, opc-carrier-list.js, opc-carrier-select.js) owns
+ * the full OPC lifecycle:
+ *   - Form validation and pay button gating
+ *   - Billing section toggle
+ *   - Carrier list fetch, loader and error states
+ *   - Cart summary and pay button amount update
+ *
+ * Add theme-specific behaviour here only — the core handles everything else.
+ */
+
+const initOnePageCheckout = (): void => {
+  const {prestashop, Theme} = window;
+
+  // Account created toast: displayed once after returning from registration via `back=...`
+  const toastTriggerEl = document.querySelector<HTMLElement>('#js-account-created-toast');
+
+  if (toastTriggerEl?.dataset.show === '1') {
+    const toastMessage = toastTriggerEl.dataset.message || 'Account successfully created';
+    const toast = Theme?.components?.useToast?.(toastMessage, {type: 'success'});
+    toast?.show?.();
+  }
+
+  // Preserve Bootstrap accordion open state across cart summary DOM replacements.
+  let openCollapseIds: string[] = [];
+
+  prestashop.on('opcCartSummaryBeforeUpdate', ({selector}: {selector: string}) => {
+    openCollapseIds = Array.from(document.querySelectorAll(`${selector} .accordion-collapse.show`))
+      .map((el) => el.id)
+      .filter(Boolean);
+  });
+
+  prestashop.on('opcCartSummaryUpdated', () => {
+    openCollapseIds.forEach((id) => {
+      const el = document.getElementById(id);
+
+      if (!el) return;
+
+      el.classList.add('show');
+
+      const btn = document.querySelector(`[data-bs-target="#${id}"]`);
+
+      if (btn) {
+        btn.classList.remove('collapsed');
+        btn.setAttribute('aria-expanded', 'true');
+      }
+    });
+    openCollapseIds = [];
+  });
+};
+
+export default initOnePageCheckout;

--- a/src/js/theme.ts
+++ b/src/js/theme.ts
@@ -9,6 +9,7 @@ import initResponsiveToggler from '@js/responsive-toggler';
 import initQuickview from '@js/quickview';
 import initCart from '@js/pages/cart';
 import initCheckout from '@js/pages/checkout';
+import initOnePageCheckout from '@js/pages/one-page-checkout';
 import initCustomer from '@js/pages/customer';
 import initProductBehavior from '@js/product';
 import initMobileMenu from '@js/mobile-menu';
@@ -44,6 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initProductBehavior();
   initQuickview();
   initCheckout();
+  initOnePageCheckout();
   initCustomer();
   initResponsiveToggler();
   initCart();

--- a/src/scss/prestashop/components/_form-fields-row.scss
+++ b/src/scss/prestashop/components/_form-fields-row.scss
@@ -1,0 +1,18 @@
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+.form-fields-row {
+  display: grid;
+  gap: 1rem;
+
+  @include media-breakpoint-up(md) {
+    &--2 {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    &--3 {
+      grid-template-columns: 1fr 1fr 1fr;
+    }
+  }
+}

--- a/src/scss/prestashop/components/_index.scss
+++ b/src/scss/prestashop/components/_index.scss
@@ -3,6 +3,7 @@
  * LICENSE.md file that was distributed with this source code.
  */
 @import "buttons-wrapper";
+@import "form-fields-row";
 @import "currency-selector";
 @import "columns-block";
 @import "language-selector";

--- a/src/scss/prestashop/components/checkout/_index.scss
+++ b/src/scss/prestashop/components/checkout/_index.scss
@@ -6,3 +6,4 @@
 @import "checkout-final-summary";
 @import "checkout-payment-option";
 @import "checkout-steps";
+@import "one-page-checkout";

--- a/src/scss/prestashop/components/checkout/_one-page-checkout.scss
+++ b/src/scss/prestashop/components/checkout/_one-page-checkout.scss
@@ -1,0 +1,47 @@
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+$component-name: one-page-checkout;
+
+.#{$component-name} {
+  @include media-breakpoint-up(lg) {
+    padding-right: 2em;
+  }
+
+  &__section {
+    padding-top: 1em;
+    padding-bottom: 1em;
+
+    & + &,
+    .js-opc-addresses-section + & {
+      padding-top: 2em;
+      border-top: 1px solid var(--bs-border-color);
+    }
+  }
+
+  &__links {
+    display: flex;
+    flex-wrap: wrap-reverse;
+    gap: 0.5rem;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+  }
+
+  &__field {
+    margin-bottom: 1rem;
+  }
+
+  &__footer {
+    padding-top: 2em;
+
+    .form-check {
+      margin-bottom: 1rem;
+    }
+  }
+
+  .opc-address-item .form-check-input,
+  .opc-address-item .form-check-label {
+    cursor: pointer;
+  }
+}

--- a/templates/_partials/form-fields-row.tpl
+++ b/templates/_partials/form-fields-row.tpl
@@ -1,0 +1,25 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{**
+ * Multi-column form field row
+ *
+ * Renders an explicit set of form fields side by side on desktop, stacked on
+ * mobile. The grid column count is derived from the number of fields passed.
+ *
+ * This partial is intentionally "dumb": it only handles layout. The caller is
+ * responsible for deciding which fields belong together in the same row and for
+ * ensuring all passed fields actually exist before including this template.
+ *
+ *
+ * @param array $fields - Explicit list of form field objects to render in a row
+ *                        (2 or 3 items — matches CSS modifiers --2 and --3)
+ *}
+
+<div class="form-fields-row form-fields-row--{$fields|count}">
+  {foreach from=$fields item="field"}
+    {form_field field=$field}
+  {/foreach}
+</div>

--- a/templates/checkout/_partials/cart-detailed-actions.tpl
+++ b/templates/checkout/_partials/cart-detailed-actions.tpl
@@ -27,7 +27,6 @@
     {else}
       <div class="d-grid">
         <a href="{$urls.pages.order}" class="btn btn-primary btn-lg">{l s='Proceed to checkout' d='Shop.Theme.Actions'}</a>
-
         {hook h='displayExpressCheckout'}
       </div>
     {/if}

--- a/templates/checkout/_partials/connected-account-info.tpl
+++ b/templates/checkout/_partials/connected-account-info.tpl
@@ -1,0 +1,35 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+<div class="step__account">
+    <p>
+        {l s='Connected as [1]%firstname% %lastname%[/1].'
+        d='Shop.Theme.Customeraccount'
+        sprintf=[
+            '[1]' => "<a href='{$urls.pages.identity}' aria-label='{l s='My account (%firstname% %lastname%)' d='Shop.Theme.Customeraccount' sprintf=['%firstname%' => $customer.firstname, '%lastname%' => $customer.lastname]}'>",
+            '[/1]' => "</a>",
+            '%firstname%' => $customer.firstname,
+            '%lastname%' => $customer.lastname
+        ]
+        }
+    </p>
+
+    <p class="mb-1">
+        {l
+        s='Not you? [1]Sign out[/1]'
+        d='Shop.Theme.Customeraccount'
+        sprintf=[
+        '[1]' => "<a class='text-danger' href='{$urls.actions.logout}'>",
+        '[/1]' => "</a>"
+        ]
+        }
+    </p>
+
+    {if !isset($empty_cart_on_logout) || $empty_cart_on_logout}
+        <p class="mb-0">
+        <small class="text-body-tertiary">{l s='If you sign out now, your cart will be emptied.' d='Shop.Theme.Checkout'}</small>
+        </p>
+    {/if}
+</div>

--- a/templates/checkout/_partials/one-page-checkout/address-fields.tpl
+++ b/templates/checkout/_partials/one-page-checkout/address-fields.tpl
@@ -1,0 +1,75 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{**
+ * One Page Checkout - Address fields partial
+ *}
+
+{assign var="_prefix_len" value=$prefix|strlen}
+{assign var="_key_firstname" value="{$prefix}firstname"}
+{assign var="_key_lastname" value="{$prefix}lastname"}
+{assign var="_key_city" value="{$prefix}city"}
+{assign var="_key_postcode" value="{$prefix}postcode"}
+{assign var="_key_id_state" value="{$prefix}id_state"}
+
+{assign var="_has_name_row" value=isset($formFields[$_key_firstname]) && isset($formFields[$_key_lastname])}
+{assign var="_has_city_row" value=isset($formFields[$_key_city]) && isset($formFields[$_key_postcode])}
+{assign var="_has_state" value=isset($formFields[$_key_id_state])}
+
+{foreach from=$formFields item="field"}
+  {if $prefix && strpos($field.name, $prefix) !== 0}{continue}{/if}
+  {if !$prefix && strpos($field.name, 'invoice_') === 0}{continue}{/if}
+
+  {if $prefix}
+    {assign var="_base" value=$field.name|substr:$_prefix_len}
+  {else}
+    {assign var="_base" value=$field.name}
+  {/if}
+
+  {if $_base === 'alias'}
+    {form_field field=$field}
+
+  {elseif $_base === 'firstname' && $_has_name_row}
+    {include file='_partials/form-fields-row.tpl'
+      fields=[$formFields[$_key_firstname], $formFields[$_key_lastname]]
+    }
+
+  {elseif $_base === 'lastname' && $_has_name_row}
+  {elseif $_base === 'city' && $_has_city_row}
+    {if $_has_state}
+      {include file='_partials/form-fields-row.tpl'
+        fields=[$formFields[$_key_city], $formFields[$_key_id_state], $formFields[$_key_postcode]]
+      }
+    {else}
+      {include file='_partials/form-fields-row.tpl'
+        fields=[$formFields[$_key_city], $formFields[$_key_postcode]]
+      }
+    {/if}
+
+  {elseif $_base === 'postcode' && $_has_city_row}
+  {elseif $_base === 'id_state' && $_has_city_row}
+  {elseif $_base === 'id_country'}
+    <div class="form-group mb-3">
+      <label class="form-label{if $field.required} required{/if}" for="field-{$field.name}">
+        {$field.label}
+      </label>
+      <select
+        class="form-select"
+        name="{$field.name}"
+        id="field-{$field.name}"
+        {if $field.required}required{/if}
+      >
+        <option value="">{l s='-- please choose --' d='Shop.Forms.Labels'}</option>
+        {foreach from=$field.availableValues item="label" key="value"}
+          <option value="{$value}" {if (string) $value === (string) $field.value}selected{/if}>{$label}</option>
+        {/foreach}
+      </select>
+      {include file='_partials/form-errors.tpl' errors=$field.errors|default:[]}
+    </div>
+
+  {else}
+    {form_field field=$field}
+  {/if}
+{/foreach}

--- a/templates/checkout/_partials/one-page-checkout/address-list.tpl
+++ b/templates/checkout/_partials/one-page-checkout/address-list.tpl
@@ -1,0 +1,125 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{**
+ * One Page Checkout - Address List
+ *}
+
+<div class="d-flex flex-column mb-3">
+  {assign var="_selected_address" value=$selected_address|intval}
+  {assign var="_address_count" value=$customer.addresses|count}
+  {foreach from=$customer.addresses item="address"}
+    {assign var="_address_id" value=$address.id|default:$address.id_address|intval}
+    {assign var="is_address_selected" value=$_address_id === $_selected_address || ($_selected_address === 0 && $_address_count === 1 && $address@first)}
+    <div
+      class="opc-address-item d-flex p-2 border{if $address@first} rounded-top{/if}{if $is_address_selected} border-primary z-1 selected{/if}"
+      {if !$address@first}style="margin-top: -1px;"{/if}
+      role="button"
+      data-id-address="{$_address_id}"
+    >
+      <div class="form-check mb-2">
+        <input
+          type="radio"
+          class="form-check-input js-opc-address-radio"
+          name="id_address_{if $prefix}invoice{else}delivery{/if}"
+          id="opc-address-{if $prefix}invoice{else}delivery{/if}-{$_address_id}"
+          value="{$_address_id}"
+          {if $is_address_selected}checked{/if}
+          aria-label="{l s='Select address: %alias%' sprintf=['%alias%' => $address.alias] d='Shop.Theme.Actions'}"
+          aria-describedby="opc-address-details-{$_address_id}"
+        >
+      </div>
+
+      <div class="flex-grow-1">
+        <label class="form-check-label {if $is_address_selected}fw-semibold{/if}" for="opc-address-{if $prefix}invoice{else}delivery{/if}-{$_address_id}">
+          {$address.alias}
+        </label>
+        <p class="mb-2 text-muted small" id="opc-address-details-{$_address_id}">
+          <span class="visually-hidden">{l s='Address details:' d='Shop.Theme.Actions'}</span>
+          {$address.firstname} {$address.lastname}<br>
+          {$address.address1}{if $address.address2} {$address.address2}{/if}<br>
+          {$address.postcode} {$address.city}
+        </p>
+      </div>
+
+      <div class="opc-address-card__actions flex-shrink-0">
+        <div class="dropdown">
+          <button
+            type="button"
+            class="btn p-0"
+            data-bs-toggle="dropdown"
+            aria-expanded="false"
+            aria-label="{l s='Address options' d='Shop.Theme.Actions'}"
+          >
+            <i class="material-icons">more_vert</i>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-end">
+            <li>
+              <button
+                type="button"
+                class="dropdown-item"
+                data-bs-toggle="modal"
+                data-bs-target="{if $prefix}#modal-invoice{else}#modal-delivery{/if}"
+                data-type="edit"
+                data-id_address="{$_address_id}"
+                data-alias="{$address.alias|escape:'html':'UTF-8'}"
+                data-firstname="{$address.firstname|escape:'html':'UTF-8'}"
+                data-lastname="{$address.lastname|escape:'html':'UTF-8'}"
+                data-company="{$address.company|escape:'html':'UTF-8'}"
+                data-vat_number="{$address.vat_number|escape:'html':'UTF-8'}"
+                data-address1="{$address.address1|escape:'html':'UTF-8'}"
+                data-address2="{$address.address2|escape:'html':'UTF-8'}"
+                data-city="{$address.city|escape:'html':'UTF-8'}"
+                data-postcode="{$address.postcode|escape:'html':'UTF-8'}"
+                data-id_state="{$address.id_state}"
+                data-id_country="{$address.id_country}"
+                data-phone="{$address.phone|escape:'html':'UTF-8'}"
+              >
+                {l s='Edit' d='Shop.Theme.Actions'}
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                class="dropdown-item link-danger js-delete-address"
+                data-id-address="{$_address_id}"
+                data-address-type="{if $prefix == 'invoice_'}invoice{else}delivery{/if}"
+                data-confirm-message="{l s='Are you sure you want to delete this address?' d='Shop.Theme.Checkout'}"
+              >
+                {l s='Delete' d='Shop.Theme.Actions'}
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  {/foreach}
+
+  {if $customer.addresses|count > 0}
+    <div
+      class="opc-address-item d-flex p-2 border rounded-bottom"
+      style="margin-top: -1px;"
+      role="button"
+      data-bs-toggle="modal"
+      data-type="create"
+      data-bs-target="{if $prefix == 'invoice_'}#modal-invoice{else}#modal-delivery{/if}"
+    >
+      <div class="form-check mb-2">
+        <input
+          type="radio"
+          class="form-check-input js-opc-address-radio"
+          name="id_address_{if $prefix == 'invoice_'}invoice{else}delivery{/if}"
+          id="opc-new-{if $prefix == 'invoice_'}invoice{else}delivery{/if}-address"
+          value="new_address"
+        >
+      </div>
+      <div class="flex-grow-1">
+        <label class="form-check-label" for="opc-new-{if $prefix == 'invoice_'}invoice{else}delivery{/if}-address">
+          {l s='Use a different delivery address' d='Shop.Theme.Checkout'}
+        </label>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/templates/checkout/_partials/one-page-checkout/address-modal.tpl
+++ b/templates/checkout/_partials/one-page-checkout/address-modal.tpl
@@ -1,0 +1,113 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+<div
+  id="{$modal_id}"
+  class="modal fade"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="address-modal-title"
+  aria-hidden="true"
+  data-title-new="{$title_new}"
+  data-title-edit="{$title_edit}"
+>
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable" role="document">
+    <div class="modal-content address-form-container">
+      <div class="modal-header pb-2">
+        <h2 class="mb-0">{$title_new}</h2>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <hr>
+      <div class="modal-body">
+        <div class="row">
+          <input type="hidden" name="id_address" value="">
+          <input type="hidden" name="token" value="{$token}">
+          <input type="hidden" name="address_type" value="{$address_type}">
+          {assign var="_key_alias" value="{$prefix}alias"}
+          {assign var="_key_id_country" value="{$prefix}id_country"}
+          {assign var="_key_firstname" value="{$prefix}firstname"}
+          {assign var="_key_lastname" value="{$prefix}lastname"}
+          {assign var="_key_company" value="{$prefix}company"}
+          {assign var="_key_vat_number" value="{$prefix}vat_number"}
+          {assign var="_key_address1" value="{$prefix}address1"}
+          {assign var="_key_address2" value="{$prefix}address2"}
+          {assign var="_key_city" value="{$prefix}city"}
+          {assign var="_key_postcode" value="{$prefix}postcode"}
+          {assign var="_key_id_state" value="{$prefix}id_state"}
+          {assign var="_key_phone" value="{$prefix}phone"}
+
+          {if isset($formFields[$_key_id_country])}
+            <div class="form-group mb-3">
+              <label class="form-label{if $formFields[$_key_id_country].required} required{/if}" for="{$modal_id}-field-id_country">
+                {$formFields[$_key_id_country].label}
+              </label>
+              <select
+                class="form-select"
+                name="{$formFields[$_key_id_country].name}"
+                id="{$modal_id}-field-id_country"
+                {if $formFields[$_key_id_country].required}required{/if}
+              >
+                <option value="">{l s='-- please choose --' d='Shop.Forms.Labels'}</option>
+                {foreach from=$formFields[$_key_id_country].availableValues item="label" key="value"}
+                  <option value="{$value}" {if (string) $value === (string) $formFields[$_key_id_country].value}selected{/if}>{$label}</option>
+                {/foreach}
+              </select>
+            </div>
+          {/if}
+
+          {if isset($formFields[$_key_alias])}{form_field field=$formFields[$_key_alias]}{/if}
+
+          {if isset($formFields[$_key_firstname]) && isset($formFields[$_key_lastname])}
+            {include file='_partials/form-fields-row.tpl' fields=[$formFields[$_key_firstname], $formFields[$_key_lastname]]}
+          {/if}
+
+          {if isset($formFields[$_key_company])}{form_field field=$formFields[$_key_company]}{/if}
+
+          {if isset($formFields[$_key_vat_number])}{form_field field=$formFields[$_key_vat_number]}{/if}
+
+          {if isset($formFields[$_key_address1])}{form_field field=$formFields[$_key_address1]}{/if}
+
+          {if isset($formFields[$_key_address2])}{form_field field=$formFields[$_key_address2]}{/if}
+
+          <div class="form-fields-row form-fields-row--2 address-country-row">
+            {if isset($formFields[$_key_city])}{form_field field=$formFields[$_key_city]}{/if}
+            <div class="form-group mb-3 state-field-wrapper" style="{if !isset($formFields[$_key_id_state]) || empty($formFields[$_key_id_state].availableValues)}display: none;{/if}">
+              <label class="form-label{if isset($formFields[$_key_id_state]) && $formFields[$_key_id_state].required} required{/if}" for="{$modal_id}-field-id_state">
+                {l s='State' d='Shop.Forms.Labels'}
+              </label>
+              <select
+                class="form-select"
+                name="{if isset($formFields[$_key_id_state])}{$formFields[$_key_id_state].name}{else}{$prefix}id_state{/if}"
+                id="{$modal_id}-field-id_state"
+                data-select-placeholder="{l s='-- please choose --' d='Shop.Forms.Labels' js=1}"
+              >
+                <option value="">{l s='-- please choose --' d='Shop.Forms.Labels'}</option>
+                {if isset($formFields[$_key_id_state]) && isset($formFields[$_key_id_state].availableValues)}
+                  {foreach from=$formFields[$_key_id_state].availableValues item="label" key="value"}
+                    <option value="{$value}" {if $value eq $formFields[$_key_id_state].value}selected{/if}>{$label}</option>
+                  {/foreach}
+                {/if}
+              </select>
+            </div>
+            {if isset($formFields[$_key_postcode])}{form_field field=$formFields[$_key_postcode]}{/if}
+          </div>
+
+          {if isset($formFields[$_key_phone])}{form_field field=$formFields[$_key_phone]}{/if}
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button
+          id="submit-address-modal"
+          type="button"
+          class="btn btn-primary"
+          data-loading-text="{l s='Saving...' d='Shop.Theme.Checkout'}"
+          data-text="{l s='Save' d='Shop.Theme.Actions'}"
+        >
+          {l s='Save' d='Shop.Theme.Actions'}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/checkout/_partials/one-page-checkout/addresses-section.tpl
+++ b/templates/checkout/_partials/one-page-checkout/addresses-section.tpl
@@ -1,0 +1,136 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{* Delivery Address Modal *}
+{include file='checkout/_partials/one-page-checkout/address-modal.tpl'
+modal_id='modal-delivery'
+formFields=$deliveryFields
+title_new={l s='New delivery address' d='Shop.Theme.Checkout'}
+title_edit={l s='Edit delivery address' d='Shop.Theme.Checkout'}
+address_type='delivery'
+prefix=''
+}
+
+{* Billing Address Modal *}
+{include file='checkout/_partials/one-page-checkout/address-modal.tpl'
+modal_id='modal-invoice'
+formFields=$invoiceFields
+title_new={l s='New billing address' d='Shop.Theme.Checkout'}
+title_edit={l s='Edit billing address' d='Shop.Theme.Checkout'}
+address_type='invoice'
+prefix='invoice_'
+}
+
+{include file='checkout/_partials/one-page-checkout/delete-address-modal.tpl'}
+
+{assign var="_addresses_count" value=$customer.addresses|count}
+{assign var="_delivery_selected_address" value=$deliveryFields.id_address_delivery.value|default:($cart.id_address_delivery|default:0)}
+{assign var="_billing_selected_address" value=$invoiceMetaFields.id_address_invoice.value|default:($cart.id_address_invoice|default:0)}
+
+<template id="opc-delivery-address-loader">
+  {include file='checkout/_partials/one-page-checkout/opc-loader.tpl'
+    message={l s='Loading addresses...' d='Shop.Theme.Checkout'}
+  }
+</template>
+
+<template id="opc-delivery-address-error">
+  {include file='checkout/_partials/one-page-checkout/opc-error.tpl'
+    message={l s='An error occurred while loading addresses. Please try again.' d='Shop.Theme.Checkout'}
+    retry_label={l s='Retry' d='Shop.Theme.Checkout'}
+    retry_action='retry-addresses'
+  }
+</template>
+
+<template id="opc-billing-address-loader">
+  {include file='checkout/_partials/one-page-checkout/opc-loader.tpl'
+    message={l s='Loading addresses...' d='Shop.Theme.Checkout'}
+  }
+</template>
+
+<template id="opc-billing-address-error">
+  {include file='checkout/_partials/one-page-checkout/opc-error.tpl'
+    message={l s='An error occurred while loading addresses. Please try again.' d='Shop.Theme.Checkout'}
+    retry_label={l s='Retry' d='Shop.Theme.Checkout'}
+    retry_action='retry-addresses'
+  }
+</template>
+
+<section class="one-page-checkout__section">
+  <h2 class="one-page-checkout__title">
+    {if $is_virtual_cart}
+      {l s='Billing address' d='Shop.Theme.Checkout'}
+    {else}
+      {l s='Delivery address' d='Shop.Theme.Checkout'}
+    {/if}
+  </h2>
+
+  <section id="opc-delivery-address" class="form-fields">
+    <div id="opc-delivery-address-content">
+        <div id="opc-delivery-address-content-list" class="{if $_addresses_count <= 0}d-none{/if}">
+          {if $_addresses_count > 0}
+          {include file='checkout/_partials/one-page-checkout/address-list.tpl'
+            prefix=''
+            selected_address=$_delivery_selected_address
+          }
+          {/if}
+        </div>
+
+      <div id="opc-delivery-address-fields" class="{if $_addresses_count > 0}d-none{/if}">
+        {include file='checkout/_partials/one-page-checkout/address-fields.tpl'
+          formFields=$deliveryFields
+          prefix=''
+        }
+      </div>
+    </div>
+
+    {if !$is_virtual_cart}
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="opc-use-same-address" name="use_same_address" value="1" {if $useSameAddressField.value}checked{/if}>
+        <label class="form-check-label" for="opc-use-same-address">
+          {l s='Use this address for invoice too' d='Shop.Theme.Checkout'}
+        </label>
+      </div>
+    {/if}
+  </section>
+</section>
+
+{if !$is_virtual_cart}
+<section class="one-page-checkout__section" id="opc-billing-section" style="display: none;">
+  <h2 class="one-page-checkout__title">{l s='Billing address' d='Shop.Theme.Checkout'}</h2>
+
+  <section class="form-fields">
+    <div id="opc-billing-address-content">
+        <div id="opc-billing-address-content-list" class="{if $_addresses_count <= 1}d-none{/if}">
+          {if $_addresses_count > 1}
+          {include file='checkout/_partials/one-page-checkout/address-list.tpl'
+            prefix='invoice_'
+            selected_address=$_billing_selected_address
+          }
+          {/if}
+        </div>
+
+      <div id="opc-billing-address-fields" class="{if $_addresses_count > 1}d-none{/if}">
+        {if isset($invoiceMetaFields.id_address_invoice)}
+          <input type="hidden" name="{$invoiceMetaFields.id_address_invoice.name}" value="{$invoiceMetaFields.id_address_invoice.value}">
+        {/if}
+
+        {include file='checkout/_partials/one-page-checkout/address-fields.tpl'
+          formFields=$invoiceFields
+          prefix='invoice_'
+        }
+      </div>
+    </div>
+  </section>
+</section>
+{/if}
+
+{capture name="address_selector_bottom"}{hook h='displayAddressSelectorBottom'}{/capture}
+{if $smarty.capture.address_selector_bottom}
+  {block name='address_selector_bottom'}
+    <div class="address-selector-bottom mt-3">
+      {$smarty.capture.address_selector_bottom nofilter}
+    </div>
+  {/block}
+{/if}

--- a/templates/checkout/_partials/one-page-checkout/carriers.tpl
+++ b/templates/checkout/_partials/one-page-checkout/carriers.tpl
@@ -1,0 +1,60 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{**
+ * OPC — Carrier list partial (AJAX refresh)
+ * Variables: $delivery_options, $delivery_option
+ *}
+
+{if $delivery_options|count}
+  <div class="delivery-options__list">
+    {foreach from=$delivery_options item=carrier key=carrier_id name=delivery_options}
+      <div class="delivery-option__item js-delivery-option">
+        <label class="delivery-option__label" for="opc_delivery_option_{$carrier.id}">
+          <div class="delivery-option__left">
+            <span class="delivery-option__check form-check">
+              <input
+                type="radio"
+                class="form-check-input"
+                name="delivery_option"
+                id="opc_delivery_option_{$carrier.id}"
+                value="{$carrier_id}"
+                {if $delivery_option == $carrier_id}checked{/if}
+              >
+            </span>
+
+            <div class="delivery-option__carrier {if $carrier.logo}delivery-option__carrier--hasLogo{/if}">
+              {if $carrier.logo}
+                <img class="delivery-option__carrier-logo" src="{$carrier.logo}" alt="{$carrier.name}" loading="lazy" aria-hidden="true">
+              {/if}
+              <span class="delivery-option__carrier-name">{$carrier.name}</span>
+            </div>
+          </div>
+
+          <div class="delivery-option__content">
+            {$carrier.delay}
+          </div>
+
+          <div class="delivery-option__price">
+            {$carrier.price}
+          </div>
+        </label>
+
+        <div class="delivery-option__extra js-carrier-extra" {if $delivery_option == $carrier_id}data-active{/if}>
+          {capture name='extra'}{$carrier.extraContent nofilter}{/capture}
+          {if !empty($smarty.capture.extra)}
+            <div class="delivery-option__extra-content js-carrier-extra-content">
+              {$smarty.capture.extra nofilter}
+            </div>
+          {/if}
+        </div>
+      </div>
+    {/foreach}
+  </div>
+{else}
+  <p class="alert alert-warning mb-0">
+    {l s='Unfortunately, there are no carriers available for your delivery address.' d='Shop.Theme.Checkout'}
+  </p>
+{/if}

--- a/templates/checkout/_partials/one-page-checkout/contact-section.tpl
+++ b/templates/checkout/_partials/one-page-checkout/contact-section.tpl
@@ -1,0 +1,50 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{hook h='displayPersonalInformationTop' customer=$customer}
+
+{$isGuestCheckoutEnabled = $configuration.is_guest_checkout_enabled}
+
+{if !$customer.is_logged}
+  <section class="one-page-checkout__section">
+    <h2 class="one-page-checkout__title">{l s='Contact information' d='Shop.Theme.Checkout'}</h2>
+
+    <div class="one-page-checkout__links">
+      <a class="one-page-checkout__link" href="{$urls.pages.authentication}?back={$urls.pages.order}">
+        {l s='Already have an account? Sign in' d='Shop.Theme.Checkout'}
+      </a>
+      <a class="one-page-checkout__link" href="{$urls.pages.registration}?back={$urls.pages.order}">
+        {l s='Create account' d='Shop.Theme.Checkout'}
+      </a>
+    </div>
+
+    {if $isGuestCheckoutEnabled}
+      {if isset($contactFields['email'])}
+        <div class="one-page-checkout__field">
+          <label class="form-label" for="field-email">{l s='Continue as guest' d='Shop.Theme.Checkout'}</label>
+          <input class="form-control" type="email" name="email" id="field-email" value="{$contactFields['email']['value']}" required>
+          {include file='_partials/form-errors.tpl' errors=$contactFields['email']['errors']|default:[]}
+        </div>
+      {/if}
+
+      {if isset($contactFields['optin'])}
+        <div class="one-page-checkout__field">
+          {form_field field=$contactFields['optin']}
+        </div>
+      {/if}
+
+      {foreach from=$additionalCustomerFields item="field"}
+        <div class="one-page-checkout__field">
+          {form_field field=$field}
+        </div>
+      {/foreach}
+    {/if}
+  </section>
+{else}
+  <section class="one-page-checkout__section">
+    <h2 class="one-page-checkout__title">{l s='Contact information' d='Shop.Theme.Checkout'}</h2>
+    {include file='checkout/_partials/connected-account-info.tpl'}
+  </section>
+{/if}

--- a/templates/checkout/_partials/one-page-checkout/delete-address-modal.tpl
+++ b/templates/checkout/_partials/one-page-checkout/delete-address-modal.tpl
@@ -1,0 +1,49 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+<div
+  id="opc-delete-address-confirm-modal"
+  class="modal fade"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="opc-delete-address-confirm-title"
+  aria-hidden="true"
+>
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2 id="opc-delete-address-confirm-title" class="mb-0">
+          {l s='Delete this address?' d='Shop.Theme.Checkout'}
+        </h2>
+        <button
+          type="button"
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="{l s='Close' d='Shop.Theme.Actions'}"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <p class="mb-0">
+          {l s='This action will remove the selected address from your checkout.' d='Shop.Theme.Checkout'}
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button
+          type="button"
+          class="btn btn-outline-primary js-opc-delete-address-cancel"
+          data-bs-dismiss="modal"
+        >
+          {l s='Cancel' d='Shop.Theme.Actions'}
+        </button>
+        <button
+          type="button"
+          class="btn btn-outline-danger js-opc-delete-address-confirm"
+        >
+          {l s='Delete' d='Shop.Theme.Actions'}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/checkout/_partials/one-page-checkout/delivery-section.tpl
+++ b/templates/checkout/_partials/one-page-checkout/delivery-section.tpl
@@ -1,0 +1,75 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{**
+ * OPC — Delivery method section
+ * Included by one-page-checkout.tpl.
+ * Also renderable standalone for AJAX refresh.
+ *
+ * Variables:
+ *   $delivery_options         - available carriers (may be empty on first load)
+ *   $delivery_option          - currently selected carrier key
+ *   $id_address_delivery      - current cart delivery address ID
+ *   $hookDisplayBeforeCarrier
+ *   $hookDisplayAfterCarrier
+ *}
+
+<section class="one-page-checkout__section js-opc-delivery-section">
+  <h2 class="one-page-checkout__title">{l s='Delivery method' d='Shop.Theme.Checkout'}</h2>
+
+  <div id="delivery-options__hook">
+    {if isset($hookDisplayBeforeCarrier)}
+      {$hookDisplayBeforeCarrier nofilter}
+    {else}
+      {hook h='displayBeforeCarrier'}
+    {/if}
+  </div>
+
+  <div class="one-page-checkout__placeholder" id="opc-delivery-methods" data-id-address="{$id_address_delivery|intval}"
+    data-url-update="{url entity='order' params=['ajax' => 1, 'action' => 'opcSelectCarrier']}"
+    data-msg-no-carriers="{l s='Unfortunately, there are no carriers available for your delivery address.' d='Shop.Theme.Checkout'}"
+  >
+    {if $delivery_options|count}
+      {include file='checkout/_partials/one-page-checkout/carriers.tpl'
+        delivery_options=$delivery_options
+        delivery_option=$delivery_option
+      }
+    {else}
+      <div class="card card-body bg-light">
+        {l s='You will see the available delivery methods once you\'ve entered your delivery address.' d='Shop.Theme.Checkout'}
+      </div>
+    {/if}
+  </div>
+
+  <div class="delivery-options__display-after-carrier" id="hook-display-after-carrier">
+    {if isset($hookDisplayAfterCarrier)}
+      {$hookDisplayAfterCarrier nofilter}
+    {else}
+      {hook h='displayAfterCarrier'}
+    {/if}
+  </div>
+
+  <div class="delivery-options__extra-carrier" id="extra_carrier"></div>
+
+  {include file='checkout/_partials/one-page-checkout/order-options.tpl'
+    delivery_message=$delivery_message|default:''
+    recyclablePackAllowed=$recyclablePackAllowed|default:false
+    recyclable=$recyclable|default:false
+    gift=$gift|default:[]
+  }
+
+  <template id="opc-template-loader">
+    {include file='checkout/_partials/one-page-checkout/opc-loader.tpl'
+      message={l s='Loading delivery methods...' d='Shop.Theme.Checkout'}
+    }
+  </template>
+
+  <template id="opc-template-carriers-error">
+    {include file='checkout/_partials/one-page-checkout/opc-error.tpl'
+      message={l s='An error occurred while loading carriers. Please try again.' d='Shop.Theme.Checkout'}
+      retry_label={l s='Retry' d='Shop.Theme.Checkout'}
+    }
+  </template>
+</section>

--- a/templates/checkout/_partials/one-page-checkout/opc-error.tpl
+++ b/templates/checkout/_partials/one-page-checkout/opc-error.tpl
@@ -1,0 +1,26 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{**
+ * OPC — Error state
+ * Intended to be embedded as a <template> element so JS can clone it.
+ *
+ * Variables:
+ *   $message (optional) — error message displayed to the user
+ *}
+<div class="alert alert-danger mb-0 d-flex flex-column flex-sm-row align-items-center gap-2">
+  <p class="mb-0 flex-grow-1">
+    {if isset($message) && $message}
+      {$message|escape:'html'}
+    {else}
+      {l s='An error occurred. Please try again.' d='Shop.Theme.Checkout'}
+    {/if}
+  </p>
+  {if isset($retry_label) && $retry_label}
+    <button type="button" class="btn btn-sm btn-outline-danger flex-shrink-0" data-opc-action="{if isset($retry_action) && $retry_action}{$retry_action|escape:'html'}{else}retry-carriers{/if}">
+      {$retry_label|escape:'html'}
+    </button>
+  {/if}
+</div>

--- a/templates/checkout/_partials/one-page-checkout/opc-loader.tpl
+++ b/templates/checkout/_partials/one-page-checkout/opc-loader.tpl
@@ -1,0 +1,20 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{**
+ * OPC — Loader / spinner
+ * Intended to be embedded as a <template> element so JS can clone it.
+ *
+ * Variables:
+ *   $message (optional) — text displayed below the spinner
+ *}
+<div class="d-flex flex-column justify-content-center align-items-center h-100 gap-2 py-3">
+  <div class="spinner-border text-primary" role="status">
+    <span class="visually-hidden">{l s='Loading...' d='Shop.Theme.Checkout'}</span>
+  </div>
+  {if isset($message) && $message}
+    <p class="text-muted small mb-0">{$message|escape:'html'}</p>
+  {/if}
+</div>

--- a/templates/checkout/_partials/one-page-checkout/order-options.tpl
+++ b/templates/checkout/_partials/one-page-checkout/order-options.tpl
@@ -1,0 +1,70 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{**
+ * OPC — Order options (delivery message, recyclable packaging, gift)
+ * Mirrors the order-options block from shipping.tpl for ISO UX.
+ *
+ * Variables: $delivery_message, $recyclablePackAllowed, $recyclable, $gift
+ *}
+
+<div class="order-options mt-3">
+  <div class="mb-3">
+    <label for="delivery_message" class="form-label">
+      {l s='Write a comment about this order' d='Shop.Theme.Checkout'}
+    </label>
+    <textarea
+      class="form-control"
+      rows="2"
+      id="delivery_message"
+      name="delivery_message"
+      placeholder="{l s='Write your comment...' d='Shop.Theme.Checkout'}"
+    >{$delivery_message|escape:'html'}</textarea>
+  </div>
+
+  {if $recyclablePackAllowed}
+    <div class="form-check mb-3">
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="input_recyclable"
+        name="recyclable"
+        value="1"
+        {if $recyclable}checked{/if}
+      >
+      <label class="form-check-label" for="input_recyclable">
+        {l s='I would like to receive my order in recycled packaging.' d='Shop.Theme.Checkout'}
+      </label>
+    </div>
+  {/if}
+
+  {if $gift.allowed}
+    <div class="form-check mb-2">
+      <label class="form-check-label" for="input_gift" data-bs-toggle="collapse" data-bs-target="#opc-gift-message">
+        <input
+          class="form-check-input js-gift-checkbox"
+          type="checkbox"
+          id="input_gift"
+          name="gift"
+          value="1"
+          {if $gift.isGift}checked{/if}
+        >
+        {$gift.label}
+      </label>
+    </div>
+
+    <div id="opc-gift-message" class="collapse{if $gift.isGift} show{/if} mb-3">
+      <label for="gift_message" class="form-label">
+        {l s="If you'd like, you can add a note to the gift:" d='Shop.Theme.Checkout'}
+      </label>
+      <textarea
+        class="form-control"
+        rows="2"
+        id="gift_message"
+        name="gift_message"
+      >{$gift.message}</textarea>
+    </div>
+  {/if}
+</div>

--- a/templates/checkout/_partials/one-page-checkout/payment-methods.tpl
+++ b/templates/checkout/_partials/one-page-checkout/payment-methods.tpl
@@ -1,0 +1,75 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{**
+ * OPC — Payment methods list partial (AJAX refresh)
+ * Variables: $payment_options, $is_free, $selected_payment_module, $selected_payment_selection_key
+ *}
+
+{foreach from=$payment_options item="module_options"}
+  {foreach from=$module_options item="option"}
+    <div id="{$option.id}-container" class="payment-option">
+
+      {* JS-enabled: radio + label *}
+      <div class="payment-option__form-check form-check">
+        <input
+          class="payment-option__input form-check-input ps-shown-by-js{if $option.binary} binary{/if}"
+          type="radio"
+          name="payment-option"
+          data-module-name="{$option.module_name}"
+          data-selection-key="{$option.selection_key|default:''}"
+          id="{$option.id}"
+          value="{$option.id}"
+          {if ($selected_payment_selection_key && $selected_payment_selection_key == $option.selection_key) || (!$selected_payment_selection_key && $selected_payment_module == $option.module_name) || $is_free} checked {/if}
+        >
+        <label class="payment-option__label form-check-label" for="{$option.id}">
+          {if $option.logo}
+            <img class="img-fluid" src="{$option.logo}" loading="lazy" alt="">
+          {/if}
+          {$option.call_to_action_text}
+        </label>
+      </div>
+
+{* Additional information (hidden until selected) *}
+      {if $option.additionalInformation}
+        <div
+          id="{$option.id}-additional-information"
+          class="payment-option__additional-information js-additional-information"
+          {if ($selected_payment_selection_key && $selected_payment_selection_key != $option.selection_key) || (!$selected_payment_selection_key && $option.module_name != $selected_payment_module)}style="display: none;"{/if}
+        >
+          {$option.additionalInformation nofilter}
+        </div>
+      {/if}
+
+      {* Payment form *}
+      <div
+        id="pay-with-{$option.id}-form"
+        class="js-payment-option-form"
+        {if ($selected_payment_selection_key && $selected_payment_selection_key != $option.selection_key) || (!$selected_payment_selection_key && $option.module_name != $selected_payment_module)}style="display: none;"{/if}
+      >
+        {if $option.form}
+          {$option.form nofilter}
+        {else}
+          <form class="js-opc-payment-fallback" action="{$option.action nofilter}" method="post">
+            {foreach from=$option.inputs item=input}
+              <input
+                type="{$input.type}"
+                name="{$input.name}"
+                value="{$input.value}"
+                class="js-payment-option-input"
+                {if ($selected_payment_selection_key && $selected_payment_selection_key != $option.selection_key) || (!$selected_payment_selection_key && $option.module_name != $selected_payment_module)}disabled{/if}
+              >
+            {/foreach}
+          </form>
+        {/if}
+      </div>
+
+    </div>
+  {/foreach}
+{foreachelse}
+  <p class="alert alert-danger">
+    {l s='Unfortunately, there are no payment method available.' d='Shop.Theme.Checkout'}
+  </p>
+{/foreach}

--- a/templates/checkout/_partials/one-page-checkout/payment-section.tpl
+++ b/templates/checkout/_partials/one-page-checkout/payment-section.tpl
@@ -1,0 +1,53 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{**
+ * OPC — Payment method section
+ * Included by one-page-checkout.tpl.
+ * Also renderable standalone for AJAX refresh.
+ *
+ * Variables:
+ *   $payment_options          - available payment options (may be empty on first load)
+ *   $is_free                  - boolean, true when cart total is 0
+ *   $selected_payment_module  - legacy fallback module_name of the currently selected payment option
+ *   $selected_payment_selection_key - stable OPC selection key for the currently selected payment option
+ *}
+
+<section class="one-page-checkout__section js-opc-payment-section">
+  <h2 class="one-page-checkout__title">{l s='Payment method' d='Shop.Theme.Checkout'}</h2>
+
+  {hook h='displayPaymentTop'}
+
+  <div class="one-page-checkout__placeholder" id="opc-payment-methods"
+    data-url-update="{url entity='order' params=['ajax' => 1, 'action' => 'opcSelectPayment']}"
+  >
+    {if $payment_options|count}
+      {include file='checkout/_partials/one-page-checkout/payment-methods.tpl'
+        payment_options=$payment_options
+        is_free=$is_free
+        selected_payment_module=$selected_payment_module
+        selected_payment_selection_key=$selected_payment_selection_key|default:''
+      }
+    {else}
+      <div class="card card-body bg-light">
+        {l s='You will see the available payment methods once you\'ve entered your delivery address.' d='Shop.Theme.Checkout'}
+      </div>
+    {/if}
+  </div>
+
+  <template id="opc-template-payment-loader">
+    {include file='checkout/_partials/one-page-checkout/opc-loader.tpl'
+      message={l s='Loading payment methods...' d='Shop.Theme.Checkout'}
+    }
+  </template>
+
+  <template id="opc-template-payment-error">
+    {include file='checkout/_partials/one-page-checkout/opc-error.tpl'
+      message={l s='An error occurred while loading payment methods. Please try again.' d='Shop.Theme.Checkout'}
+      retry_label={l s='Retry' d='Shop.Theme.Checkout'}
+      retry_action='retry-payment'
+    }
+  </template>
+</section>

--- a/templates/checkout/_partials/steps/one-page-checkout.tpl
+++ b/templates/checkout/_partials/steps/one-page-checkout.tpl
@@ -1,0 +1,74 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+
+{**
+ * One Page Checkout - Layout
+ *}
+
+<form id="opc-form" class="one-page-checkout" method="POST" action="{$urls.pages.order}" data-ps-action="form-validation">
+  {include file='_partials/form-errors.tpl' errors=$errors['']}
+  {include file='_partials/form-errors.tpl' errors=$validation_error_messages|default:[]}
+
+  <div class="js-opc-contact-section">
+    {include file='checkout/_partials/one-page-checkout/contact-section.tpl'}
+  </div>
+
+  <div class="js-opc-addresses-section">
+    {include file='checkout/_partials/one-page-checkout/addresses-section.tpl'}
+  </div>
+
+  {* ===== Delivery method ===== *}
+  {if !$is_virtual_cart}
+    {include file='checkout/_partials/one-page-checkout/delivery-section.tpl'
+      delivery_options=$delivery_options
+      delivery_option=$delivery_option
+      id_address_delivery=$cart.id_address_delivery|intval
+      hookDisplayBeforeCarrier=$hookDisplayBeforeCarrier|default:null
+      hookDisplayAfterCarrier=$hookDisplayAfterCarrier|default:null
+      delivery_message=$delivery_message|default:''
+      recyclablePackAllowed=$recyclablePackAllowed|default:false
+      recyclable=$recyclable|default:false
+      gift=$gift|default:[]
+    }
+  {/if}
+
+</form>
+
+{* Payment section is rendered outside the main form to avoid nested payment forms. *}
+{include file='checkout/_partials/one-page-checkout/payment-section.tpl'
+  payment_options=$payment_options|default:[]
+  is_free=$is_free|default:false
+  selected_payment_module=$selected_payment_module|default:''
+  selected_payment_selection_key=$selected_payment_selection_key|default:''
+}
+
+<div class="one-page-checkout__footer">
+  {* ===== Terms & conditions ===== *}
+  {if $conditions_to_approve|count}
+    {foreach from=$conditions_to_approve item="condition" key="condition_name"}
+      <div class="form-check">
+        <input id="conditions_to_approve[{$condition_name}]"
+               name="conditions_to_approve[{$condition_name}]"
+               required
+               type="checkbox"
+               value="1"
+               class="form-check-input"
+        >
+        <label class="js-terms form-check-label" for="conditions_to_approve[{$condition_name}]">
+          {$condition nofilter}
+        </label>
+      </div>
+    {/foreach}
+  {/if}
+
+  {hook h='displayCheckoutBeforeConfirmation'}
+
+  {* ===== Pay button ===== *}
+  <button class="one-page-checkout__submit btn btn-primary btn-lg w-100" type="button" id="opc-pay-button" disabled>
+    {l s='Pay' d='Shop.Theme.Checkout'} <span id="opc-pay-amount">{$cart.totals.total.value}</span>
+  </button>
+
+  {hook h='displayPaymentByBinaries'}
+</div>

--- a/templates/checkout/_partials/steps/personal-information.tpl
+++ b/templates/checkout/_partials/steps/personal-information.tpl
@@ -10,39 +10,8 @@
   {hook h='displayPersonalInformationTop' customer=$customer}
 
   {if $customer.is_logged && !$customer.is_guest}
-    <div class="step__account">
-      <p>
-        {* [1][/1] is for a HTML tag. *}
-        {l s='Connected as [1]%firstname% %lastname%[/1].'
-          d='Shop.Theme.Customeraccount'
-          sprintf=[
-            '[1]' => "<a href='{$urls.pages.identity}' aria-label='{l s='My account (%firstname% %lastname%)' d='Shop.Theme.Customeraccount' sprintf=['%firstname%' => $customer.firstname, '%lastname%' => $customer.lastname]}'>",
-            '[/1]' => "</a>",
-            '%firstname%' => $customer.firstname,
-            '%lastname%' => $customer.lastname
-          ]
-        }
-      </p>
-
-      <p class="mb-1">
-        {* [1][/1] is for a HTML tag. *}
-        {l
-          s='Not you? [1]Sign out[/1]'
-          d='Shop.Theme.Customeraccount'
-          sprintf=[
-          '[1]' => "<a class='text-danger' href='{$urls.actions.logout}'>",
-          '[/1]' => "</a>"
-          ]
-        }
-      </p>
-
-      {if !isset($empty_cart_on_logout) || $empty_cart_on_logout}
-        <p class="mb-0">
-          <small class="text-body-tertiary">{l s='If you sign out now, your cart will be emptied.' d='Shop.Theme.Checkout'}</small>
-        </p>
-      {/if}
-    </div>
-
+    {include file='checkout/_partials/connected-account-info.tpl'}
+    
     <form id="checkout-continue-form" method="GET" action="{$urls.pages.order}">
       <div class="buttons-wrapper buttons-wrapper--end mt-3">
         <button

--- a/templates/checkout/checkout.tpl
+++ b/templates/checkout/checkout.tpl
@@ -11,16 +11,24 @@
 {/block}
 
 {block name='content_columns'}
-  {include file='checkout/checkout-navigation.tpl'}
+  {if isset($is_one_page_checkout_enabled) && !$is_one_page_checkout_enabled}
+    {include file='checkout/checkout-navigation.tpl'}
+  {/if}
 
   {block name='checkout_notifications'}
     {include file='_partials/notifications.tpl'}
   {/block}
+  <div
+    id="js-account-created-toast"
+    class="d-none"
+    data-show="{if !empty($show_account_created_toast)}1{else}0{/if}"
+    data-message="{l s='Account successfully created' d='Shop.Theme.Customeraccount'}"
+  ></div>
 
   <div class="columns-container container">
     <div id="center-column" class="center-column page page--full-width">
       <div class="checkout-grid row">
-        <div class="checkout-grid__content col-lg-8">
+        <div class="checkout-grid__content col-lg-8{if isset($is_one_page_checkout_enabled) && $is_one_page_checkout_enabled} order-2 order-lg-1{/if}">
           <div class="tab-content">
             {block name='checkout_process'}
               {render file='checkout/checkout-process.tpl' ui=$checkout_process}
@@ -28,7 +36,7 @@
           </div>
         </div>
 
-        <div class="checkout-grid__aside col-lg-4">
+        <div class="checkout-grid__aside col-lg-4{if isset($is_one_page_checkout_enabled) && $is_one_page_checkout_enabled} order-1 order-lg-2{/if}">
           <div class="checkout-grid__aside-wrapper">
             <div class="checkout__summary-accordion accordion">
               <div class="checkout__summary-accordion-item accordion-item">

--- a/templates/customer/_partials/customer-form.tpl
+++ b/templates/customer/_partials/customer-form.tpl
@@ -38,6 +38,9 @@
 
   {block name='customer_form_footer'}
     <input type="hidden" name="submitCreate" value="1">
+    {if isset($smarty.get.back) && $smarty.get.back !== ''}
+      <input type="hidden" name="back" value="{$smarty.get.back|escape:'htmlall':'UTF-8'}">
+    {/if}
 
     <footer class="buttons-wrapper buttons-wrapper--end">
       {block "form_buttons"}

--- a/templates/customer/_partials/login-form.tpl
+++ b/templates/customer/_partials/login-form.tpl
@@ -18,9 +18,20 @@
 
     {block name='login_form_footer'}
       <input type="hidden" name="submitLogin" value="1" tabindex="-1">
+      {if isset($smarty.get.back) && $smarty.get.back !== ''}
+        <input type="hidden" name="back" value="{$smarty.get.back|escape:'htmlall':'UTF-8'}">
+      {/if}
 
       <div class="buttons-wrapper buttons-wrapper--split buttons-wrapper--invert-mobile">
-        <a class="btn btn-basic" href="{$urls.pages.password}" rel="nofollow">
+        {assign var="password_url" value=$urls.pages.password}
+        {if isset($smarty.get.back) && $smarty.get.back !== ''}
+          {if $password_url|strpos:'?' !== false}
+            {assign var="password_url" value="`$password_url`&back=`$smarty.get.back|escape:'url'`"}
+          {else}
+            {assign var="password_url" value="`$password_url`?back=`$smarty.get.back|escape:'url'`"}
+          {/if}
+        {/if}
+        <a class="btn btn-basic" href="{$password_url}" rel="nofollow">
           {l s='Forgot your password?' d='Shop.Theme.Customeraccount'}
         </a>
 

--- a/templates/customer/authentication.tpl
+++ b/templates/customer/authentication.tpl
@@ -29,7 +29,16 @@
         <h2 class="h4">{l s='No account?' d='Shop.Theme.Customeraccount'}</h2>
 
         <div class="d-grid">
-          <a href="{$urls.pages.register}" class="btn btn-outline-primary" data-link-action="display-register-form">
+          {assign var="register_url" value=$urls.pages.register}
+
+          {if isset($smarty.get.back)}
+            {if $register_url|strpos:'?' !== false}
+              {assign var="register_url" value="`$register_url`&back=`$smarty.get.back|escape:'url'`"}
+            {else}
+              {assign var="register_url" value="`$register_url`?back=`$smarty.get.back|escape:'url'`"}
+            {/if}
+          {/if}
+          <a href="{$register_url}" class="btn btn-outline-primary" data-link-action="display-register-form">
             {l s='Create your account' d='Shop.Theme.Actions'}
           </a>
         </div>

--- a/templates/customer/password-email.tpl
+++ b/templates/customer/password-email.tpl
@@ -27,6 +27,9 @@
     </header>
 
     <section class="form-fields">
+      {if isset($smarty.get.back) && $smarty.get.back !== ''}
+        <input type="hidden" name="back" value="{$smarty.get.back|escape:'htmlall':'UTF-8'}">
+      {/if}
       <div class="mb-3">
         <label for="email" class="form-label required">{l s='Email address' d='Shop.Forms.Labels'}</label>
         <input type="email" name="email" id="email" value="{if isset($smarty.post.email)}{stripslashes($smarty.post.email)}{/if}" class="form-control" autocomplete="username" required>
@@ -45,7 +48,15 @@
   <hr>
 
   <div class="buttons-wrapper">
-    <a id="back-to-login" href="{$urls.pages.my_account}" class="btn btn-basic">
+    {assign var="back_to_login_url" value=$urls.pages.authentication}
+    {if isset($smarty.get.back) && $smarty.get.back !== ''}
+      {if $back_to_login_url|strpos:'?' !== false}
+        {assign var="back_to_login_url" value="`$back_to_login_url`&back=`$smarty.get.back|escape:'url'`"}
+      {else}
+        {assign var="back_to_login_url" value="`$back_to_login_url`?back=`$smarty.get.back|escape:'url'`"}
+      {/if}
+    {/if}
+    <a id="back-to-login" href="{$back_to_login_url}" class="btn btn-basic">
       <i class="material-icons rtl-flip" aria-hidden="true">&#xE5C4;</i>
       <span>{l s='Back to login' d='Shop.Theme.Actions'}</span>
     </a>

--- a/templates/customer/password-infos.tpl
+++ b/templates/customer/password-infos.tpl
@@ -26,7 +26,15 @@
   <hr>
 
   <div class="buttons-wrapper">
-    <a id="back-to-login" href="{$urls.pages.authentication}" class="btn btn-basic">
+    {assign var="back_to_login_url" value=$urls.pages.authentication}
+    {if isset($smarty.get.back) && $smarty.get.back !== ''}
+      {if $back_to_login_url|strpos:'?' !== false}
+        {assign var="back_to_login_url" value="`$back_to_login_url`&back=`$smarty.get.back|escape:'url'`"}
+      {else}
+        {assign var="back_to_login_url" value="`$back_to_login_url`?back=`$smarty.get.back|escape:'url'`"}
+      {/if}
+    {/if}
+    <a id="back-to-login" href="{$back_to_login_url}" class="btn btn-basic">
       <i class="material-icons rtl-flip" aria-hidden="true">&#xE5C4;</i>
       <span>{l s='Back to login' d='Shop.Theme.Actions'}</span>
     </a>

--- a/templates/customer/password-new.tpl
+++ b/templates/customer/password-new.tpl
@@ -23,6 +23,9 @@
     {/if}
 
     <section class="form-fields renew-password">
+      {if isset($smarty.get.back) && $smarty.get.back !== ''}
+        <input type="hidden" name="back" value="{$smarty.get.back|escape:'htmlall':'UTF-8'}">
+      {/if}
       <div class="mb-3">
         {l
           s='Email address: %email%'
@@ -82,7 +85,15 @@
   <hr>
 
   <div class="buttons-wrapper">
-    <a id="back-to-login" href="{$urls.pages.authentication}" class="btn btn-basic">
+    {assign var="back_to_login_url" value=$urls.pages.authentication}
+    {if isset($smarty.get.back) && $smarty.get.back !== ''}
+      {if $back_to_login_url|strpos:'?' !== false}
+        {assign var="back_to_login_url" value="`$back_to_login_url`&back=`$smarty.get.back|escape:'url'`"}
+      {else}
+        {assign var="back_to_login_url" value="`$back_to_login_url`?back=`$smarty.get.back|escape:'url'`"}
+      {/if}
+    {/if}
+    <a id="back-to-login" href="{$back_to_login_url}" class="btn btn-basic">
       <i class="material-icons rtl-flip" aria-hidden="true">&#xE5C4;</i>
       <span>{l s='Back to login' d='Shop.Theme.Actions'}</span>
     </a>

--- a/templates/customer/registration.tpl
+++ b/templates/customer/registration.tpl
@@ -16,7 +16,15 @@
     <section class="register-form">
       {render file='customer/_partials/customer-form.tpl' ui=$register_form mode='register'}
       <hr>
-      <p class="register-form__login-prompt">{l s='Already have an account?' d='Shop.Theme.Customeraccount'} <a href="{$urls.pages.authentication}">{l s='Sign in' d='Shop.Theme.Customeraccount'}</a></p>
+      {assign var="login_url" value=$urls.pages.authentication}
+      {if isset($smarty.get.back) && $smarty.get.back !== ''}
+        {if $login_url|strpos:'?' !== false}
+          {assign var="login_url" value="`$login_url`&back=`$smarty.get.back|escape:'url'`"}
+        {else}
+          {assign var="login_url" value="`$login_url`?back=`$smarty.get.back|escape:'url'`"}
+        {/if}
+      {/if}
+      <p class="register-form__login-prompt">{l s='Already have an account?' d='Shop.Theme.Customeraccount'} <a href="{$login_url}">{l s='Sign in' d='Shop.Theme.Customeraccount'}</a></p>
     </section>
   {/block}
 {/block}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -6,6 +6,7 @@ declare namespace Theme {
   type ThemeType = {
     events: EVENTS;
     selectors: SelectorsMap;
+    components: Components;
   }
 
   type Components = {


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Description? | One-page checkout experience with inline contact, address, delivery and payment sections. It also improves guest checkout, address management, checkout feedback states, and authentication redirects back to checkout. |
| Type? | new feature |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | N/A |
| Sponsor company | PrestaShop SA |
| How to test? | Enable one-page checkout, go through checkout as guest and as logged-in customer, verify address management, delivery/payment refreshes, `back` redirects after auth/registration, and the final pay button behavior. |

## Summary

When the one-page checkout option is enabled in the back-office, this PR replaces the multi-step checkout navigation with a single scrollable page. Customers fill in their contact details, address, delivery method, and payment all in one view — without jumping between steps.

Guest customers can check out without creating an account and without leaving the page. Customers can also create, edit, or delete a delivery address directly from within checkout via modal dialogs. If a customer needs to log in or register mid-checkout, they are automatically redirected back to checkout after authentication.

---

## Changes

### User-facing

- **One-page layout**: All checkout steps (contact, address, delivery, payment) are shown on a single scrollable page when OPC is enabled.
- **Inline guest checkout**: Guests fill in their contact and address information directly on the checkout page — no separate login or guest form required.
- **Address management modals**: Customers can create, edit, or delete a delivery address from within checkout without leaving the page.
- **Smart auth redirect**: If a customer is sent to the login, registration, or password-reset page from checkout, they are automatically brought back to checkout after completing the action. A success toast is displayed when a new account is created.
- **Stable cart summary**: The cart summary accordion state is preserved when sections refresh (e.g. after selecting a delivery method).

### For theme developers / contributors

**New templates** (`templates/checkout/_partials/one-page-checkout/`):

| Template | Role |
|---|---|
| `contact-section.tpl` | Email / phone field with guest checkbox |
| `addresses-section.tpl` | Address selector and billing address toggle |
| `address-list.tpl` | List of available delivery addresses |
| `address-fields.tpl` | Reusable address field block |
| `address-modal.tpl` | Create / edit address modal |
| `delete-address-modal.tpl` | Delete address confirmation modal |
| `delivery-section.tpl` + `carriers.tpl` | Delivery method selection |
| `payment-section.tpl` + `payment-methods.tpl` | Payment method selection |
| `order-options.tpl` | Terms & conditions, gift and recycling options |
| `opc-loader.tpl` / `opc-error.tpl` | Loading and error feedback states |

**Other template changes:**
- `templates/checkout/_partials/steps/one-page-checkout.tpl` — Top-level OPC layout assembling all sections.
- `templates/checkout/checkout.tpl` — Classic step navigation is conditionally hidden when OPC is active; grid columns are reordered on mobile so the cart summary appears above the form.
- `templates/_partials/form-fields-row.tpl` — New reusable partial for side-by-side form field layout.
- `templates/checkout/_partials/connected-account-info.tpl` — New reusable block displaying logged-in customer identity.
- `templates/customer/authentication.tpl`, `registration.tpl`, `password-*.tpl` — All auth pages now propagate the `back` query parameter to preserve the redirect chain back to checkout.

**JavaScript / TypeScript:**
- `src/js/pages/one-page-checkout.ts` — Theme entry point for OPC. Handles the account-created toast after registration redirect, and Bootstrap accordion open-state preservation across OPC cart summary DOM refreshes (via `prestashop.on('opcCartSummaryBeforeUpdate')` / `opcCartSummaryUpdated`).
- `src/js/pages/one-page-checkout.test.ts` — Unit tests for accordion state restoration.
- `src/js/constants/selectors-map.ts` — New `data-ps-*` selectors for OPC elements.
- `src/js/theme.ts` — OPC initializer registered in the theme entry point.

**SCSS:**
- `src/scss/prestashop/components/checkout/_one-page-checkout.scss` — Styles for the OPC layout and its components.
- `src/scss/prestashop/components/_form-fields-row.scss` — Styles for the new form-fields-row partial.

> **Note for contributors**: The native OPC module (`opc-form.js`, `opc-carrier-list.js`, `opc-carrier-select.js`) owns the full OPC lifecycle (form validation, pay-button gating, carrier fetch, cart updates). This PR only adds the theme presentation layer on top of that.

