### PR TITLE
Include the visible label in the product card details link accessible name

### DIFF
--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -106,7 +106,7 @@
                   </button>
                 </form>
               {else}
-                <a href="{$product.url}" class="product-miniature__details btn btn-outline-primary" aria-label="{l s='See details for %product_name%' sprintf=['%product_name%' => $product.name] d='Shop.Theme.Catalog'}">
+                <a href="{$product.url}" class="product-miniature__details btn btn-outline-primary" aria-label="{l s='See details for %product_name%' sprintf=['%product_name%' => $product.name] d='Shop.Theme.Actions'}">
                   {l s='See details' d='Shop.Theme.Actions'}
                 </a>
               {/if}

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -106,7 +106,7 @@
                   </button>
                 </form>
               {else}
-                <a href="{$product.url}" class="product-miniature__details btn btn-outline-primary" aria-label="{l s='View product %product_name%' sprintf=['%product_name%' => $product.name] d='Shop.Theme.Catalog'}">
+                <a href="{$product.url}" class="product-miniature__details btn btn-outline-primary" aria-label="{l s='See details for %product_name%' sprintf=['%product_name%' => $product.name] d='Shop.Theme.Catalog'}">
                   {l s='See details' d='Shop.Theme.Actions'}
                 </a>
               {/if}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | On the product miniature, the "See details" button (`catalog/_partials/miniatures/product.tpl`) reused the product title's `aria-label` ("View product %product_name%"). Its visible text is "See details", so the accessible name did not contain the visible label, failing WCAG 2.5.3 Label in Name (Level A / EN 301 549): a speech-input user saying "See details" could not activate it, and the announced name diverged from the label. This changes the button's `aria-label` to "See details for %product_name%", which contains the visible "See details" text while keeping the product-name context — mirroring the sibling quick-view control, whose `aria-label` already includes its visible "Quick view" text. The title link on the same card is unchanged (its visible text is the product name, so "View product %product_name%" is already correct there).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   |
| How to test?      | Open a page with the featured-products block (home). Inspect a card's "See details" button: `aria-label` is now "See details for <product name>" and includes the visible "See details" text. A Lighthouse/axe accessibility audit no longer reports "label-content-name-mismatch" for these links (verified on a 9.2 shop — the audit's passed-count increases and the mismatch is gone). `select` and other card controls are untouched.
