### PR TITLE
Fix issue: The WebPack preloadFonts configuration incorrectly resolves font URLs in npm run watch mode.

### DIFF
--- a/webpack/webpack.vars.js
+++ b/webpack/webpack.vars.js
@@ -57,7 +57,7 @@ exports.webpackVars = {
     filename: 'js/[name].js',
     chunkFilename: mode === 'production' ? 'js/[chunkhash].js' : 'js/[id].js',
     path: path.resolve(themeDev, '../assets'),
-    publicPath: mode === 'production' ? '../' : `${serverAddress === 'localhost' ? siteURL : `${siteURL}:${port}`}${publicPath}`,
+    publicPath: mode === 'production' || !siteURL ? '../' : `${serverAddress === 'localhost' ? siteURL : `${siteURL}:${port}`}${publicPath}`,
     pathinfo: false,
     library: {
       name: 'Theme',


### PR DESCRIPTION
Fix issue: The WebPack preloadFonts configuration incorrectly resolves font URLs in npm run watch mode.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix issue: The WebPack preloadFonts configuration incorrectly resolves font URLs in npm run watch mode.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #989
| Sponsor company   | Metin EREN
| How to test?      | Steps to reproduce below:
1. Open Terminal
2. Change directory to cd /prestashop/themes/hummingbird/
3. run the npm install command
4. run the npm run watch
5. look at the /prestashop/themes/hummingbird/assets/preload.html
