### PR TITLE
Fix improper width bug in slider.tpl template file

### DIFF
--- a/modules/ps_imageslider/views/templates/hook/slider.tpl
+++ b/modules/ps_imageslider/views/templates/hook/slider.tpl
@@ -4,7 +4,7 @@
  *}
 
 {if $homeslider.slides}
-  <section class="ps-imageslider">
+  <section class="ratio ratio-homeSlider container">
     <div
       id="ps_imageslider"
       class="carousel slide"


### PR DESCRIPTION
Fixed a layout bug where the element (whole slider) was not fitting the page container width. Wrapped the structure in proper Bootstrap classes to prevent layout breaking on wider screens.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixed a layout bug in the slider.tpl file where a page section was not adapting properly to the site width. Wrapped the structure in proper Bootstrap classes to ensure it aligns perfectly within the page container on wider screens.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | None
| Sponsor company   | None
| How to test?      | 1. Activate slider at hummingbird template's page configuration. 2. Add an image in slider configuration. 3. Open and compare website before and after change.

Website before change:
<img width="1919" height="666" alt="Zrzut ekranu 2026-05-28 113325" src="https://github.com/user-attachments/assets/2b07f16c-847c-4905-b817-55d43bd530f1" />

Website after change:
<img width="1890" height="635" alt="Zrzut ekranu 2026-05-28 113053" src="https://github.com/user-attachments/assets/e9c78fa1-1f29-4cad-b8c1-07ac63a9e072" />

