### PR TITLE
Allow HTML in product flags

### DIFF
--- a/templates/catalog/_partials/product-flags.tpl
+++ b/templates/catalog/_partials/product-flags.tpl
@@ -6,7 +6,7 @@
   {block name='product_flags'}
     <ul class="product-flags js-product-flags">
       {foreach from=$product.flags item=flag}
-        <li class="badge {$flag.type}">{$flag.label}</li>
+        <li class="badge {$flag.type}">{$flag.label nofilter}</li>
       {/foreach}
     </ul>
   {/block}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Allows the use of HTML in product flags, to add icons for example.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | TRENDO s.r.o.
| How to test?      | 

Example:
<img width="1574" height="890" alt="labels" src="https://github.com/user-attachments/assets/e60b5648-4f20-418b-bfe8-f3655d554cb9" />

cc @tblivet @ga-devfront 