### PR TITLE
Add subcategories hook

### DIFF
--- a/templates/catalog/_partials/category-header.tpl
+++ b/templates/catalog/_partials/category-header.tpl
@@ -34,9 +34,7 @@
         </div>
       {/if}
 
-      {if isset($subcategories) && $subcategories|@count > 0}
-        {include file='catalog/_partials/subcategories.tpl' subcategories=$subcategories}
-      {/if}
+      {include file='catalog/_partials/subcategories.tpl' subcategories=$subcategories|default:[]}
     </div>
   {/if}
 </div>

--- a/templates/catalog/_partials/subcategories.tpl
+++ b/templates/catalog/_partials/subcategories.tpl
@@ -4,58 +4,73 @@
  *}
 {$componentName = 'subcategory'}
 
+{**
+ * Determine if at least one subcategory has a thumbnail image.
+ * If so, set 'displaySubcategoryImages' to true so the list will render with images.
+ *}
+{assign var=displaySubcategoryImages value=false}
 {if !empty($subcategories)}
-  {**
-   * Determine if at least one subcategory has a thumbnail image.
-   * If so, set 'displaySubcategoryImages' to true so the list will render with images.
-   *}
-  {assign var=displaySubcategoryImages value=false}
   {foreach $subcategories as $category}
     {if isset($category.thumbnail) && !empty($category.thumbnail)}
       {assign var=displaySubcategoryImages value=true}
       {break}
     {/if}
   {/foreach}
+{/if}
 
+{**
+ * Get content of subcategory hook, so we display the list even if no native subcategories exist.
+ * The module receives information about whether to display images or not, so it can render accordingly, if wanted.
+ *}
+{capture name="displaySubcategoriesContent"}{hook h='displaySubcategories' displaySubcategoryImages=$displaySubcategoryImages}{/capture}
+
+{if !empty($subcategories) || !empty($smarty.capture.displaySubcategoriesContent)}
   <div class="{$componentName}">
     <div class="{$componentName}__list{if $displaySubcategoryImages} {$componentName}__list--with-images{/if}">
-      {foreach from=$subcategories item=subcategory}
-        <a class="{$componentName}__link{if $displaySubcategoryImages} {$componentName}__link--with-image{/if}" href="{$subcategory.url}" title="{$subcategory.name|escape:'html':'UTF-8'}">
-          {if $displaySubcategoryImages}
-            {if isset($subcategory.thumbnail.bySize.category_default.url) && !empty($subcategory.thumbnail.bySize.category_default.url)}
-              <picture>
-                {if isset($subcategory.thumbnail.bySize.category_default.sources.avif)}
-                  <source srcset="{$subcategory.thumbnail.bySize.category_default.sources.avif}" type="image/avif">
-                {/if}
 
-                {if isset($subcategory.thumbnail.bySize.category_default.sources.webp)}
-                  <source srcset="{$subcategory.thumbnail.bySize.category_default.sources.webp}" type="image/webp">
-                {/if}
-
+      {* Render a list of true subcategories from the core, with an image or not, depending on the pre-check before *}
+      {if !empty($subcategories)}
+        {foreach from=$subcategories item=subcategory}
+          <a class="{$componentName}__link{if $displaySubcategoryImages} {$componentName}__link--with-image{/if}" href="{$subcategory.url}" title="{$subcategory.name|escape:'html':'UTF-8'}">
+            {if $displaySubcategoryImages}
+              {if isset($subcategory.thumbnail.bySize.category_default.url) && !empty($subcategory.thumbnail.bySize.category_default.url)}
+                <picture>
+                  {if isset($subcategory.thumbnail.bySize.category_default.sources.avif)}
+                    <source srcset="{$subcategory.thumbnail.bySize.category_default.sources.avif}" type="image/avif">
+                  {/if}
+  
+                  {if isset($subcategory.thumbnail.bySize.category_default.sources.webp)}
+                    <source srcset="{$subcategory.thumbnail.bySize.category_default.sources.webp}" type="image/webp">
+                  {/if}
+  
+                  <img
+                    class="{$componentName}__thumbnail img-fluid"
+                    src="{$subcategory.thumbnail.bySize.category_default.url}"
+                    width="{$subcategory.thumbnail.bySize.category_default.width}"
+                    height="{$subcategory.thumbnail.bySize.category_default.height}"
+                    alt="{$subcategory.name|escape:'html':'UTF-8'}"
+                    loading="lazy"
+                  >
+                </picture>
+              {else}
                 <img
                   class="{$componentName}__thumbnail img-fluid"
-                  src="{$subcategory.thumbnail.bySize.category_default.url}"
-                  width="{$subcategory.thumbnail.bySize.category_default.width}"
-                  height="{$subcategory.thumbnail.bySize.category_default.height}"
+                  src="{$urls.no_picture_image.bySize.small_default.url}"
+                  width="{$urls.no_picture_image.bySize.small_default.width}"
+                  height="{$urls.no_picture_image.bySize.small_default.height}"
                   alt="{$subcategory.name|escape:'html':'UTF-8'}"
                   loading="lazy"
                 >
-              </picture>
-            {else}
-              <img
-                class="{$componentName}__thumbnail img-fluid"
-                src="{$urls.no_picture_image.bySize.small_default.url}"
-                width="{$urls.no_picture_image.bySize.small_default.width}"
-                height="{$urls.no_picture_image.bySize.small_default.height}"
-                alt="{$subcategory.name|escape:'html':'UTF-8'}"
-                loading="lazy"
-              >
+              {/if}
             {/if}
-          {/if}
+  
+            <span class="{$componentName}__name">{$subcategory.name|escape:'html':'UTF-8'}</span>
+          </a>
+        {/foreach}
+      {/if}
 
-          <span class="{$componentName}__name">{$subcategory.name|escape:'html':'UTF-8'}</span>
-        </a>
-      {/foreach}
+      {* Render the content of displaySubcategories hook we got before *}
+      {$smarty.capture.displaySubcategoriesContent nofilter}
     </div>
   </div>
 {/if}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds a new hook to display content in subcategory block. You can use it for blog posts, special filtered landing pages, appending links to "On sale" page etc.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | TRENDO s.r.o.
| How to test?      | Try to hook something to it and see if it displays. Try it in categories that have no subcategories.

### Example usage
<img width="1452" height="597" alt="hook category" src="https://github.com/user-attachments/assets/0e68100f-697a-4edc-a0fc-8cb51fbdbb42" />

### Hummingbird usage

```
<a class="subcategory__link subcategory__link--with-image" 
   style="background: #d4e5ff;border: 1px solid #8cbaff;" href="#">
    <span class="subcategory__name">
        <i class="material-icons" style="font-size: 2.2rem;color: #1765dd;">book</i>
        How to choose a sink
    </span>
</a>
```

<img width="1451" height="506" alt="hook" src="https://github.com/user-attachments/assets/f28dbc9c-f394-4d0f-91e3-84159bc22369" />
