### PR TITLE
Fix blurry product cover image below the lg breakpoint

### DIFF
--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -21,7 +21,7 @@
                     srcset="
                       {$image.bySize.default_xl.sources.avif} 400w,
                       {$image.bySize.product_main.sources.avif} 720w"
-                    sizes="(min-width: 992px) 50vw, (min-width: 360px) 33vw, 100vw"
+                    sizes="(min-width: 992px) 50vw, 100vw"
                     type="image/avif"
                   >
                 {/if}
@@ -31,7 +31,7 @@
                     srcset="
                       {$image.bySize.default_xl.sources.webp} 400w,
                       {$image.bySize.product_main.sources.webp} 720w"
-                    sizes="(min-width: 992px) 50vw, (min-width: 360px) 33vw, 100vw"
+                    sizes="(min-width: 992px) 50vw, 100vw"
                     type="image/webp"
                   >
                 {/if}
@@ -41,7 +41,7 @@
                   srcset="
                     {$image.bySize.default_xl.url} 400w,
                     {$image.bySize.product_main.url} 720w"
-                  sizes="(min-width: 992px) 50vw, (min-width: 360px) 33vw, 100vw"
+                  sizes="(min-width: 992px) 50vw, 100vw"
                   src="{$image.bySize.product_main.url}" 
                   width="{$image.bySize.product_main.width}"
                   height="{$image.bySize.product_main.height}"
@@ -144,7 +144,7 @@
             srcset="
               {$urls.no_picture_image.bySize.default_xl.sources.avif} 400w,
               {$urls.no_picture_image.bySize.product_main.sources.avif} 720w"
-            sizes="(min-width: 992px) 50vw, (min-width: 360px) 33vw, 100vw"
+            sizes="(min-width: 992px) 50vw, 100vw"
             type="image/avif"
           >
         {/if}
@@ -154,7 +154,7 @@
             srcset="
               {$urls.no_picture_image.bySize.default_xl.sources.webp} 400w,
               {$urls.no_picture_image.bySize.product_main.sources.webp} 720w"
-            sizes="(min-width: 992px) 50vw, (min-width: 360px) 33vw, 100vw"
+            sizes="(min-width: 992px) 50vw, 100vw"
             type="image/webp"
           >
         {/if}
@@ -164,7 +164,7 @@
           srcset="
             {$urls.no_picture_image.bySize.default_xl.url} 400w,
             {$urls.no_picture_image.bySize.product_main.url} 720w"
-          sizes="(min-width: 992px) 50vw, (min-width: 360px) 33vw, 100vw"
+          sizes="(min-width: 992px) 50vw, 100vw"
           width="{$urls.no_picture_image.bySize.product_main.width}"
           height="{$urls.no_picture_image.bySize.product_main.height}"
           src="{$urls.no_picture_image.bySize.default_xl.url}" 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The product cover image renders blurry between roughly 720px and 992px. Its `sizes` attribute declared `(min-width: 992px) 50vw, (min-width: 360px) 33vw, 100vw`, but below the `lg` breakpoint the gallery stacks to full content width, so at those viewports the cover is displayed at ~70-80vw, not 33vw. The browser therefore picked the smaller `default_xl` (400w) candidate for a ~516-696px slot and upscaled it. `33vw` matches the 3-up product-list card, not the cover. This drops the incorrect middle stop so the cover uses `(min-width: 992px) 50vw, 100vw`: 50vw for the side-by-side desktop layout, full width once it stacks — which makes the browser select the `product_main` (720w) candidate at those widths. Fixes #703.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #703
| Sponsor company   |
| How to test?      | Open a product page, then in DevTools device toolbar (responsive mode) set the width between 720px and 992px **with the DPR selector at 1**, disable cache and reload. Before: the cover's `currentSrc` is the 400w `default_xl` variant, upscaled across the full-width slot (soft). After: it is the 720w `product_main` variant (sharp). Note: on a 2x/HiDPI display both before and after already resolve to `product_main`, so the difference is only visible at DPR 1. Verified via `currentSrc` at 760/800/900px (DPR 1: `default_xl` -> `product_main`; DPR 2: `product_main` in both). Desktop (>= 992px, 50vw) and the modal/thumbnail markup are unchanged.

