### PR TITLE
Fix duplicate product manufacturer block name in product page

### DIFF
--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -44,7 +44,7 @@
         </h1>
       {/block}
 
-      {block name='product_manufacturer'}
+      {block name='product_header_manufacturer'}
         {if isset($product_manufacturer->id) && $product_manufacturer->active}
           <div class="product__manufacturer">
             <a href="{$product_manufacturer->url}" aria-label="{l s='Product brand: %brand_name%' sprintf=['%brand_name%' => $product_manufacturer->name] d='Shop.Theme.Catalog'}">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR renames the `product_manufacturer` block in `themes/hummingbird/templates/catalog/product.tpl` to make it unique within the product page template structure.<br/>The same block name was used both in `product.tpl` and in `templates/catalog/_partials/product-details.tpl`.<br/><br/>Because Smarty block overrides are resolved by block name, overriding the manufacturer block from the product template could also affect the manufacturer block rendered in product details. This made targeted overrides on the product page ambiguous and unreliable.
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | Codencode snc
| How to test?      | see below


---
## How to test

1. Create a child theme based on `hummingbird`.

2. Override `templates/catalog/product.tpl` in the child theme with:

```smarty
{extends file='parent:catalog/product.tpl'}

{block name='product_header_manufacturer'}
  <p>override product_manufacturer product.tpl</p>
{/block}

3. Open a product page for a product with a brand/manufacturer assigned.

4. Verify that override `product_manufacturer` product.tpl is displayed only below the product name.

5. Verify that the content inside the Product Details tab is unchanged and does not display override `product_manufacturer` product.tpl.