### PR TITLE
Label the birthday date fields as an accessible group

### DIFF
--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -12,7 +12,7 @@
 
   <div class="mb-3{if !empty($field.errors)} has-error{/if}">
     {if ($field.type !== 'checkbox')}
-      <label class="form-label{if $field.required} required{/if}" for="field-{$field.name}">
+      <label class="form-label{if $field.required} required{/if}" id="field-{$field.name}-label" for="field-{$field.name}">
         {if $field.type !== 'checkbox'}
           {$field.label}
         {/if}
@@ -50,7 +50,6 @@
 
       {block name='form_field_item_radio'}
         <div aria-labelledby="field-{$field.name}-label">
-          <p class="visually-hidden" id="field-{$field.name}-label">{$field.label}</p>
           {foreach from=$field.availableValues item="label" key="value"}
             <div class="form-check form-check-inline">
               <input
@@ -114,7 +113,7 @@
     {elseif $field.type === 'birthday'}
 
       {block name='form_field_item_birthday'}
-        <div class="js-parent-focus">
+        <div class="js-parent-focus" role="group" aria-labelledby="field-{$field.name}-label">
           {html_select_date
           field_order=DMY
           time={$field.value}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | For a `birthday` form field, `form-fields.tpl` renders the shared top `<label for="field-{$field.name}">`, but `{html_select_date}` emits three `<select>` elements with no such id — the label targets a nonexistent element and the date selects have no programmatic label (WCAG 1.3.1 / 4.1.2). The fix gives the shared top label a stable `id="field-{$field.name}-label"` and points the date group at it with `role="group" aria-labelledby`, exposing the three selects as one labelled group. The same top label now also serves the `radio-buttons` type, whose wrapper already used `aria-labelledby="field-{$field.name}-label"` via a separate visually-hidden `<p>` — that `<p>` becomes redundant and is removed, which also avoids a duplicate id. No visual change.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   |
| How to test?      | On a form with a birthday field (e.g. account creation), the day/month/year group is announced with the field's label in the accessibility tree; a `radio-buttons` group is still labelled by the visible top label; an axe/Lighthouse scan no longer flags the date selects as unlabelled and there is no duplicate id.
