### PR TITLE
Fix register searchbar outside-click listener once instead of on every search

### DIFF
--- a/src/js/modules/ps_searchbar.ts
+++ b/src/js/modules/ps_searchbar.ts
@@ -254,6 +254,19 @@ const initSearchbar = () => {
 
     searchClear?.addEventListener('blur', handleBlur);
 
+    // Close dropdown when clicking outside (registered once, not on every search)
+    window.addEventListener('click', (event: Event) => {
+      const target = <Node>event.target;
+
+      // Check if click is outside both the search widget and the dropdown
+      if (!searchWidget.contains(target) && !searchDropdown.contains(target)) {
+        searchDropdown.classList.add('d-none');
+        searchInput.setAttribute('aria-expanded', 'false');
+        currentResultIndex = -1;
+        searchWidgetHasFocus = false;
+      }
+    });
+
     const triggerSearch = async () => {
       if (!searchUrl || searchInput.value.trim() === '') return;
 
@@ -291,19 +304,6 @@ const initSearchbar = () => {
           });
 
           link.addEventListener('blur', handleBlur);
-        });
-
-        // Close dropdown when clicking outside
-        window.addEventListener('click', (event: Event) => {
-          const target = <Node>event.target;
-
-          // Check if click is outside both the search widget and the dropdown
-          if (!searchWidget.contains(target) && !searchDropdown.contains(target)) {
-            searchDropdown.classList.add('d-none');
-            searchInput.setAttribute('aria-expanded', 'false');
-            currentResultIndex = -1;
-            searchWidgetHasFocus = false;
-          }
         });
       } else {
         searchResults.innerHTML = '';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Register the searchbar outside-click listener once at init instead of re-adding it on every search
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | --
| Sponsor company   | @PrestaShopCorp
| How to test?      | --
