### PR TITLE
Add useful links in store details

### DIFF
--- a/templates/cms/stores.tpl
+++ b/templates/cms/stores.tpl
@@ -72,19 +72,31 @@
                         <ul class="store__contacts">
                           {if $store.phone}
                             <li class="store__contact">
-                              <i class="material-icons" aria-hidden="true">&#xE0B0;</i>{$store.phone}
+                              <i class="material-icons" aria-hidden="true">&#xE0B0;</i>
+                              <a href="tel:{$store.phone|replace:' ':''}"
+                                aria-label="{l s='Call our store %store_name% on the number: %phone%' sprintf=['%store_name%' => $store.name, '%phone%' => $store.phone] d='Shop.Theme.Global'}">
+                                {$store.phone}
+                              </a>
                             </li>
                           {/if}
           
                           {if $store.fax}
                             <li class="store__contact">
-                              <i class="material-icons" aria-hidden="true">&#xE8AD;</i>{$store.fax}
+                              <i class="material-icons" aria-hidden="true">&#xE8AD;</i>
+                              <a href="tel:{$store.fax|replace:' ':''}"
+                                aria-label="{l s='Send a fax to our store %store_name% at: %fax%' sprintf=['%store_name%' => $store.name, '%fax%' => $store.fax] d='Shop.Theme.Global'}">
+                                {$store.fax}
+                              </a>
                             </li>
                           {/if}
           
                           {if $store.email}
                             <li class="store__contact store__contact--email">
-                              <i class="material-icons" aria-hidden="true">&#xE0BE;</i>{$store.email}
+                              <i class="material-icons" aria-hidden="true">&#xE0BE;</i>
+                              <a href="mailto:{$store.email}"
+                                aria-label="{l s='Send an email to our store %store_name% at: %email%' sprintf=['%store_name%' => $store.name, '%email%' => $store.email] d='Shop.Theme.Global'}">
+                                {$store.email}
+                              </a>
                             </li>
                           {/if}
                         </ul>

--- a/templates/cms/stores.tpl
+++ b/templates/cms/stores.tpl
@@ -74,7 +74,7 @@
                             <li class="store__contact">
                               <i class="material-icons" aria-hidden="true">&#xE0B0;</i>
                               <a href="tel:{$store.phone|replace:' ':''}"
-                                aria-label="{l s='Call our store %store_name% on the number: %phone%' sprintf=['%store_name%' => $store.name, '%phone%' => $store.phone] d='Shop.Theme.Global'}">
+                                aria-label="{l s='Call %store_name% at: %phone%' sprintf=['%store_name%' => $store.name, '%phone%' => $store.phone] d='Shop.Theme.Global'}">
                                 {$store.phone}
                               </a>
                             </li>
@@ -84,7 +84,7 @@
                             <li class="store__contact">
                               <i class="material-icons" aria-hidden="true">&#xE8AD;</i>
                               <a href="tel:{$store.fax|replace:' ':''}"
-                                aria-label="{l s='Send a fax to our store %store_name% at: %fax%' sprintf=['%store_name%' => $store.name, '%fax%' => $store.fax] d='Shop.Theme.Global'}">
+                                aria-label="{l s='Send a fax to %store_name% at: %fax%' sprintf=['%store_name%' => $store.name, '%fax%' => $store.fax] d='Shop.Theme.Global'}">
                                 {$store.fax}
                               </a>
                             </li>
@@ -94,7 +94,7 @@
                             <li class="store__contact store__contact--email">
                               <i class="material-icons" aria-hidden="true">&#xE0BE;</i>
                               <a href="mailto:{$store.email}"
-                                aria-label="{l s='Send an email to our store %store_name% at: %email%' sprintf=['%store_name%' => $store.name, '%email%' => $store.email] d='Shop.Theme.Global'}">
+                                aria-label="{l s='Send an email to %store_name% at: %email%' sprintf=['%store_name%' => $store.name, '%email%' => $store.email] d='Shop.Theme.Global'}">
                                 {$store.email}
                               </a>
                             </li>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add useful links to phone number, fax number, and email address on stores page
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   | 
| How to test?      | Add contact email, phone and fax number to the any store and go to stores page in FO
