### PR TITLE
Debounce the scroll-padding resize handler to avoid forced reflow

### DIFF
--- a/src/js/helpers/scrollPadding.test.ts
+++ b/src/js/helpers/scrollPadding.test.ts
@@ -1,0 +1,37 @@
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+import initScrollPaddingTop from '@helpers/scrollPadding';
+
+describe('scrollPadding', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '<header data-ps-ref="header"></header>';
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('debounces the resize handler so it runs once per settle instead of once per event', () => {
+    const setPropertySpy = jest.spyOn(document.documentElement.style, 'setProperty');
+
+    initScrollPaddingTop();
+
+    window.dispatchEvent(new Event('resize'));
+    window.dispatchEvent(new Event('resize'));
+    window.dispatchEvent(new Event('resize'));
+
+    // Debounced: no forced reflow / style write has happened yet.
+    expect(setPropertySpy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(100);
+
+    // setScrollPaddingTop() ran exactly once (it sets two custom properties), not once per event.
+    expect(setPropertySpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/js/helpers/scrollPadding.ts
+++ b/src/js/helpers/scrollPadding.ts
@@ -4,8 +4,9 @@
  */
 
 import SelectorsMap from '@constants/selectors-map';
+import debounce from '@helpers/debounce';
 
-const setScrollPaddingTop = () => {
+const setScrollPaddingTop = async () => {
   const header = document.querySelector(SelectorsMap.layout.header) as HTMLElement;
 
   if (header) {
@@ -45,7 +46,10 @@ const initScrollPaddingTop = () => {
     setScrollPaddingTop();
     bindHeaderFocus();
   });
-  window.addEventListener('resize', setScrollPaddingTop);
+  // Debounce the resize handler: setScrollPaddingTop() reads header.offsetHeight (a forced layout
+  // reflow) and writes CSS custom properties, and 'resize' fires many times per second while the
+  // window is dragged. The scroll padding only needs to be correct once the resize settles.
+  window.addEventListener('resize', debounce(setScrollPaddingTop, 100));
 };
 
 export default initScrollPaddingTop;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | `initScrollPaddingTop()` registers `setScrollPaddingTop` directly as the `resize` handler. The handler reads `header.offsetHeight` (forced synchronous reflow) and writes two CSS custom properties on every resize tick, many times per second while the window is dragged, although the scroll padding only needs to be correct once the resize settles. This debounces the resize handler (100 ms) with the theme's existing `debounce` helper; `setScrollPaddingTop` becomes `async` to match the helper's signature (same pattern as `debounce(triggerEmit, ...)` in `product.ts`). The `load` path is unchanged. Covered by a new Jest test: 3 resize events produce 1 recalculation after the debounce window (6 setProperty calls / 3 events before the change).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   |
| How to test?      | `npx jest scrollPadding` — the new test asserts the debounced behavior. Manually: resize the window; the `--scroll-padding-top` custom property updates once after resizing stops instead of on every intermediate event.
