### PR TITLE
Improve order detail page heading hierarchy and table accessibility

### DIFF
--- a/templates/customer/_partials/order-carrier.tpl
+++ b/templates/customer/_partials/order-carrier.tpl
@@ -3,9 +3,9 @@
  * LICENSE.md file that was distributed with this source code.
  *}
 <section class="order-carriers">
-  <h3 class="h3" id="order_carriers_heading">{l s='Shipment tracking details' d='Shop.Theme.Customeraccount'}</h3>
+  <h2 id="order_carriers_heading">{l s='Shipment tracking details' d='Shop.Theme.Customeraccount'}</h2>
 
-  <div class="grid-table" role="table" aria-label="{l s='Order tracking' d='Shop.Theme.Customeraccount'}" aria-describedby="order_carriers_heading">
+  <div class="grid-table" role="table" aria-label="{l s='Order tracking' d='Shop.Theme.Customeraccount'}">
     <div class="grid-table__inner grid-table__inner--5" role="rowgroup">
       <div class="grid-table__header" role="row">
         <span class="grid-table__cell" role="columnheader">{l s='Date' d='Shop.Theme.Global'}</span>

--- a/templates/customer/_partials/order-detail-no-return-multishipment.tpl
+++ b/templates/customer/_partials/order-detail-no-return-multishipment.tpl
@@ -3,7 +3,7 @@
  * LICENSE.md file that was distributed with this source code.
  *}
 {block name='order_products_table'}
-  <div class="grid-table grid-table--collapse mb-0" role="table" aria-label="{l s='Products details' d='Shop.Theme.Customeraccount'}" aria-describedby="order_products_heading">
+  <div class="grid-table grid-table--collapse mb-0" role="table" aria-label="{l s='Products details' d='Shop.Theme.Customeraccount'}">
     <div class="grid-table__inner grid-table__inner--4" role="rowgroup">
       <div class="grid-table__header" role="row">
         <span class="grid-table__cell" role="columnheader">{l s='Product' d='Shop.Theme.Catalog'}</span>

--- a/templates/customer/_partials/order-detail-no-return.tpl
+++ b/templates/customer/_partials/order-detail-no-return.tpl
@@ -3,7 +3,7 @@
  * LICENSE.md file that was distributed with this source code.
  *}
 {block name='order_products_table'}
-  <div class="grid-table grid-table--collapse mb-0" role="table" aria-label="{l s='Products details' d='Shop.Theme.Customeraccount'}" aria-describedby="order_products_heading">
+  <div class="grid-table grid-table--collapse mb-0" role="table" aria-label="{l s='Products details' d='Shop.Theme.Customeraccount'}">
     <div class="grid-table__inner grid-table__inner--4" role="rowgroup">
       <div class="grid-table__header" role="row">
         <span class="grid-table__cell" role="columnheader">{l s='Product' d='Shop.Theme.Catalog'}</span>

--- a/templates/customer/_partials/order-detail-return-multishipment.tpl
+++ b/templates/customer/_partials/order-detail-return-multishipment.tpl
@@ -4,7 +4,7 @@
  *}
 {block name='order_products_table'}
   <form id="order-return-form" class="js-order-return-form" action="{$urls.pages.order_follow}" method="post" data-ps-action="form-validation">
-    <div class="grid-table grid-table--collapse mb-0" role="table" data-ps-ref="order-return-products-table" aria-label="{l s='Products details' d='Shop.Theme.Catalog'}" aria-describedby="order_products_heading">
+    <div class="grid-table grid-table--collapse mb-0" role="table" data-ps-ref="order-return-products-table" aria-label="{l s='Products details' d='Shop.Theme.Catalog'}">
       <div class="grid-table__inner grid-table__inner--6" role="rowgroup">
         <div class="grid-table__header" role="row">
           <span class="grid-table__cell" role="columnheader" aria-label="{l s='Select product to return' d='Shop.Theme.Catalog'}">
@@ -61,7 +61,7 @@
     <hr class="order-separator">
 
     <section class="order-merchandise-return">
-      <h3 class="h3">{l s='Merchandise return' d='Shop.Theme.Customeraccount'}</h3>
+      <h2>{l s='Merchandise return' d='Shop.Theme.Customeraccount'}</h2>
 
       <label class="form-label required" for="return_notes">{l s='Return notes' d='Shop.Forms.Labels'}</label>
 

--- a/templates/customer/_partials/order-detail-return.tpl
+++ b/templates/customer/_partials/order-detail-return.tpl
@@ -4,7 +4,7 @@
  *}
 {block name='order_products_table'}
   <form id="order-return-form" class="js-order-return-form" action="{$urls.pages.order_follow}" method="post" data-ps-action="form-validation">
-    <div class="grid-table grid-table--collapse mb-0" role="table" data-ps-ref="order-return-products-table" aria-label="{l s='Products details' d='Shop.Theme.Catalog'}" aria-describedby="order_products_heading">
+    <div class="grid-table grid-table--collapse mb-0" role="table" data-ps-ref="order-return-products-table" aria-label="{l s='Products details' d='Shop.Theme.Catalog'}">
       <div class="grid-table__inner grid-table__inner--6" role="rowgroup">
         <div class="grid-table__header" role="row">
           <span class="grid-table__cell" role="columnheader" aria-label="{l s='Select product to return' d='Shop.Theme.Catalog'}">
@@ -185,7 +185,7 @@
     <hr class="order-separator">
 
     <section class="order-merchandise-return">
