### PR TITLE
Remove product_without_taxes block as it is never displayed

### DIFF
--- a/src/scss/prestashop/pages/_product.scss
+++ b/src/scss/prestashop/pages/_product.scss
@@ -68,6 +68,12 @@ $component-name: product;
       color: var(--bs-tertiary-color);
     }
 
+    &__taxless-price {
+      font-size: 0.875rem;
+      line-height: 1.2;
+      color: var(--bs-tertiary-color);
+    }
+
     &__prices {
       font-size: 1.25rem;
       line-height: 1;

--- a/templates/catalog/_partials/product-prices.tpl
+++ b/templates/catalog/_partials/product-prices.tpl
@@ -81,12 +81,6 @@
             {/if}
           {/block}
         </div>
-
-        {block name='product_without_taxes'}
-          {if $priceDisplay == 2}
-            <span class="product__taxless-price">{l s='%price% tax excl.' d='Shop.Theme.Catalog' sprintf=['%price%' => $product.price_tax_exc]}</span>
-          {/if}
-        {/block}
       </div>
     {/block}
 

--- a/templates/catalog/_partials/product-prices.tpl
+++ b/templates/catalog/_partials/product-prices.tpl
@@ -81,6 +81,12 @@
             {/if}
           {/block}
         </div>
+
+        {block name='product_without_taxes'}
+          {if $priceDisplay == 0 && $configuration.is_b2b}
+            <span class="product__taxless-price">{l s='%price% tax excluded' d='Shop.Theme.Catalog' sprintf=['%price%' => $product.price_tax_exc]}</span>
+          {/if}
+        {/block}
       </div>
     {/block}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Remove the `product_without_taxes` block, as it is never displayed due to an incorrect condition (`$priceDisplay == 2`, while only returns `0` or `1`). I believe this feature displaying at the time both prices (with and without taxes) is not needed in the default theme. WDYT?
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/hummingbird/issues/1031
| Sponsor company   | @PrestaShopCorp
| How to test?      | --
