### PR TITLE
Disable autocorrect on form text fields to avoid mangling names and addresses

### DIFF
--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -207,6 +207,7 @@
           id="field-{$field.name}"
           type="{$field.type}"
           value="{$field.value}"
+          autocorrect="off"
           {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}
           {if isset($field.availableValues.placeholder)}placeholder="{$field.availableValues.placeholder}"{/if}
           {if $field.maxLength}maxlength="{$field.maxLength}"{/if}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Text inputs rendered by the shared `_partials/form-fields.tpl` (`form_field_item_other` block) carry no `autocorrect` attribute, so on mobile the browser autocorrects what users type. For the fields this block renders — first/last name, address, city, company, VAT, etc. — autocorrect turns proper nouns and structured values into dictionary words (e.g. surnames and street names get "corrected"), which is a documented source of checkout and address-form friction (Baymard: disable autocorrect on name/address/email fields). This adds `autocorrect="off"` to the input. It applies to every front-office form that uses the shared renderer, including the one-page checkout and registration address forms; the multi-line delivery-message textarea has its own block and is untouched, so free-text keeps autocorrect.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   |
| How to test?      | Open any form using the shared field renderer (e.g. `/registration` or the checkout address form) on a mobile device/emulation and inspect a text field: it now carries `autocorrect="off"`, so typing a surname or street name is no longer autocorrected. Verified on a 9.2 shop — first name, last name and email inputs render `autocorrect="off"`. `type`, `autocomplete`, `required` and the other attributes are unchanged.
