### PR TITLE
Fix product variants legend markup in Hummingbird

### DIFF
--- a/src/scss/prestashop/components/product/_product-variant.scss
+++ b/src/scss/prestashop/components/product/_product-variant.scss
@@ -5,9 +5,12 @@ $component-name: product-variant;
   &__selected {
     display: inline-block;
     width: auto;
-    margin-block-end: 0.5rem;
     font-size: var(--bs-body-font-size);
     line-height: var(--bs-body-line-height);
+  }
+
+  &__attributes {
+    margin-block-start: 0.5rem;
   }
 
   // Radios

--- a/src/scss/prestashop/components/product/_product-variant.scss
+++ b/src/scss/prestashop/components/product/_product-variant.scss
@@ -5,6 +5,7 @@ $component-name: product-variant;
   &__selected {
     display: inline-block;
     width: auto;
+    margin-block-end: 0;
     font-size: var(--bs-body-font-size);
     line-height: var(--bs-body-line-height);
   }

--- a/src/scss/prestashop/components/product/_product-variant.scss
+++ b/src/scss/prestashop/components/product/_product-variant.scss
@@ -1,15 +1,11 @@
 $component-name: product-variant;
 
 .#{$component-name} {
-  &__label {
-    margin-block-end: 0.5rem;
-  }
-
   &__legend,
   &__selected {
     display: inline-block;
     width: auto;
-    margin-block-end: 0;
+    margin-block-end: 0.5rem;
     font-size: var(--bs-body-font-size);
     line-height: var(--bs-body-line-height);
   }

--- a/templates/catalog/_partials/product-variants.tpl
+++ b/templates/catalog/_partials/product-variants.tpl
@@ -11,15 +11,13 @@
         {assign var=legendId value="legend_{$id_attribute_group}_{$product.id}"}
 
         <fieldset class="product-variant">
-          <div class="product-variant__label">
-            <legend class="form-label product-variant__legend" id="{$legendId}">{$group.name}</legend>
-            <span class="selected-value product-variant__selected" aria-hidden="true">
-              {l s=': ' d='Shop.Theme.Catalog'}
-              {foreach from=$group.attributes key=id_attribute item=group_attribute}
-                {if $group_attribute.selected}{$group_attribute.name}{/if}
-              {/foreach}
-            </span>
-          </div>
+          <legend class="form-label product-variant__legend" id="{$legendId}">{$group.name}</legend>
+          <span class="selected-value product-variant__selected" aria-hidden="true">
+            {l s=': ' d='Shop.Theme.Catalog'}
+            {foreach from=$group.attributes key=id_attribute item=group_attribute}
+              {if $group_attribute.selected}{$group_attribute.name}{/if}
+            {/foreach}
+          </span>
 
           {if $group.group_type == 'select'}
             <select

--- a/templates/catalog/_partials/product-variants.tpl
+++ b/templates/catalog/_partials/product-variants.tpl
@@ -19,75 +19,77 @@
             {/foreach}
           </span>
 
-          {if $group.group_type == 'select'}
-            <select
-              class="form-select"
-              id="{$inputId}"
-              aria-labelledby="{$legendId}"
-              data-product-attribute="{$id_attribute_group}"
-              name="group[{$id_attribute_group}]">
-              {foreach from=$group.attributes key=id_attribute item=group_attribute}
-                <option value="{$id_attribute}" {if $group_attribute.selected} selected="selected"{/if}>{$group_attribute.name}</option>
-              {/foreach}
-            </select>
-          {elseif $group.group_type == 'color'}
-            <div id="{$groupId}" class="product-variant__colors" role="radiogroup" aria-labelledby="{$legendId}">
-              {foreach from=$group.attributes key=id_attribute item=group_attribute}
-                {assign var=inputId value="input_{$id_attribute_group}_{$id_attribute}_{$product.id}"}
-                {assign var=labelId value="label_{$id_attribute_group}_{$id_attribute}_{$product.id}"}
+          <div class="product-variant__attributes">
+            {if $group.group_type == 'select'}
+              <select
+                class="form-select"
+                id="{$inputId}"
+                aria-labelledby="{$legendId}"
+                data-product-attribute="{$id_attribute_group}"
+                name="group[{$id_attribute_group}]">
+                {foreach from=$group.attributes key=id_attribute item=group_attribute}
+                  <option value="{$id_attribute}" {if $group_attribute.selected} selected="selected"{/if}>{$group_attribute.name}</option>
+                {/foreach}
+              </select>
+            {elseif $group.group_type == 'color'}
+              <div id="{$groupId}" class="product-variant__colors" role="radiogroup" aria-labelledby="{$legendId}">
+                {foreach from=$group.attributes key=id_attribute item=group_attribute}
+                  {assign var=inputId value="input_{$id_attribute_group}_{$id_attribute}_{$product.id}"}
+                  {assign var=labelId value="label_{$id_attribute_group}_{$id_attribute}_{$product.id}"}
 
