### PR TITLE
Format the B2B tax-excluded price with the currency

### DIFF
--- a/templates/catalog/_partials/product-prices.tpl
+++ b/templates/catalog/_partials/product-prices.tpl
@@ -84,7 +84,7 @@
 
         {block name='product_without_taxes'}
           {if $priceDisplay == 0 && $configuration.is_b2b}
-            <span class="product__taxless-price">{l s='%price% tax excluded' d='Shop.Theme.Catalog' sprintf=['%price%' => $product.price_tax_exc]}</span>
+            <span class="product__taxless-price">{l s='%price% tax excluded' d='Shop.Theme.Catalog' sprintf=['%price%' => $product.price_tax_excluded]}</span>
           {/if}
         {/block}
       </div>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When the B2B option is enabled, the product page rendered the "tax excluded" price from the raw `price_tax_exc` amount, so it showed an unformatted number instead of a currency-formatted price. This uses the presenter's already formatted `price_tax_excluded` value — the same one the presenter uses as the main `price` when the shop is in tax-excluded display mode. Fixes #1076.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #1076
| Sponsor company   |
| How to test?      | Enable B2B mode (Shop Parameters > Customer Settings > B2B mode) and open a product page. Before: the "%price% tax excluded" line shows a raw unformatted number (e.g. `10.000000 tax excluded`). After: it shows the currency-formatted price (e.g. `€10.00 tax excluded`), matching the main price formatting. Only the `product__taxless-price` line changes; the tax-included price and the rest of the block are untouched.
