### PR TITLE
Fix mobile menu aria label

### DIFF
--- a/modules/ps_mainmenu/ps_mainmenu.tpl
+++ b/modules/ps_mainmenu/ps_mainmenu.tpl
@@ -215,7 +215,7 @@
   class="ps-mainmenu ps-mainmenu--mobile offcanvas offcanvas-start js-menu-canvas"
   tabindex="-1"
   id="mobileMenu"
-  aria-labelledby="mobileMenuLabel"
+  aria-label="{l s='Main menu' d='Shop.Theme.Global'}"
 >
   <div class="offcanvas-header">
     <div class="ps-mainmenu__back-button">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR fixes an accessibility issue in the mobile menu template. The `aria-labelledby="mobileMenuLabel"` attribute referenced a non-existing element ID, so it has been replaced with an explicit `aria-label="{l s='Main menu' d='Shop.Theme.Global'}"`.<br/>This avoids an invalid ARIA reference and provides an accessible name for the mobile menu.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | Codencode snc
| How to test?      | 
