### PR TITLE
Render the form field attr attributes in the form fields partial

### DIFF
--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -2,10 +2,15 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
+{capture assign='field_attr'}
+  {foreach from=$field.attr|default:[] key="attrName" item="attrValue"}
+    {$attrName|escape:'html'}="{$attrValue|escape:'html'}"
+  {/foreach}
+{/capture}
 {if $field.type == 'hidden'}
 
   {block name='form_field_item_hidden'}
-    <input type="hidden" name="{$field.name}" value="{$field.value}">
+    <input type="hidden" name="{$field.name}" value="{$field.value}" {$field_attr nofilter}>
   {/block}
 
 {else}
@@ -22,7 +27,7 @@
     {if $field.type === 'select'}
 
       {block name='form_field_item_select'}
-        <select class="form-select" name="{$field.name}" id="field-{$field.name}" {if $field.required}required{/if}>
+        <select class="form-select" name="{$field.name}" id="field-{$field.name}" {if $field.required}required{/if} {$field_attr nofilter}>
           <option value disabled selected>{l s='-- please choose --' d='Shop.Forms.Labels'}</option>
           {foreach from=$field.availableValues item="label" key="value"}
             <option value="{$value}" {if $value eq $field.value} selected {/if}>{$label}</option>
@@ -38,6 +43,7 @@
         name="{$field.name}"
         id="field-{$field.name}"
         {if $field.required}required{/if}
+        {$field_attr nofilter}
         >
           <option value disabled selected>{l s='-- please choose --' d='Shop.Forms.Labels'}</option>
           {foreach from=$field.availableValues item="label" key="value"}
@@ -102,6 +108,7 @@
             aria-label="{$field.availableValues.placeholder}"
           {/if}
           {if $field.required}required{/if}
+          {$field_attr nofilter}
         >
         {if isset($field.availableValues.comment)}
           <span class="form-text">
@@ -156,6 +163,7 @@
             {/if}
             spellcheck="false"
             {if $field.required}required{/if}
+            {$field_attr nofilter}
           >
 
           <button
@@ -189,6 +197,7 @@
           {if $field.required}required{/if}
           {if isset($field.availableValues.rows)}rows="{$field.availableValues.rows}"{/if}
           {if isset($field.availableValues.cols)}cols="{$field.availableValues.cols}"{/if}
+          {$field_attr nofilter}
         >{$field.value|default}</textarea>
         {if isset($field.availableValues.comment)}
           <span class="form-text">
@@ -210,9 +219,9 @@
           {if isset($field.availableValues.placeholder)}placeholder="{$field.availableValues.placeholder}"{/if}
           {if $field.maxLength}maxlength="{$field.maxLength}"{/if}
           {if !empty($field.minLength)}minlength="{$field.minLength}"{/if}
-          {foreach from=$field.attr|default:[] key="attrName" item="attrValue"}{$attrName|escape:'html'}="{$attrValue|escape:'html'}" {/foreach}
           aria-label="{$field.label}"
           {if $field.required}required{/if}
+          {$field_attr nofilter}
         >
         {if isset($field.availableValues.comment)}
           <span class="form-text">

--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -211,6 +211,7 @@
           {if isset($field.availableValues.placeholder)}placeholder="{$field.availableValues.placeholder}"{/if}
           {if $field.maxLength}maxlength="{$field.maxLength}"{/if}
           {if !empty($field.minLength)}minlength="{$field.minLength}"{/if}
+          {foreach from=$field.attr|default:[] key="attrName" item="attrValue"}{$attrName|escape:'html'}="{$attrValue|escape:'html'}" {/foreach}
           aria-label="{$field.label}"
           {if $field.required}required{/if}
         >


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Core's `FormField` carries an `attr` array (exported by `FormFieldCore::toArray()`), and core runs the `additionalHtmlAttributesFormFields` hook so modules can add HTML attributes to a form field — but `_partials/form-fields.tpl` never renders them, so everything placed in that slot is silently dropped. This renders the `attr` map on the generic input branch (`form_field_item_other`): each entry becomes an HTML attribute (name and value escaped), with `|default:[]` keeping the output byte-identical for callers that set no attributes. Concrete consumer: ps_onepagecheckout sets `inputmode="numeric"` on the postcode field for digits-only zip formats (PrestaShop/ps_onepagecheckout#101), so touch devices open the numeric keyboard — a standard mobile checkout keyboard optimization (https://baymard.com/blog/mobile-checkout). Verified end-to-end on a 9.2 shop against this change.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   |
| How to test?      | Render any form through `{form_field field=$field}` — unchanged markup. Set `$field.attr = ['inputmode' => 'numeric']` server-side (`FormField::setAttr()`) — the input renders `inputmode="numeric"`. With PrestaShop/ps_onepagecheckout#101 on a 9.2 shop, the checkout postcode inputs carry `inputmode="numeric"` for France.
