### PR TITLE
Fix page scrolling to top when navigating the search with the keyboard

### DIFF
--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -4,7 +4,7 @@
  */
 
 export const layout = {
-  stickyHeader: '.js-sticky-header',
+  header: '[data-ps-ref="header"]',
 };
 
 export const facetedsearch = {

--- a/src/js/helpers/scrollPadding.ts
+++ b/src/js/helpers/scrollPadding.ts
@@ -6,7 +6,7 @@
 import SelectorsMap from '@constants/selectors-map';
 
 const setScrollPaddingTop = () => {
-  const header = document.querySelector(SelectorsMap.layout.stickyHeader) as HTMLElement;
+  const header = document.querySelector(SelectorsMap.layout.header) as HTMLElement;
 
   if (header) {
     const headerHeight = header.offsetHeight;
@@ -16,8 +16,35 @@ const setScrollPaddingTop = () => {
   }
 };
 
+// Disable while a header control is focused to stop browser scrolling the page to top.
+const suspendScrollPadding = () => {
+  document.documentElement.style.setProperty('scroll-padding-top', '0px');
+};
+
+// Restore after a suspend.
+const restoreScrollPadding = () => {
+  document.documentElement.style.setProperty('scroll-padding-top', 'var(--scroll-padding-top)');
+};
+
+// Suspend while focus is inside the header, restore once it leaves.
+const bindHeaderFocus = () => {
+  const header = document.querySelector(SelectorsMap.layout.header) as HTMLElement;
+
+  if (!header) return;
+
+  header.addEventListener('focusin', suspendScrollPadding);
+  header.addEventListener('focusout', (e: FocusEvent) => {
+    if (!header.contains(e.relatedTarget as Node)) {
+      restoreScrollPadding();
+    }
+  });
+};
+
 const initScrollPaddingTop = () => {
-  window.addEventListener('load', setScrollPaddingTop);
+  window.addEventListener('load', () => {
+    setScrollPaddingTop();
+    bindHeaderFocus();
+  });
   window.addEventListener('resize', setScrollPaddingTop);
 };
 

--- a/templates/layouts/layout-both-columns.tpl
+++ b/templates/layouts/layout-both-columns.tpl
@@ -29,7 +29,7 @@
       {include file='catalog/_partials/product-activation.tpl'}
     {/block}
 
-    <header id="header" class="header js-sticky-header">
+    <header id="header" class="header js-sticky-header" data-ps-ref="header">
       {block name='header'}
         {include file='_partials/header.tpl'}
       {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The sticky header's controls (search input, etc.) sit inside the scroll-padding-top band, so the browser scrolls the page to the top on focus/keystroke. Suspend scroll-padding-top while focus is inside the header and restore it on leave, leaving the --scroll-padding-top custom property intact so anchor offsets keep working.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/hummingbird/issues/1013
| Sponsor company   | @PrestaShopCorp
| How to test?      | Follow the issue
