### PR TITLE
Only enforce password policies for new customers password

### DIFF
--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -136,6 +136,7 @@
     {elseif $field.type === 'password'}
 
       {block name='form_field_item_password'}
+        {assign var='apply_password_policy' value=$field.autocomplete === 'new-password'}
 
         <div class="input-group password-field">
           <input
@@ -145,12 +146,14 @@
             type="password"
             {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}
             value=""
-            minlength="{$configuration.password_policy.minimum_length|default:8}"
-            maxlength="{$configuration.password_policy.maximum_length|default:72}"
-            data-minscore="{$configuration.password_policy.minimum_score|default:3}"
-            data-bs-placement="top"
-            data-bs-trigger="manual"
-            data-ps-ref="password-policy-input"
+            {if $apply_password_policy}
+              minlength="{$configuration.password_policy.minimum_length|default:8}"
+              maxlength="{$configuration.password_policy.maximum_length|default:72}"
+              data-minscore="{$configuration.password_policy.minimum_score|default:3}"
+              data-bs-placement="top"
+              data-bs-trigger="manual"
+              data-ps-ref="password-policy-input"
+            {/if}
             spellcheck="false"
             {if $field.required}required{/if}
           >
@@ -169,7 +172,9 @@
           </button>
         </div>
 
-        <div data-ps-target="password-feedback-target"></div>
+        {if $apply_password_policy}
+          <div data-ps-target="password-feedback-target"></div>
+        {/if}
       {/block}
 
     {elseif $field.type === 'textarea'}

--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -136,7 +136,7 @@
     {elseif $field.type === 'password'}
 
       {block name='form_field_item_password'}
-        {assign var='apply_password_policy' value=$field.autocomplete === 'new-password'}
+        {assign var='apply_password_policy' value=($field.autocomplete|default:'') === 'new-password'}
 
         <div class="input-group password-field">
           <input


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Only enforce new theme password policies (length) for new customer password. It's a very silent issue for shop migration if in the past you have different password policies and your customer defined weaker password. The theme will force to enter 8 char for the connection. A lot of your old customers will not be able to log anymore and the message they receive is only "you cannot enter less than x char". It's bad. Maybe if we want to cover this case we need to be explicit and request a password reset. But in this PR, i only deactivate the TPL check for the field where it is not used in account creation.
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     |
| How to test?      | Use a customer account defined in old Presta versions that you know the password is short and you will see you cannot login anymore.

AI assisted proposition, to only enforce client check (tpl) on this field when
` {assign var='apply_password_policy' value=$field.autocomplete === 'new-password'}`

