### PR TITLE
Add alt text to product customization images

### DIFF
--- a/templates/catalog/_partials/customization-modal.tpl
+++ b/templates/catalog/_partials/customization-modal.tpl
@@ -29,7 +29,7 @@
               {assign var=image_modal_id value="{$componentName}_image--{mt_rand()}"}
 
               <a href="#{$image_modal_id}" data-bs-toggle="modal" data-bs-dismiss="modal" >
-                <img class="{$componentName}__img" src="{$field.image.small.url}">
+                <img class="{$componentName}__img" src="{$field.image.small.url}" alt="{$field.label}">
               </a>
 
               {append var='image_modals'
@@ -59,7 +59,7 @@
             </div>
 
             <div class="modal-body">
-              <img class="{$componentName}__img-popup img-fluid" src="{$image_modal['image_url']}">
+              <img class="{$componentName}__img-popup img-fluid" src="{$image_modal['image_url']}" alt="{$image_modal['title']}">
             </div>
 
             <div class="modal-footer">

--- a/templates/catalog/_partials/product-customization-modal.tpl
+++ b/templates/catalog/_partials/product-customization-modal.tpl
@@ -40,7 +40,7 @@
                   {assign var=image_modal_id value="{$componentName}_image--{mt_rand()}"}
 
                   <a href="#{$image_modal_id}" data-bs-toggle="modal" data-bs-dismiss="modal" >
-                    <img class="{$componentName}__img" src="{$field.image.small.url}">
+                    <img class="{$componentName}__img" src="{$field.image.small.url}" alt="{$field.label}">
                   </a>
 
                   {append var='image_modals'
@@ -72,7 +72,7 @@
               </div>
   
               <div class="modal-body">
-                <img class="{$componentName}__img-popup img-fluid" src="{$image_modal['image_url']}">
+                <img class="{$componentName}__img-popup img-fluid" src="{$image_modal['image_url']}" alt="{$image_modal['title']}">
               </div>
   
               <div class="modal-footer">

--- a/templates/catalog/_partials/product-customization.tpl
+++ b/templates/catalog/_partials/product-customization.tpl
@@ -26,7 +26,7 @@
 
                 {if $field.is_customized}
                   <div class="product-customization__image-wrapper">
-                    <img src="{$field.image.small.url}" class="product-customization__image img-fluid" loading="lazy">
+                    <img src="{$field.image.small.url}" class="product-customization__image img-fluid" loading="lazy" alt="{$field.label}">
 
                     <a class="product-customization__image-remove link-danger" href="{$field.remove_image_url}" rel="nofollow" role="button">
                       {l s='Remove image' d='Shop.Theme.Actions'}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The product-customization image previews and their zoom modals render `<img>` elements without an `alt` attribute. In `customization-modal.tpl` and `product-customization-modal.tpl` the thumbnail is the only content of a modal-trigger `<a>`, so the link has no accessible name (WCAG 2.4.4, 4.1.2); the zoom-popup images and the current-customization preview in `product-customization.tpl` are missing `alt` as well (WCAG 1.1.1). This adds meaningful `alt` text from labels already in template scope: the customization field label (`$field.label`) for thumbnails/preview and the modal title (`$image_modal['title']`) for popup images — following the theme's existing `alt="{$...}"` pattern used in the product/brand/category miniatures.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   |
| How to test?      | On a product with an image-type customization field, open the customization modal and inspect the thumbnails and zoom popups: each `<img>` carries an `alt` equal to the field label, and the modal-trigger link exposes that label as its accessible name. An axe/Lighthouse scan no longer flags "Links do not have a discernible name" / "Image elements do not have alt attributes" for these images.
