### PR TITLE
Close mobile menu when switching to desktop layout

### DIFF
--- a/src/js/mobile-menu.ts
+++ b/src/js/mobile-menu.ts
@@ -3,6 +3,7 @@
  * file that was distributed with this source code.
  */
 
+import {Offcanvas} from 'bootstrap';
 import {isHTMLElement} from '@helpers/typeguards';
 
 const initMobileMenu = () => {
@@ -14,6 +15,7 @@ const initMobileMenu = () => {
   const backButton = document.querySelector(MobileMenuMap.backButton);
   const menuCanvas = document.querySelector(MobileMenuMap.menuCanvas);
   const defaultBackTitle = backTitle?.innerHTML;
+  const desktopMenu = document.querySelector('.js-menu-desktop');
 
   const backToParent = () => {
     if (
@@ -47,6 +49,34 @@ const initMobileMenu = () => {
       }
     }
   };
+
+  const closeMobileMenu = (): void => {
+    if (!isHTMLElement(menuCanvas)) {
+      return;
+    }
+
+    Offcanvas.getInstance(menuCanvas)?.hide();
+  };
+
+  const isDesktopMenuVisible = (): boolean => {
+    if (!isHTMLElement(desktopMenu)) {
+      return false;
+    }
+
+    return window.getComputedStyle(desktopMenu).display !== 'none';
+  };
+
+  let wasDesktopMenuVisible = isDesktopMenuVisible();
+
+  window.addEventListener('resize', () => {
+    const isNowDesktopMenuVisible = isDesktopMenuVisible();
+
+    if (!wasDesktopMenuVisible && isNowDesktopMenuVisible) {
+      closeMobileMenu();
+    }
+
+    wasDesktopMenuVisible = isNowDesktopMenuVisible;
+  });
 
   menuCanvas?.addEventListener('hidden.bs.offcanvas', () => {
     const currentMenu = document.querySelector(MobileMenuMap.menuCurrent);


### PR DESCRIPTION
Automatically closes the mobile offcanvas menu when the viewport switches to the desktop layout, preventing the mobile menu from remaining open after resizing.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR closes the mobile offcanvas menu automatically when switching from the mobile layout to the desktop layout.<br><br>The visibility of the desktop menu is checked using the actual computed style of `.js-menu-desktop`, avoiding hardcoded breakpoints.<br><br>When the desktop menu becomes visible after a viewport resize, the existing Bootstrap Offcanvas instance is closed using `Offcanvas.getInstance(menuCanvas)?.hide()`.<br><br>This prevents the mobile menu from remaining open in an inconsistent state after resizing the viewport to desktop.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/hummingbird/issues/1025
| Sponsor company   | Codencode snc
| How to test?      | 1. Open the Hummingbird theme on a mobile viewport.<br>2. Open the mobile menu.<br>3. Resize the viewport to a desktop width.<br>4. Check that the mobile offcanvas menu is closed automatically when the desktop menu becomes visible.