### PR TITLE
Improve password policy handling

### DIFF
--- a/src/js/components/usePasswordPolicy.ts
+++ b/src/js/components/usePasswordPolicy.ts
@@ -26,15 +26,13 @@ const safeParseJSON = (jsonString: string): Record<string, string> => {
 // Utility function to update requirement icons
 const updateRequirementIcons = (
   feedbackContainer: HTMLElement,
-  elementInput: HTMLInputElement,
+  lengthValid: boolean,
   strengthValid: boolean,
 ): void => {
   const lengthIcon = feedbackContainer.querySelector(PasswordPolicyMap.requirementLengthIcon);
   const scoreIcon = feedbackContainer.querySelector(PasswordPolicyMap.requirementScoreIcon);
 
   // Password length validation
-  const lengthValid = !elementInput.validity.tooShort && !elementInput.validity.tooLong;
-
   if (lengthIcon) {
     lengthIcon.classList.toggle('text-success', lengthValid);
     lengthIcon.classList.toggle('text-danger', !lengthValid);
@@ -51,8 +49,9 @@ const updateRequirementIcons = (
 const updateProgressBar = (
   feedbackContainer: HTMLElement,
   strength: number,
+  requirementsMet: boolean,
 ): void => {
-  const strengthFeedback = getProgressBarInfo(strength);
+  const strengthFeedback = getProgressBarInfo(strength, requirementsMet);
   const progressBar = feedbackContainer.querySelector<HTMLElement>(PasswordPolicyMap.progressBar);
 
   if (progressBar) {
@@ -98,19 +97,25 @@ const buildValidationMessage = (
 };
 
 // Utility function to get password strength feedback
-const getProgressBarInfo = (strength: number) => {
-  const strengthLevels = {
-    0: {color: 'bg-danger', percentage: 20},
-    1: {color: 'bg-danger', percentage: 40},
-    2: {color: 'bg-danger', percentage: 60},
-    3: {color: 'bg-success', percentage: 80},
-    4: {color: 'bg-success', percentage: 100},
+// The color must stay consistent with the requirement icons: the bar is green
+// only when the password meets the whole policy (length AND score) configured
+// in the back office.
+export const getProgressBarInfo = (strength: number, requirementsMet: boolean): {color: string, percentage: number} => {
+  const strengthPercentages = {
+    0: 20,
+    1: 40,
+    2: 60,
+    3: 80,
+    4: 100,
   };
 
-  const validKeys = Object.keys(strengthLevels).map(Number);
+  const validKeys = Object.keys(strengthPercentages).map(Number);
   const safeStrength = validKeys.includes(strength) ? strength : 0;
 
-  return strengthLevels[safeStrength as keyof typeof strengthLevels];
+  return {
+    color: requirementsMet ? 'bg-success' : 'bg-danger',
+    percentage: strengthPercentages[safeStrength as keyof typeof strengthPercentages],
+  };
 };
 
 const passwordValidation = async (
@@ -138,8 +143,8 @@ const passwordValidation = async (
     const scoreValid = minScore <= result.score;
 
     // Update UI components
-    updateRequirementIcons(feedbackContainer, elementInput, scoreValid);
-    updateProgressBar(feedbackContainer, result.score);
+    updateRequirementIcons(feedbackContainer, lengthValid, scoreValid);
+    updateProgressBar(feedbackContainer, result.score, lengthValid && scoreValid);
 
     // Set custom validity
     const announceValidity = feedbackContainer.querySelector<HTMLElement>(PasswordPolicyMap.announceValidity);

--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -136,6 +136,8 @@
     {elseif $field.type === 'password'}
 
       {block name='form_field_item_password'}
+        {* Enforce policy check only for new passwords (autocomplete="new-password") existing ones may predate the current policy and must stay usable. *}
+        {assign var='apply_password_policy' value=($field.autocomplete|default:'') === 'new-password'}
 
         <div class="input-group password-field">
           <input
@@ -145,12 +147,14 @@
             type="password"
             {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}
             value=""
-            minlength="{$configuration.password_policy.minimum_length|default:8}"
-            maxlength="{$configuration.password_policy.maximum_length|default:72}"
-            data-minscore="{$configuration.password_policy.minimum_score|default:3}"
-            data-bs-placement="top"
-            data-bs-trigger="manual"
-            data-ps-ref="password-policy-input"
+            {if $apply_password_policy}
+              minlength="{$configuration.password_policy.minimum_length|default:8}"
+              maxlength="{$configuration.password_policy.maximum_length|default:72}"
+              data-minscore="{$configuration.password_policy.minimum_score|default:3}"
+              data-bs-placement="top"
+              data-bs-trigger="manual"
+              data-ps-ref="password-policy-input"
+            {/if}
             spellcheck="false"
             {if $field.required}required{/if}
           >
@@ -169,7 +173,9 @@
           </button>
         </div>
 
-        <div data-ps-target="password-feedback-target"></div>
+        {if $apply_password_policy}
+          <div data-ps-target="password-feedback-target"></div>
+        {/if}
       {/block}
 
     {elseif $field.type === 'textarea'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use `autocomplete="current-password"` on the current-password field (core) and only apply the password policy to `new-password` fields (theme). An existing password may predate the policy and must stay usable, so it's no longer validated. Also fixes the strength bar to turn green only when both length and score requirements are met.<br><br>Related: PrestaShop/PrestaShop#41709 / PrestaShop/hummingbird#1044
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | --
| Sponsor company   | @PrestaShopCorp
| How to test?      | --
