### PR TITLE
Improve product thumbnails list markup accessibility

### DIFF
--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -223,7 +223,7 @@ const selectorsMap = {
     thumbnail: '.js-thumb-container',
     productImagesModal: '[data-ps-ref="product-images-modal"]',
     productImagesModalCarousel: '[data-ps-ref="product-images-modal-carousel"]',
-    activeThumbail: (id: number): string => `.product__thumbnails-item:nth-child(${id + 1}) .js-thumb-container`,
+    activeThumbail: (id: number): string => `[data-ps-ref="product-thumbnail-item"]:nth-child(${id + 1}) [data-ps-ref="product-thumbnail"]`,
     productAvailability: '[data-ps-ref="product-availability"]',
     rightSection: '[data-ps-ref="product-right"]',
   },

--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -223,7 +223,7 @@ const selectorsMap = {
     thumbnail: '.js-thumb-container',
     productImagesModal: '[data-ps-ref="product-images-modal"]',
     productImagesModalCarousel: '[data-ps-ref="product-images-modal-carousel"]',
-    activeThumbail: (id: number): string => `.js-thumb-container:nth-child(${id + 1})`,
+    activeThumbail: (id: number): string => `.product__thumbnails-item:nth-child(${id + 1}) .js-thumb-container`,
     productAvailability: '[data-ps-ref="product-availability"]',
     rightSection: '[data-ps-ref="product-right"]',
   },

--- a/src/scss/prestashop/pages/_product.scss
+++ b/src/scss/prestashop/pages/_product.scss
@@ -20,6 +20,7 @@ $component-name: product;
     }
 
     &__thumbnail {
+      width: 100%;
       padding: 0;
       background-color: transparent;
       border: none;

--- a/src/scss/prestashop/pages/_product.scss
+++ b/src/scss/prestashop/pages/_product.scss
@@ -20,7 +20,6 @@ $component-name: product;
     }
 
     &__thumbnail {
-      width: 100%;
       padding: 0;
       background-color: transparent;
       border: none;
@@ -32,6 +31,7 @@ $component-name: product;
       }
 
       &-image {
+        width: 100%;
         border-radius: var(--bs-border-radius);
         outline: 0.125rem solid transparent;
         outline-offset: -0.125rem;

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -83,47 +83,50 @@
       <div class="product__thumbnails">
         <ul class="product__thumbnails-list">
           {foreach from=$product.images item=image key=key name=productThumbnails}
-            <button
-              class="product__thumbnail focus-ring js-thumb-container{if $image.id_image == $product.default_image.id_image} active{/if}"
-              data-bs-target="#product-images-{$product.id}"
-              data-bs-slide-to="{$key}"
-              {if $image.id_image == $product.default_image.id_image}
-                aria-current="true"
-              {/if}
-              aria-label="{l s='Slide to product image %number%' d='Shop.Theme.Catalog' sprintf=['%number%' => $key + 1]}"
-            >
-              <picture>
-                {if isset($image.bySize.default_xs.sources.avif)}
-                  <source 
-                    srcset="
-                      {$image.bySize.default_xs.sources.avif},
-                      {$image.bySize.default_xl.sources.avif} 2x"
-                    type="image/avif"
-                  >
+            <li class="product__thumbnails-item">
+              <button
+                type="button"
+                class="product__thumbnail focus-ring js-thumb-container{if $image.id_image == $product.default_image.id_image} active{/if}"
+                data-bs-target="#product-images-{$product.id}"
+                data-bs-slide-to="{$key}"
+                {if $image.id_image == $product.default_image.id_image}
+                  aria-current="true"
                 {/if}
+                aria-label="{l s='Slide to product image %number%' d='Shop.Theme.Catalog' sprintf=['%number%' => $key + 1]}"
+              >
+                <picture>
+                  {if isset($image.bySize.default_xs.sources.avif)}
+                    <source 
+                      srcset="
+                        {$image.bySize.default_xs.sources.avif},
+                        {$image.bySize.default_xl.sources.avif} 2x"
+                      type="image/avif"
+                    >
+                  {/if}
 
-                {if isset($image.bySize.default_xs.sources.webp)}
-                  <source 
+                  {if isset($image.bySize.default_xs.sources.webp)}
+                    <source 
+                      srcset="
+                        {$image.bySize.default_xs.sources.webp},
+                        {$image.bySize.default_xl.sources.webp} 2x"
+                      type="image/webp"
+                    >
+                  {/if}
+
+                  <img
+                    class="product__thumbnail-image outline outline--rounded img-fluid js-thumb{if $image.id_image == $product.default_image.id_image} js-thumb-selected{/if}"
                     srcset="
-                      {$image.bySize.default_xs.sources.webp},
-                      {$image.bySize.default_xl.sources.webp} 2x"
-                    type="image/webp"
+                      {$image.bySize.default_xs.url},
+                      {$image.bySize.default_xl.url} 2x"
+                    width="{$image.bySize.default_xs.width}"
+                    height="{$image.bySize.default_xs.height}"
+                    loading="lazy"
+                    alt="{$image.legend}"
+                    title="{$image.legend}"
                   >
-                {/if}
-
-                <img
-                  class="product__thumbnail-image outline outline--rounded img-fluid js-thumb{if $image.id_image == $product.default_image.id_image} js-thumb-selected{/if}"
-                  srcset="
-                    {$image.bySize.default_xs.url},
-                    {$image.bySize.default_xl.url} 2x"
-                  width="{$image.bySize.default_xs.width}"
-                  height="{$image.bySize.default_xs.height}"
-                  loading="lazy"
-                  alt="{$image.legend}"
-                  title="{$image.legend}"
-                >
-              </picture>
-            </button>
+                </picture>
+              </button>
+            </li>
           {/foreach}
         </ul>
       </div>

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -83,10 +83,11 @@
       <div class="product__thumbnails">
         <ul class="product__thumbnails-list">
           {foreach from=$product.images item=image key=key name=productThumbnails}
-            <li class="product__thumbnails-item">
+            <li class="product__thumbnails-item" data-ps-ref="product-thumbnail-item">
               <button
                 type="button"
                 class="product__thumbnail focus-ring js-thumb-container{if $image.id_image == $product.default_image.id_image} active{/if}"
+                data-ps-ref="product-thumbnail"
                 data-bs-target="#product-images-{$product.id}"
                 data-bs-slide-to="{$key}"
                 {if $image.id_image == $product.default_image.id_image}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR improves the product thumbnails markup on the product page by wrapping each thumbnail button inside a `<li>` element. <br/><br/>This makes the HTML structure more semantic and accessible, since the direct children of a `<ul>` should be list items. <br/>It also adds `type="button"` to the thumbnail buttons to prevent unwanted submit behavior in form contexts.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | Codencode snc
| How to test?      | 1. Go to a product page with multiple images. <br/>2. Check that the product thumbnails are displayed correctly. <br/>3. Click each thumbnail and verify that the main product image changes as expected. <br/>4. Inspect the generated HTML and verify that: <br/>   - `.product__thumbnails-list` is a `<ul>`; <br/>   - each direct child of the `<ul>` is a `<li class="product__thumbnails-item">`; <br/>   - each thumbnail button has `type="button"`; <br/>   - the active thumbnail still has the `active` class and `aria-current="true"`. <br/>5. Verify that there are no visual regressions on desktop and mobile.