-      <h3 class="h3">{l s='Merchandise return' d='Shop.Theme.Customeraccount'}</h3>
+      <h2>{l s='Merchandise return' d='Shop.Theme.Customeraccount'}</h2>
 
       <label class="form-label required" for="return_notes">{l s='Return notes' d='Shop.Forms.Labels'}</label>
 

--- a/templates/customer/_partials/order-messages.tpl
+++ b/templates/customer/_partials/order-messages.tpl
@@ -29,7 +29,7 @@
 {block name='order_message_form'}
   <section class="order-message-form">
     <form action="{$urls.pages.order_detail}" method="post" data-ps-action="form-validation">
-      <h3 class="h3">{l s='Add a message' d='Shop.Theme.Customeraccount'}</h3>
+      <h2>{l s='Add a message' d='Shop.Theme.Customeraccount'}</h2>
 
       <p>
         {l s='If you would like to add a comment about your order, please write it in the field below.' d='Shop.Theme.Customeraccount'}

--- a/templates/customer/_partials/order-shipments.tpl
+++ b/templates/customer/_partials/order-shipments.tpl
@@ -3,9 +3,9 @@
  * LICENSE.md file that was distributed with this source code.
  *}
 <section class="order-carriers">
-  <h3 class="h3" id="order_carriers_heading">{l s='Shipment tracking details' d='Shop.Theme.Customeraccount'}</h3>
+  <h2 id="order_carriers_heading">{l s='Shipment tracking details' d='Shop.Theme.Customeraccount'}</h2>
 
-  <div class="grid-table" role="table" aria-label="{l s='Order tracking' d='Shop.Theme.Customeraccount'}" aria-describedby="order_carriers_heading">
+  <div class="grid-table" role="table" aria-label="{l s='Order tracking' d='Shop.Theme.Customeraccount'}">
     <div class="grid-table__inner grid-table__inner--5" role="rowgroup">
       <div class="grid-table__header" role="row">
         <span class="grid-table__cell" role="columnheader">{l s='Date' d='Shop.Theme.Global'}</span>

--- a/templates/customer/order-detail.tpl
+++ b/templates/customer/order-detail.tpl
@@ -67,9 +67,9 @@
 
   {block name='order_status'}
     <section class="order-status">
-      <h2 class="h3" id="order_status_heading">{l s='Follow your order\'s status step-by-step' d='Shop.Theme.Customeraccount'}</h2>
+      <h2 id="order_status_heading">{l s='Follow your order\'s status step-by-step' d='Shop.Theme.Customeraccount'}</h2>
 
-      <div class="order-status__table grid-table grid-table--collapse" role="table" aria-label="{l s='Order status' d='Shop.Theme.Customeraccount'}" aria-describedby="order_status_heading">
+      <div class="order-status__table grid-table grid-table--collapse" role="table" aria-label="{l s='Order status' d='Shop.Theme.Customeraccount'}">
         <div class="grid-table__inner grid-table__inner--2" role="rowgroup">
           <div class="grid-table__header" role="row">
             <span class="grid-table__cell" role="columnheader">{l s='Date' d='Shop.Theme.Global'}</span>
@@ -109,15 +109,15 @@
 
   {block name='order_addresses'}
     <section class="order-addresses">
-      <h3 class="h3">{l s='Addresses' d='Shop.Theme.Customeraccount'}</h3>
+      <h2>{l s='Addresses' d='Shop.Theme.Customeraccount'}</h2>
 
       <div class="order-addresses__list">
         {if $order.addresses.delivery}
           <article id="delivery-address" class="address-card">
             <div class="address-card__container">
-              <h4 class="address-card__alias">
+              <h3 class="address-card__alias">
                 {l s='Delivery address: %alias%' d='Shop.Theme.Checkout' sprintf=['%alias%' => $order.addresses.delivery.alias]}
-              </h4>
+              </h3>
 
               <address class="address-card__content mb-0">{$order.addresses.delivery.formatted nofilter}</address>
             </div>
@@ -126,9 +126,9 @@
 
         <article id="invoice-address" class="address-card">
           <div class="address-card__container">
-            <h4 class="address-card__alias">
+            <h3 class="address-card__alias">
               {l s='Invoice address: %alias%' d='Shop.Theme.Checkout' sprintf=['%alias%' => $order.addresses.invoice.alias]}
-            </h4>
+            </h3>
 
             <address class="address-card__content mb-0">{$order.addresses.invoice.formatted nofilter}</address>
           </div>
@@ -148,7 +148,7 @@
 
   {block name='order_products'}
     <section class="order-products">
-      <h3 class="h3" id="order_products_heading">{l s='Products details' d='Shop.Theme.Customeraccount'}</h3>
+      <h2 id="order_products_heading">{l s='Products details' d='Shop.Theme.Customeraccount'}</h2>
 
       {block name='order_detail'}
         {if $order.details.is_returnable}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Improves the heading hierarchy in the Hummingbird order detail page by promoting the main section titles to `h2`, demoting delivery and invoice address titles to `h3`, and aligning the merchandise return section with the same semantic level.<br/><br/>Removes redundant `aria-describedby` attributes from the order status, shipment tracking, and product detail table-like containers when they only repeated the heading already covered by `aria-label`, keeping the markup cleaner and more meaningful for assistive technologies.
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | @Codencode 
| How to test?      | Go to the customer order detail page and verify that the main section titles are announced and rendered as h2, that delivery and invoice address titles are h3, and that the order status, shipment tracking, and product detail table-like containers no longer use redundant aria-describedby references to their headings.