### PR TITLE
Mark the redundant payment-option logo as decorative

### DIFF
--- a/templates/checkout/_partials/steps/payment.tpl
+++ b/templates/checkout/_partials/steps/payment.tpl
@@ -37,7 +37,7 @@
 
             <label class="payment-option__label form-check-label" for="{$option.id}">
               {if $option.logo}
-                <img class="img-fluid" src="{$option.logo}" loading="lazy">
+                <img class="img-fluid" src="{$option.logo}" loading="lazy" alt="">
               {/if}
               {$option.call_to_action_text}
             </label>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In the payment step each option renders its logo as `<img src="{$option.logo}">` inside the option `<label>` with no `alt`, so a screen reader falls back to announcing the image filename alongside the method name. The method is already named by the adjacent `{$option.call_to_action_text}`, so the logo is decorative: this adds `alt=""` so assistive technology skips the image and announces the payment method once (WCAG 1.1.1).
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   |
| How to test?      | On the checkout payment step, the payment option logo carries `alt=""`; a screen reader announces only the payment method name, not the image filename.
