### PR TITLE
Add required attribute to date field in Hummingbird form template

### DIFF
--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -92,7 +92,18 @@
     {elseif $field.type === 'date'}
 
       {block name='form_field_item_date'}
-        <input name="{$field.name}" class="form-control" type="date" id="field-{$field.name}" value="{$field.value}"{if isset($field.availableValues.placeholder)} placeholder="{$field.availableValues.placeholder}" aria-label="{$field.availableValues.placeholder}"{/if}>
+        <input
+          name="{$field.name}"
+          class="form-control"
+          type="date"
+          id="field-{$field.name}"
+          value="{$field.value}"
+          {if isset($field.availableValues.placeholder)}
+            placeholder="{$field.availableValues.placeholder}"
+            aria-label="{$field.availableValues.placeholder}"
+          {/if}
+          {if $field.required}required{/if}
+        >
         {if isset($field.availableValues.comment)}
           <span class="form-text">
             {$field.availableValues.comment}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR adds the required attribute to the date field rendering in the Hummingbird theme form partial, so date inputs now behave consistently with the other required form fields.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | @Codencode 
| How to test?      | 1. Install module: [pr_1027_hummingbirt.zip](https://github.com/user-attachments/files/28384740/pr_1027_hummingbirt.zip)  .</br>2. Open the module configuration page and click the front-office demo link.</br>3. On the demo page, verify that the date field has the required attribute, consistently with the required text input and textarea.

