### PR TITLE
Replace outer nav element with div in pagination template

### DIFF
--- a/templates/_partials/pagination.tpl
+++ b/templates/_partials/pagination.tpl
@@ -4,7 +4,7 @@
  *}
 {$componentName = 'pagination'}
 
-<nav class="{$componentName}__container">
+<div class="{$componentName}__container">
   <div class="{$componentName}__number">
     {block name='pagination_summary'}
       {l s='Showing %from%-%to% of %total% item(s)' d='Shop.Theme.Catalog' sprintf=['%from%' => $pagination.items_shown_from ,'%to%' => $pagination.items_shown_to, '%total%' => $pagination.total_items]}
@@ -69,4 +69,4 @@
       </nav>
     {/block}
   </div>
-</nav>
+</div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The pagination template contained a nested `<nav>` element, where the outer `<nav>` was used only as a layout container.<br/>This PR replaces the outer `<nav>` with a `<div>`, keeping the inner `<nav>` with its `aria-label`. This improves the semantic HTML structure and avoids nested navigation landmarks while preserving the existing layout and behavior.| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | Codencode snc
| How to test?      | 1. Open any front office page with pagination (for example a category with multiple product pages).<br/>2. Verify that the pagination is displayed and works as before.<br/>3. Inspect the generated HTML and check that the outer pagination container is now a `<div>` while the pagination navigation is still wrapped in a single `<nav aria-label="Products pagination">`.
