### PR TITLE
Render radio attribute groups as buttons on the product page

### DIFF
--- a/src/scss/prestashop/components/product/_product-variant.scss
+++ b/src/scss/prestashop/components/product/_product-variant.scss
@@ -18,8 +18,7 @@ $component-name: product-variant;
   &__radios {
     display: flex;
     flex-wrap: wrap;
-    row-gap: 0.5rem;
-    column-gap: 0.875rem;
+    gap: 0.5rem;
     margin-bottom: 0;
   }
 

--- a/templates/catalog/_partials/product-variants.tpl
+++ b/templates/catalog/_partials/product-variants.tpl
@@ -71,19 +71,20 @@
                   {assign var=inputId value="input_{$id_attribute_group}_{$id_attribute}_{$product.id}"}
                   {assign var=labelId value="label_{$id_attribute_group}_{$id_attribute}_{$product.id}"}
 
-                  <div class="product-variant__radio form-check">
+                  <div class="product-variant__radio">
                     <input
-                      class="form-check-input"
+                      class="btn-check"
                       type="radio"
                       id="{$inputId}"
                       data-product-attribute="{$id_attribute_group}"
                       name="group[{$id_attribute_group}]"
                       value="{$id_attribute}"
                       aria-labelledby="{$labelId}"
+                      autocomplete="off"
                       {if $group_attribute.selected} checked="checked" aria-checked="true"{/if}
                     >
-                    <label for="{$inputId}">
-                      <span class="form-check-label" id="{$labelId}"><span class="visually-hidden">{$group.group_name} - </span>{$group_attribute.name}</span>
+                    <label class="btn btn-outline-primary" for="{$inputId}">
+                      <span id="{$labelId}"><span class="visually-hidden">{$group.group_name} - </span>{$group_attribute.name}</span>
                     </label>
                   </div>
                 {/foreach}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | A `radio`-type attribute group renders each option as a plain `form-check` radio (small circle + text), while Baymard's product-page research recommends variation options — size in particular — be exposed as button-like selectors (https://baymard.com/blog/use-buttons-for-size-selection, "Always Use 'Buttons' for Size Selection (28% of Desktop Sites Don't)"). The theme already renders `color` as swatches and `select` as a dropdown; only `radio` was left as bare radios. This renders the `radio` branch with Bootstrap's `btn-check` pattern (already used elsewhere in the theme): a visually-hidden radio input (keeping `type="radio"`, `name`, `value`, `data-product-attribute`, `aria-labelledby` and the checked state) plus a `<label class="btn btn-outline-primary">`. `role="radiogroup"` and radio semantics are preserved, so keyboard/arrow-key selection and the variation-sync JS keep working; `select` and `color` are untouched. Fixes #1066.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #1066
| Sponsor company   |
| How to test?      | Set an attribute group used by a product to `group_type = radio` in the BO (or `UPDATE ps_attribute_group SET group_type='radio'` for e.g. the demo Size group), open that product: the options render as an outline-button group with all values visible, the selected value shows a filled button, selecting one syncs price/URL/availability, and add-to-cart still works. Verified live on a 9.2 shop. `select` and `color` group types render exactly as before.
