### PR TITLE
Update order-detail.tpl

### DIFF
--- a/templates/customer/order-detail.tpl
+++ b/templates/customer/order-detail.tpl
@@ -139,7 +139,7 @@
 
   <hr class="order-separator">
 
-  {capture name='displayOrderDetail'}{hook h='displayOrderDetail'}{/capture}
+  {capture name='displayOrderDetail'}{hook h='displayOrderDetail' order=$order}{/capture}
   {if $smarty.capture.displayOrderDetail}
     {$smarty.capture.displayOrderDetail nofilter}
 

--- a/templates/customer/order-detail.tpl
+++ b/templates/customer/order-detail.tpl
@@ -139,7 +139,7 @@
 
   <hr class="order-separator">
 
-  {capture name='displayOrderDetail'}{hook h='displayOrderDetail' order=$order}{/capture}
+  {capture name='displayOrderDetail'}{$HOOK_DISPLAYORDERDETAIL nofilter}{/capture}
   {if $smarty.capture.displayOrderDetail}
     {$smarty.capture.displayOrderDetail nofilter}
 


### PR DESCRIPTION
| Questions         | Answers
  | ------------------| -------------------------------------------------------
  | Description?      | Check below
  | Type?             | bug fix
  | BC breaks?        | no
  | Deprecations?     | no
  | Fixed ticket?     | 
  | Sponsor company   | https://www.openservis.cz/
  | How to test?      | Check below
  
   
  DESCRIPTION
  
  In `templates/customer/order-detail.tpl` the `displayOrderDetail` hook was re-invoked directly with `{hook
  h='displayOrderDetail'}` and **no parameters**. `OrderDetailController` already runs `Hook::exec('displayOrderDetail', ['order' =>
  $order])` and assigns the result to `$HOOK_DISPLAYORDERDETAIL`, but the template ignored that variable and called the hook again
  bare — so modules listening on `displayOrderDetail` received an empty `$params` (no `order` key). This broke those modules and, on
  PHP 8, produced warnings (`Undefined array key "order"`, `Attempt to read property "id" on null`). This change renders the
  controller-provided `$HOOK_DISPLAYORDERDETAIL` instead, so the hook again receives the real `Order` object. It is consistent with
  the Classic theme and with how Hummingbird already renders `$HOOK_ORDER_CONFIRMATION` and `$HOOK_PAYMENT_RETURN`.
  
  HOW TO TEST
  
1.  Install PrestaShop 9.x with the Hummingbird theme.
2. Enable a module implementing
  `hookDisplayOrderDetail()` that reads `$params['order']` (e.g. one that prints `$params['order']->id`). 
3. Open a customer
  order-detail page (`index.php?controller=order-detail&id_order=X`). **Before:** `$params['order']` is undefined — the module output
   is missing and PHP 8 logs `Undefined array key "order"` / `Attempt to read property "id" on null`. **After:** the hook receives
  the `Order` object, the module renders correctly, and the warnings are gone.