### PR TITLE
Pause the homepage slider autoplay on mobile viewports

### DIFF
--- a/src/js/constants/selectors-map.ts
+++ b/src/js/constants/selectors-map.ts
@@ -7,6 +7,10 @@ export const layout = {
   header: '[data-ps-ref="header"]',
 };
 
+export const imageslider = {
+  autoRotating: '#ps_imageslider[data-bs-ride="carousel"]',
+};
+
 export const facetedsearch = {
   range: '.js-faceted-slider',
   rangeContainer: '.js-faceted-slider-container',
@@ -199,6 +203,7 @@ export const passwordPolicy = {
 
 const selectorsMap = {
   layout,
+  imageslider,
   qtyInput,
   alert: {
     selector: '#notifications .container',

--- a/src/js/modules/ps_imageslider.test.ts
+++ b/src/js/modules/ps_imageslider.test.ts
@@ -1,0 +1,77 @@
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+import {Carousel} from 'bootstrap';
+import initImageslider from '@js/modules/ps_imageslider';
+
+jest.mock('bootstrap');
+
+const pause = jest.fn();
+const cycle = jest.fn();
+
+type MediaListener = (event: {matches: boolean}) => void;
+
+const mockMatchMedia = (matches: boolean) => {
+  const listeners: MediaListener[] = [];
+  const mediaQueryList = {
+    matches,
+    addEventListener: (_: string, callback: MediaListener) => listeners.push(callback),
+    dispatch: (newMatches: boolean) => listeners.forEach((callback) => callback({matches: newMatches})),
+  };
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: () => mediaQueryList,
+  });
+
+  return mediaQueryList;
+};
+
+describe('ps_imageslider autoplay policy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Carousel.getOrCreateInstance as jest.Mock).mockReturnValue({pause, cycle});
+    document.body.innerHTML = '<div id="ps_imageslider" class="carousel slide" data-bs-ride="carousel"></div>';
+  });
+
+  it('pauses the slider on mobile viewports', () => {
+    mockMatchMedia(true);
+
+    initImageslider();
+
+    expect(pause).toHaveBeenCalledTimes(1);
+    expect(cycle).not.toHaveBeenCalled();
+  });
+
+  it('lets the slider auto-rotate on desktop viewports', () => {
+    mockMatchMedia(false);
+
+    initImageslider();
+
+    expect(cycle).toHaveBeenCalledTimes(1);
+    expect(pause).not.toHaveBeenCalled();
+  });
+
+  it('re-applies the policy when the viewport crosses the breakpoint', () => {
+    const mediaQueryList = mockMatchMedia(false);
+
+    initImageslider();
+    expect(cycle).toHaveBeenCalledTimes(1);
+
+    mediaQueryList.dispatch(true);
+    expect(pause).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when the slider is not configured to auto-rotate', () => {
+    mockMatchMedia(true);
+    document.body.innerHTML = '<div id="ps_imageslider" class="carousel slide"></div>';
+
+    initImageslider();
+
+    expect(pause).not.toHaveBeenCalled();
+    expect(cycle).not.toHaveBeenCalled();
+  });
+});

--- a/src/js/modules/ps_imageslider.ts
+++ b/src/js/modules/ps_imageslider.ts
@@ -1,0 +1,37 @@
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+import {Carousel} from 'bootstrap';
+import SelectorsMap from '@constants/selectors-map';
+
+// Below the `lg` breakpoint (Bootstrap: < 992px) touch users cannot hover to pause the
+// carousel, so the homepage slider should not auto-rotate on mobile even when a speed is
+// configured. `data-bs-ride="carousel"` is honoured by Bootstrap on every viewport, so the
+// autoplay is paused/resumed here as the viewport crosses the breakpoint.
+const MOBILE_BREAKPOINT = '(max-width: 991.98px)';
+
+const applyAutoplayPolicy = (carousel: Carousel, isMobile: boolean): void => {
+  if (isMobile) {
+    carousel.pause();
+  } else {
+    carousel.cycle();
+  }
+};
+
+const initImageslider = (): void => {
+  const slider = document.querySelector<HTMLElement>(SelectorsMap.imageslider.autoRotating);
+
+  if (!slider) {
+    return;
+  }
+
+  const carousel = Carousel.getOrCreateInstance(slider);
+  const mediaQuery = window.matchMedia(MOBILE_BREAKPOINT);
+
+  applyAutoplayPolicy(carousel, mediaQuery.matches);
+  mediaQuery.addEventListener('change', (event) => applyAutoplayPolicy(carousel, event.matches));
+};
+
+export default initImageslider;

--- a/src/js/theme.ts
+++ b/src/js/theme.ts
@@ -34,6 +34,7 @@ import initScrollPaddingTop from '@helpers/scrollPadding';
 import initProductAccessibility from '@js/accessibility/product';
 import initCartAccessibility from '@js/accessibility/cart';
 import initProductComments from '@js/modules/productcomments';
+import initImageslider from '@js/modules/ps_imageslider';
 import parseData from '@helpers/parseData';
 
 initEmitter();
@@ -62,6 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
   usePasswordPolicy();
   initCategoryTree();
   initScrollPaddingTop();
+  initImageslider();
   initBlockCart();
   initProductComments();
   // Accessibility


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The homepage image slider auto-rotates on every viewport because `data-bs-ride="carousel"` is honoured by Bootstrap regardless of screen size. On mobile, touch users cannot hover to pause, so the carousel keeps advancing under them. This adds a small `ps_imageslider` module that, below the `lg` breakpoint (< 992px), pauses the slider and resumes auto-rotation on larger viewports, re-applying the policy via a `matchMedia` change listener when the viewport crosses the breakpoint. Desktop auto-rotation and the manual prev/next/indicator controls are unchanged; if no speed is configured (no `data-bs-ride`), the module is a no-op. Fixes #1070.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #1070
| Sponsor company   |
| How to test?      | On a mobile viewport (< 992px), open the homepage: the slider no longer advances on its own. On desktop it still auto-rotates. Crossing the breakpoint (resize) flips the behavior without a reload. Covered by a Jest test (`ps_imageslider.test.ts`): pauses on mobile, cycles on desktop, re-applies on breakpoint change, no-op without autoplay. Verified live on a 9.2 shop (mobile: slide stays put over 6s; desktop: advances).
