### PR TITLE
Fix unbalanced markup in the customer order templates

### DIFF
--- a/templates/customer/_partials/order-detail-return-multishipment.tpl
+++ b/templates/customer/_partials/order-detail-return-multishipment.tpl
@@ -83,7 +83,7 @@
         <button class="btn btn-primary" type="submit" name="submitReturnMerchandise" data-ps-action="form-validation-submit">
           {l s='Request a return' d='Shop.Theme.Customeraccount'}
         </button>
-      </footer>
-    </div>
+      </div>
+    </section>
   </form>
 {/block}

--- a/templates/customer/_partials/order-detail-return.tpl
+++ b/templates/customer/_partials/order-detail-return.tpl
@@ -207,7 +207,7 @@
         <button class="btn btn-primary" type="submit" name="submitReturnMerchandise" data-ps-action="form-validation-submit">
           {l s='Request a return' d='Shop.Theme.Customeraccount'}
         </button>
-      </footer>
-    </div>
+      </div>
+    </section>
   </form>
 {/block}

--- a/templates/customer/_partials/order-messages.tpl
+++ b/templates/customer/_partials/order-messages.tpl
@@ -20,6 +20,7 @@
           </div>
         </div>
       {/foreach}
+      </div>
     </section>
 
     <hr class="order-separator">
@@ -63,7 +64,7 @@
         <button type="submit" name="submitMessage" class="btn btn-primary" data-ps-action="form-validation-submit">
           {l s='Send your message' d='Shop.Theme.Actions'}
         </button>
-      </footer>
+      </div>
     </form>
   </section>
 {/block}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Three customer-account order partials close elements with a stray `</footer>` although no `<footer>` exists in the files, leaving the surrounding `<section>`/`<div>` unclosed. `order-messages.tpl`: the form's buttons wrapper was closed with `</footer>` and `order-message__list` was never closed; `order-detail-return.tpl` and `order-detail-return-multishipment.tpl`: the buttons wrapper closed with `</footer>` and the `order-merchandise-return` section closed with `</div>` instead of `</section>`. The stray tags are replaced with the correct closers and the missing `</div>` added; every file now balances (`footer` 0/0, `section` and `div` counts equal). Browsers auto-recover from the invalid markup, so there is no visible change — a markup-validity fix.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   |
| How to test?      | Run the three templates through an HTML validator (or diff the tag counts): no stray `</footer>`, all sections and divs balanced; customer order pages render unchanged.