-                <div class="product-variant__color input-color">
-                  <input 
-                    class="input-color__input"
-                    type="radio"
-                    id="{$inputId}"
-                    data-product-attribute="{$id_attribute_group}"
-                    name="group[{$id_attribute_group}]"
-                    value="{$id_attribute}"
-                    aria-labelledby="{$labelId}"
-                    {if $group_attribute.selected} checked="checked" aria-checked="true"{/if}
-                  >
-                  <label
-                    class="input-color__label{if $group_attribute.texture} input-color__label--texture{/if}{if $group_attribute.selected} input-color__label--active{/if}"
-                    for="{$inputId}"
-                  >
-                    <span id="{$labelId}"
-                      {if $group_attribute.texture}
-                        class="color texture {if $group_attribute.selected}active{/if}" style="background-image: url({$group_attribute.texture})"
-                      {elseif $group_attribute.html_color_code}
-                        class="color {if $group_attribute.selected}active{/if}" style="background-color: {$group_attribute.html_color_code}"
-                      {/if}
+                  <div class="product-variant__color input-color">
+                    <input 
+                      class="input-color__input"
+                      type="radio"
+                      id="{$inputId}"
+                      data-product-attribute="{$id_attribute_group}"
+                      name="group[{$id_attribute_group}]"
+                      value="{$id_attribute}"
+                      aria-labelledby="{$labelId}"
+                      {if $group_attribute.selected} checked="checked" aria-checked="true"{/if}
                     >
-                      <span class="visually-hidden">{$group.group_name} - {$group_attribute.name}</span>
-                    </span>
-                  </label>
-                </div>
-              {/foreach}
-            </div>
-          {elseif $group.group_type == 'radio'}
-            <div id="{$groupId}" class="product-variant__radios" role="radiogroup" aria-labelledby="{$legendId}">
-              {foreach from=$group.attributes key=id_attribute item=group_attribute}
-                {assign var=inputId value="input_{$id_attribute_group}_{$id_attribute}_{$product.id}"}
-                {assign var=labelId value="label_{$id_attribute_group}_{$id_attribute}_{$product.id}"}
+                    <label
+                      class="input-color__label{if $group_attribute.texture} input-color__label--texture{/if}{if $group_attribute.selected} input-color__label--active{/if}"
+                      for="{$inputId}"
+                    >
+                      <span id="{$labelId}"
+                        {if $group_attribute.texture}
+                          class="color texture {if $group_attribute.selected}active{/if}" style="background-image: url({$group_attribute.texture})"
+                        {elseif $group_attribute.html_color_code}
+                          class="color {if $group_attribute.selected}active{/if}" style="background-color: {$group_attribute.html_color_code}"
+                        {/if}
+                      >
+                        <span class="visually-hidden">{$group.group_name} - {$group_attribute.name}</span>
+                      </span>
+                    </label>
+                  </div>
+                {/foreach}
+              </div>
+            {elseif $group.group_type == 'radio'}
+              <div id="{$groupId}" class="product-variant__radios" role="radiogroup" aria-labelledby="{$legendId}">
+                {foreach from=$group.attributes key=id_attribute item=group_attribute}
+                  {assign var=inputId value="input_{$id_attribute_group}_{$id_attribute}_{$product.id}"}
+                  {assign var=labelId value="label_{$id_attribute_group}_{$id_attribute}_{$product.id}"}
 
-                <div class="product-variant__radio form-check">
-                  <input
-                    class="form-check-input"
-                    type="radio"
-                    id="{$inputId}"
-                    data-product-attribute="{$id_attribute_group}"
-                    name="group[{$id_attribute_group}]"
-                    value="{$id_attribute}"
-                    aria-labelledby="{$labelId}"
-                    {if $group_attribute.selected} checked="checked" aria-checked="true"{/if}
-                  >
-                  <label for="{$inputId}">
-                    <span class="form-check-label" id="{$labelId}"><span class="visually-hidden">{$group.group_name} - </span>{$group_attribute.name}</span>
-                  </label>
-                </div>
-              {/foreach}
-            </div>
-          {/if}
+                  <div class="product-variant__radio form-check">
+                    <input
+                      class="form-check-input"
+                      type="radio"
+                      id="{$inputId}"
+                      data-product-attribute="{$id_attribute_group}"
+                      name="group[{$id_attribute_group}]"
+                      value="{$id_attribute}"
+                      aria-labelledby="{$labelId}"
+                      {if $group_attribute.selected} checked="checked" aria-checked="true"{/if}
+                    >
+                    <label for="{$inputId}">
+                      <span class="form-check-label" id="{$labelId}"><span class="visually-hidden">{$group.group_name} - </span>{$group_attribute.name}</span>
+                    </label>
+                  </div>
+                {/foreach}
+              </div>
+            {/if}
+          </div>
         </fieldset>
       {/if}
     {/foreach}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR fixes the product variants markup in the Hummingbird theme to keep the `legend` as a direct child of `fieldset`, which is the correct semantic and accessible HTML structure.<br/>Previously, the legend was wrapped inside a `<div>`, making the markup invalid. This change removes that wrapper and slightly adjusts the related spacing in SCSS by moving the margin to `.product-variant__legend`, preserving the same visual separation with valid markup.
| Type?            | bug fix / improvement / new feature / refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | Codencode snc
| How to test?      | 1. Open a product page using the Hummingbird theme.<br/>2. Verify each variant group renders legend directly inside fieldset.<br/>3. Confirm the selected value still displays correctly and spacing is unchanged.