### PR TITLE
Improve social follow link accessibility

### DIFF
--- a/modules/ps_socialfollow/ps_socialfollow.tpl
+++ b/modules/ps_socialfollow/ps_socialfollow.tpl
@@ -9,7 +9,7 @@
         <ul class="list-unstyled d-flex column-gap-1 row-gap-2 flex-wrap justify-content-center align-items-center mb-0">
           {foreach from=$social_links key=key item='social_link'}
             <li>
-              <a class="p-2" href="{$social_link.url}" title="{$social_link.label}" target="_blank" rel="noopener noreferrer">
+              <a class="p-2" href="{$social_link.url}" title="{$social_link.label}" target="_blank" rel="noopener noreferrer" aria-label="{$social_link.label}">
                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 16 16">
                   {if $key === 'facebook'}
                     <path d="M16 8.049c0-4.446-3.582-8.05-8-8.05C3.58 0-.002 3.603-.002 8.05c0 4.017 2.926 7.347 6.75 7.951v-5.625h-2.03V8.05H6.75V6.275c0-2.017 1.195-3.131 3.022-3.131.876 0 1.791.157 1.791.157v1.98h-1.009c-.993 0-1.303.621-1.303 1.258v1.51h2.218l-.354 2.326H9.25V16c3.824-.604 6.75-3.934 6.75-7.951"/>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR improves the accessibility of the social follow links. <br/>The `aria-label` attribute has been added to each social link using the existing social network label: `aria-label="{$social_link.label}"`<br/>This provides an explicit accessible name for the link, helping assistive technologies identify the purpose of each social media link more clearly.| Type?             | bug fix / improvement / new feature / refactor
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | @Codencode 
| How to test?      | 1. Enable and configure the `ps_socialfollow` module with at least one social network link.<br/>2. Open a page where the social follow block is displayed.<br/>3. Inspect the social link markup.<br/>4. Check that each social link contains the `aria-label` attribute with the expected social network label.