### PR TITLE
fix : make wishlist-footer-links clickable

### DIFF
--- a/src/scss/prestashop/modules/_blockwishlist.scss
+++ b/src/scss/prestashop/modules/_blockwishlist.scss
@@ -40,4 +40,8 @@ $component-name: wishlist;
       color: inherit !important;
     }
   }
+
+  &-pagination {
+    display: inline-block;
+  }
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      |  The links in the footer of the product list page of the blockwishlist module are not clickable, they are under the ul.wishlist-products-list . I did the same thing as what is done in the classic theme, set the pagination's display to inline-block. This is volontarily a conservative change, applied only to .wishlist-pagination, because we don't want to create side effects. It may be better to apply it to the .pagination class globally if other modules encounter the same issue. 
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | n/a
| Sponsor company   | Kookline
| How to test?      |  On a new prestashop 9.1 install, with Hummingbird 2.0.0, enable blockwishlist module, create a wishlist in the customer account, add a product to it and navigate to the list. Try to click on either link under the product, home / back to wishlist