### PR TITLE
Fix inline stylesheet rendering with nofilter

### DIFF
--- a/templates/_partials/stylesheets.tpl
+++ b/templates/_partials/stylesheets.tpl
@@ -8,6 +8,6 @@
 
 {foreach $stylesheets.inline as $stylesheet}
   <style>
-    {$stylesheet.content}
+    {$stylesheet.content nofilter}
   </style>
 {/foreach}


### PR DESCRIPTION

<img width="675" height="184" alt="609135009-745676b6-04e3-4244-ae50-f17d8da390a4" src="https://github.com/user-attachments/assets/f7e891f7-c5dc-46b6-917f-9ad7ebdbca60" />
Double quotes in the CSS code are converted to &quot; and single quotes are converted to &#039; so the CSS code on the page doesn't work.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | using the inline option in registerStylesheet with 'inline' => true Double quotes in the CSS code are converted to &quot; and single quotes are converted to &#039; so the CSS code on the page doesn't work.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#41752
| How to test?      | you need to add a file in a demo module you are using with this code 

NOTE: @ingridusta here is a module to perform tests 🙂
[inlinecsstest.zip](https://github.com/user-attachments/files/29054464/inlinecsstest.zip)


$this->context->controller->registerStylesheet(
'modules-'.$this->name.'-hide-alias',
'/modules/'.$this->name.'/views/css/hide-alias.css',
['media' => 'all', 'priority' => 151, 'inline' => true]
);

then go into the source code of the front part of a page and see what code comes out

<img width="491" height="267" alt="Schermata del 2026-06-17 12-37-25" src="https://github.com/user-attachments/assets/e482f673-b06b-4482-8c18-f4d35da3d101" />

<img width="549" height="340" alt="Schermata del 2026-06-17 12-39-07" src="https://github.com/user-attachments/assets/06d2e521-6f24-4af2-b71d-fedd678182ca" />
