### PR TITLE
Improve order confirmation payment information heading semantics

### DIFF
--- a/modules/ps_cashondelivery/views/templates/hook/displayOrderConfirmation.tpl
+++ b/modules/ps_cashondelivery/views/templates/hook/displayOrderConfirmation.tpl
@@ -5,7 +5,7 @@
 
 <div id="ps_cashondelivery-displayOrderConfirmation" class="card border-1 mb-3">
   <div class="card-body">
-    <p class="h2">{l s='Payment information' d='Shop.Theme.Checkout'}</p>
+    <h2>{l s='Payment information' d='Shop.Theme.Checkout'}</h2>
 
     <p class="h3 card-subtitle text-secondary mb-3">{l s='Pay by Cash on Delivery' d='Modules.Cashondelivery.Shop'}</p>
 

--- a/modules/ps_cashondelivery/views/templates/hook/payment_return.tpl
+++ b/modules/ps_cashondelivery/views/templates/hook/payment_return.tpl
@@ -5,7 +5,7 @@
 
 <div id="ps_cashondelivery-displayOrderConfirmation" class="card border-1 mb-3">
   <div class="card-body">
-    <p class="h2">{l s='Payment information' d='Shop.Theme.Checkout'}</p>
+    <h2>{l s='Payment information' d='Shop.Theme.Checkout'}</h2>
 
     <p class="h3 card-subtitle text-secondary mb-3">{l s='Pay by Cash on Delivery' d='Modules.Cashondelivery.Shop'}</p>
 
@@ -21,4 +21,3 @@
     <a href="{$contact_url}" rel="nofollow">{l s='customer support' d='Modules.Cashondelivery.Shop'}</a>.
   </div>
 </div>
-

--- a/modules/ps_checkpayment/views/templates/hook/payment_return.tpl
+++ b/modules/ps_checkpayment/views/templates/hook/payment_return.tpl
@@ -5,7 +5,7 @@
 
 <div class="card border-1 mb-3">
   <div class="card-body">
-    <p class="h2">{l s='Payment information' d='Shop.Theme.Checkout'}</p>
+    <h2>{l s='Payment information' d='Shop.Theme.Checkout'}</h2>
 
     <p class="h3 card-subtitle text-secondary mb-3">{l s='Pay by Check' d='Modules.Checkpayment.Shop'}</p>
 

--- a/modules/ps_wirepayment/views/templates/hook/payment_return.tpl
+++ b/modules/ps_wirepayment/views/templates/hook/payment_return.tpl
@@ -5,7 +5,7 @@
 
 <div class="card border-1 mb-3">
   <div class="card-body">
-    <p class="h2">{l s='Payment information' d='Shop.Theme.Checkout'}</p>
+    <h2>{l s='Payment information' d='Shop.Theme.Checkout'}</h2>
 
     <p class="h3 card-subtitle text-secondary mb-3">{l s='Pay by Bank Wire' d='Modules.Wirepayment.Shop'}</p>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Replaces the styled paragraph used for the payment information title on the order confirmation page with a real `h2` in the Hummingbird payment module templates, so the section has the correct semantic heading level while preserving the existing content and layout.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     |
| Sponsor company   | @Codencode 
| How to test?      | Place an order with a payment method covered by the Hummingbird module overrides, open the order confirmation page, and verify that "Payment information" is rendered as an `h2` instead of a paragraph styled with the `.h2` class.


