### PR TITLE
Guide visitors from the search no-results page instead of dead-ending

### DIFF
--- a/templates/catalog/listing/search.tpl
+++ b/templates/catalog/listing/search.tpl
@@ -14,6 +14,11 @@
 
 {block name='error_content'}
   <p>{l s='Search again what you are looking for.' d='Shop.Theme.Catalog'}</p>
+  <ul class="search-no-results-tips">
+    <li>{l s='Check the spelling of your search term.' d='Shop.Theme.Catalog'}</li>
+    <li>{l s='Try a more general or different keyword.' d='Shop.Theme.Catalog'}</li>
+  </ul>
+  <a class="btn btn-primary" href="{$urls.pages.index}">{l s='Browse our catalog' d='Shop.Theme.Catalog'}</a>
 {/block}
 
 {block name='product_list_header'}

--- a/templates/catalog/listing/search.tpl
+++ b/templates/catalog/listing/search.tpl
@@ -13,12 +13,12 @@
 {/block}
 
 {block name='error_content'}
-  <p>{l s='Search again what you are looking for.' d='Shop.Theme.Catalog'}</p>
-  <ul class="search-no-results-tips">
+  <p>{l s='We couldn\'t find any matching products.' d='Shop.Theme.Catalog'}</p>
+  <ul>
     <li>{l s='Check the spelling of your search term.' d='Shop.Theme.Catalog'}</li>
     <li>{l s='Try a more general or different keyword.' d='Shop.Theme.Catalog'}</li>
   </ul>
-  <a class="btn btn-primary" href="{$urls.pages.index}">{l s='Browse our catalog' d='Shop.Theme.Catalog'}</a>
+  <a class="btn btn-primary" href="{$urls.pages.index}">{l s='Back to home' d='Shop.Theme.Catalog'}</a>
 {/block}
 
 {block name='product_list_header'}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The search "no results" state dead-ended the visitor: `catalog/listing/search.tpl`'s `error_content` block was a single line, "Search again what you are looking for.", with no path forward. On-site search UX research flags a failed search as a high-intent moment that should guide users onward rather than dead-end them (https://baymard.com/blog/ecommerce-search-query-types). This enriches the block with two search tips (spelling, broaden the term) and a "Browse our catalog" button linking to `$urls.pages.index`. Presentation-only — no controller/data changes, all strings translatable under `Shop.Theme.Catalog`, no new SCSS (reuses `btn btn-primary`). Fixes #1068.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #1068
| Sponsor company   |
| How to test?      | Search for a term with no matches (e.g. `xqzptvwk`). The no-results page now shows the two tips and a "Browse our catalog" button pointing at the shop home, instead of only "Search again what you are looking for.". A search that returns products is unchanged (the block only renders on the no-products path). Verified live on a 9.2 shop.
