### PR TITLE
Use new image feature

### DIFF
--- a/config/theme.yml
+++ b/config/theme.yml
@@ -219,6 +219,11 @@ global_settings:
       width: 2000
       height: 400
       scope: [categories]
+    manufacturer_product_page:
+      width: 98
+      height: 98
+      scope: [manufacturers]
+      image_fitment: bound
 
 theme_settings:
   rtl_generation: false

--- a/templates/catalog/_partials/product-details.tpl
+++ b/templates/catalog/_partials/product-details.tpl
@@ -25,14 +25,14 @@
                 </div>
 
                 <div class="details__right">
-                  {if isset($product_manufacturer.image.bySize.small_default.url)}
+                  {if isset($product_manufacturer.image.bySize.manufacturer_product_page.url)}
                     <a href="{$product_manufacturer->url}">
-                      <img src="{$product_manufacturer.image.bySize.small_default.url}"
+                      <img src="{$product_manufacturer.image.bySize.manufacturer_product_page.url}"
                         class="img-fluid details__manufacturer-logo"
                         alt="{$product_manufacturer->name}"
                         loading="lazy"
-                        width="{$product_manufacturer.image.bySize.small_default.width}"
-                        height="{$product_manufacturer.image.bySize.small_default.height}"
+                        width="{$product_manufacturer.image.bySize.manufacturer_product_page.width}"
+                        height="{$product_manufacturer.image.bySize.manufacturer_product_page.height}"
                         aria-label="{l s='Brand: %brand_name%' sprintf=['%brand_name%' => $product_manufacturer->name] d='Shop.Theme.Catalog'}"
                       >
                     </a>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Puts the new https://github.com/PrestaShop/PrestaShop/pull/41977 feature to use. Adds new image dimension for manufacturers and uses it on the product page.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | TRENDO s.r.o.
| How to test?      | See that the new image doesn't have whitespace anymore.
