### PR TITLE
Use server side structured data if available

### DIFF
--- a/templates/_partials/head.tpl
+++ b/templates/_partials/head.tpl
@@ -37,14 +37,14 @@
     {/foreach}
   {/block}
 
-  {** Render structured data from the server **}
+  {** Render structured data from the core. Available since PrestaShop 9.2 **}
   {if !empty($structured_data)}
     {foreach from=$structured_data item="element"}
       {** 320 in the method parameter means JSON_UNESCAPED_SLASHES (64) + JSON_UNESCAPED_UNICODE (256) **}
     <script type="application/ld+json">{$element|@json_encode:320 nofilter}</script>
     {/foreach}
 
-  {** Render them in a legacy, manual way. This will be removed in future versions of this theme. **}
+  {** Or render them in a legacy, manual way. This will be removed in future versions of this theme. **}
   {else}
     {block name='head_microdata'}
       {include file='_partials/microdata/head-jsonld.tpl'}

--- a/templates/_partials/head.tpl
+++ b/templates/_partials/head.tpl
@@ -37,11 +37,20 @@
     {/foreach}
   {/block}
 
-  {block name='head_microdata'}
-    {include file='_partials/microdata/head-jsonld.tpl'}
-  {/block}
+  {** Render structured data from the server **}
+  {if !empty($structured_data)}
+    {foreach from=$structured_data item="element"}
+      {** 320 in the method parameter means JSON_UNESCAPED_SLASHES (64) + JSON_UNESCAPED_UNICODE (256) **}
+    <script type="application/ld+json">{$element|@json_encode:320 nofilter}</script>
+    {/foreach}
 
-  {block name='head_microdata_special'}{/block}
+  {** Render them in a legacy, manual way. This will be removed in future versions of this theme. **}
+  {else}
+    {block name='head_microdata'}
+      {include file='_partials/microdata/head-jsonld.tpl'}
+    {/block}
+    {block name='head_microdata_special'}{/block}
+  {/if}
 
   {block name='head_pagination_seo'}
     {include file='_partials/pagination-seo.tpl'}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds server side structured data added in https://github.com/PrestaShop/PrestaShop/pull/37552 to the template. The manual way of rendering them is still available not to break compatibility. We can remove the old part for Hummingbird 3 and PrestaShop 10.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | TRENDO s.r.o.
| How to test?      | 
