### PR TITLE
Improve rich text link accessibility in Hummingbird theme

### DIFF
--- a/src/scss/prestashop/components/_rich-text.scss
+++ b/src/scss/prestashop/components/_rich-text.scss
@@ -5,6 +5,17 @@
 .rich-text {
   line-height: 1.5;
 
+  a {
+    text-decoration: underline;
+    text-decoration-thickness: 0.1em;
+    text-underline-offset: 0.15em;
+
+    &:hover {
+      color: var(--bs-link-hover-color);
+      text-decoration-thickness: 0.2em;
+    }
+  }
+
   table {
     @include table;
     @include table-bordered;

--- a/src/scss/prestashop/components/_rich-text.scss
+++ b/src/scss/prestashop/components/_rich-text.scss
@@ -7,7 +7,6 @@
 
   a {
     text-decoration: underline;
-    text-decoration-thickness: 0.1em;
     text-underline-offset: 0.15em;
 
     &:hover {

--- a/src/scss/prestashop/components/_rich-text.scss
+++ b/src/scss/prestashop/components/_rich-text.scss
@@ -7,11 +7,10 @@
 
   a {
     text-decoration: underline;
-    text-underline-offset: 0.15em;
+    text-underline-offset: 0.125em;
 
     &:hover {
-      color: var(--bs-link-hover-color);
-      text-decoration-thickness: 0.2em;
+      text-underline-offset: 0.25em;
     }
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Improves accessibility of links inside rich text content by restoring a persistent underline and making hover/focus states perceivable beyond color alone.<br/>This helps users distinguish links more reliably in CMS pages, product descriptions, and category descriptions.<br/>It aligns the theme with better accessibility practices by not relying on color as the only visual cue for interactive text.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | @Codencode 
| How to test?      | 1. Open a CMS page, a product page with description content, and a category page with description content, then verify that links inside rich text are underlined by default.<br/>2. Hover those links and verify that the hover state is perceivable not only through color change, but also through the thicker and more offset underline.<br/>3. Navigate with keyboard using Tab and verify that focused links display a visible focus outline.<br/>4. Confirm that links outside rich text areas keep their existing styling unchanged.