### PR TITLE
Fix back param issue

### DIFF
--- a/modules/ps_customersignin/ps_customersignin.tpl
+++ b/modules/ps_customersignin/ps_customersignin.tpl
@@ -132,8 +132,8 @@
     {else}
       <div class="header-block">
         <a
-          {if $page.page_name == 'authentication'}
-            href="{$urls.pages.authentication}?back={$urls.pages.my_account|urlencode}"
+          {if $urls.pages.authentication|strpos:'back=' !== false}
+            href="{$urls.pages.authentication}"
           {else}
             href="{$urls.pages.authentication}?back={$urls.current_url|urlencode}"
           {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixes the sign-in link on the authentication/registration/password pages in PrestaShop 9.2. Related changes on CORE : https://github.com/PrestaShop/PrestaShop/commit/1e8df39e977, the template now delegates the back param to the core and only seeds it with the current URL on regular content pages.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | --
| Sponsor company   | @PrestaShopCorp
| How to test?      | --
