### PR TITLE
Support an optional id prefix in the form fields partial

### DIFF
--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -2,6 +2,7 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
+{assign var='id_prefix' value=$id_prefix|default:''}
 {capture assign='field_attr'}
   {foreach from=$field.attr|default:[] key="attrName" item="attrValue"}
     {$attrName|escape:'html'}="{$attrValue|escape:'html'}"
@@ -17,7 +18,7 @@
 
   <div class="mb-3{if !empty($field.errors)} has-error{/if}">
     {if ($field.type !== 'checkbox')}
-      <label class="form-label{if $field.required} required{/if}" id="field-{$field.name}-label" for="field-{$field.name}">
+      <label class="form-label{if $field.required} required{/if}" id="{$id_prefix}field-{$field.name}-label" for="{$id_prefix}field-{$field.name}">
         {if $field.type !== 'checkbox'}
           {$field.label}
         {/if}
@@ -27,7 +28,7 @@
     {if $field.type === 'select'}
 
       {block name='form_field_item_select'}
-        <select class="form-select" name="{$field.name}" id="field-{$field.name}" {if $field.required}required{/if} {$field_attr nofilter}>
+        <select class="form-select" name="{$field.name}" id="{$id_prefix}field-{$field.name}" {if $field.required}required{/if} {$field_attr nofilter}>
           <option value disabled selected>{l s='-- please choose --' d='Shop.Forms.Labels'}</option>
           {foreach from=$field.availableValues item="label" key="value"}
             <option value="{$value}" {if $value eq $field.value} selected {/if}>{$label}</option>
@@ -41,7 +42,7 @@
         <select
         class="form-select js-country"
         name="{$field.name}"
-        id="field-{$field.name}"
+        id="{$id_prefix}field-{$field.name}"
         {if $field.required}required{/if}
         {$field_attr nofilter}
         >
@@ -55,19 +56,19 @@
     {elseif $field.type === 'radio-buttons'}
 
       {block name='form_field_item_radio'}
-        <div aria-labelledby="field-{$field.name}-label">
+        <div aria-labelledby="{$id_prefix}field-{$field.name}-label">
           {foreach from=$field.availableValues item="label" key="value"}
             <div class="form-check form-check-inline">
               <input
                 class="form-check-input"
                 type="radio"
                 name="{$field.name}"
-                id="field-{$field.name}_{$value}"
+                id="{$id_prefix}field-{$field.name}_{$value}"
                 value="{$value}"
                 {if $field.required}required{/if}
                 {if $value eq $field.value} checked {/if}
               >
-              <label class="form-check-label" for="field-{$field.name}_{$value}">
+              <label class="form-check-label" for="{$id_prefix}field-{$field.name}_{$value}">
                 {$label}
               </label>
             </div>
@@ -84,11 +85,11 @@
             name="{$field.name}"
             type="checkbox"
             value="1"
-            id="field-{$field.name}"
+            id="{$id_prefix}field-{$field.name}"
             value="1" {if $field.value}checked="checked"{/if}
             {if $field.required}required{/if}
           >
-          <label class="form-check-label{if $field.required} required{/if}" for="field-{$field.name}">
+          <label class="form-check-label{if $field.required} required{/if}" for="{$id_prefix}field-{$field.name}">
             {$field.label nofilter}
           </label>
         </div>
@@ -101,7 +102,7 @@
           name="{$field.name}"
           class="form-control"
           type="date"
-          id="field-{$field.name}"
+          id="{$id_prefix}field-{$field.name}"
           value="{$field.value}"
           {if isset($field.availableValues.placeholder)}
             placeholder="{$field.availableValues.placeholder}"
@@ -120,7 +121,7 @@
     {elseif $field.type === 'birthday'}
 
       {block name='form_field_item_birthday'}
-        <div class="js-parent-focus" role="group" aria-labelledby="field-{$field.name}-label">
+        <div class="js-parent-focus" role="group" aria-labelledby="{$id_prefix}field-{$field.name}-label">
           {html_select_date
           field_order=DMY
           time={$field.value}
@@ -149,7 +150,7 @@
           <input
             class="form-control"
             name="{$field.name}"
-            id="field-{$field.name}"
+            id="{$id_prefix}field-{$field.name}"
             type="password"
             {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}
             value=""
@@ -173,7 +174,7 @@
             data-text-show="{l s='Show password' d='Shop.Theme.Actions'}"
             data-text-hide="{l s='Hide password' d='Shop.Theme.Actions'}"
             aria-label="{l s='Show password' d='Shop.Theme.Actions'}"
-            aria-controls="field-{$field.name}"
+            aria-controls="{$id_prefix}field-{$field.name}"
             aria-live="polite"
           >
             <i class="material-icons" aria-hidden="true">&#xE8F4;</i>
@@ -189,7 +190,7 @@
 
       {block name='form_field_item_textarea'}
         <textarea
-          id="field-{$field.name}"
+          id="{$id_prefix}field-{$field.name}"
           class="form-control"
           name="{$field.name}"
           {if isset($field.availableValues.placeholder)}placeholder="{$field.availableValues.placeholder}"{/if}
@@ -212,7 +213,7 @@
         <input
           class="form-control"
           name="{$field.name}"
-          id="field-{$field.name}"
+          id="{$id_prefix}field-{$field.name}"
           type="{$field.type}"
           value="{$field.value}"
           {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | `_partials/form-fields.tpl` hardcodes `id="field-{$field.name}"` (and the matching `for` / `aria-labelledby` / `aria-controls` attributes), so anything rendering the same field names twice on one page — e.g. a hidden edit modal next to an inline form — produces duplicate ids, and labels bind to the first (hidden) instance: the visible inputs lose their programmatic label (WCAG 1.3.1 / 4.1.1) and clicking a label focuses a hidden field. This adds an optional `id_prefix` parameter: every generated id and id-reference becomes `{$id_prefix|default:''}field-{$field.name}` (14 occurrences). With no parameter the output is byte-identical, so existing callers are unaffected. Concrete consumer: ps_onepagecheckout renders the address fields inline and in two hidden modals — 21 duplicate ids on the checkout page (PrestaShop/ps_onepagecheckout#94); its paired PR PrestaShop/ps_onepagecheckout#95 passes `id_prefix="{$modal_id}-"`. Verified together on a 9.2 shop: duplicate ids drop from 21 to 0 and every visible input keeps its own label binding.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   |
| How to test?      | Render any form through `{form_field field=$field}` — unchanged markup. Render with `{form_field field=$field id_prefix="x-"}` — the input id and its label `for` become `x-field-{name}`. With PrestaShop/ps_onepagecheckout#95 applied on a 9.2 shop, `document.querySelectorAll('[id]')` on the checkout shows no duplicates.
