### PR TITLE
Add a hook to display content under cart summary

### DIFF
--- a/templates/checkout/cart.tpl
+++ b/templates/checkout/cart.tpl
@@ -53,7 +53,9 @@
 
         <hr>
 
-        {hook h='displayCartBelowSummary'}
+        {block name='cart_below_summary'}
+          {hook h='displayCartBelowSummary'}
+        {/block}
 
         {block name='hook_reassurance'}
           {hook h='displayReassurance'}

--- a/templates/checkout/cart.tpl
+++ b/templates/checkout/cart.tpl
@@ -53,6 +53,8 @@
 
         <hr>
 
+        {hook h='displayCartBelowSummary'}
+
         {block name='hook_reassurance'}
           {hook h='displayReassurance'}
         {/block}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds a hook that displays content under the summary on cart page. I don't want to mix it with reassurance hook because that would need conditioning out to avoid displaying it on other pages.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | TRENDO s.r.o.
| How to test?      | 

### Example usage
<img width="1488" height="789" alt="Snímek obrazovky 2026-06-23 141411" src="https://github.com/user-attachments/assets/2b4b222f-cbf8-4e6e-b6c7-a6612c899c98" />
