### PR TITLE
Fix product schema image and price validity

### DIFF
--- a/templates/_partials/microdata/product-jsonld.tpl
+++ b/templates/_partials/microdata/product-jsonld.tpl
@@ -31,7 +31,7 @@
     "name": {$product.name|json_encode nofilter},
     "description": {$page.meta.description|json_encode nofilter},
     "category": {$product.category_name|json_encode nofilter},
-    {if !empty($product.cover)}"image": {$product.cover.bySize.home_default.url|json_encode nofilter},{/if}
+    {if !empty($product.cover)}"image": {$product.cover.large.url|json_encode nofilter},{/if}
     "sku": {if $product.reference}{$product.reference|json_encode nofilter}{else}{$product.id|json_encode nofilter}{/if},
     "mpn": {if $product.mpn}{$product.mpn|json_encode nofilter}{elseif $product.reference}{$product.reference|json_encode nofilter}{else}{$product.id|json_encode nofilter}{/if}
     {if $product.ean13},"gtin": {$product.ean13|json_encode nofilter}{/if}
@@ -68,7 +68,6 @@
       "priceCurrency": {$currency.iso_code|json_encode nofilter},
       "price": "{$product.price_amount}",
       "url": {$product.url|json_encode nofilter},
-      "priceValidUntil": "{($smarty.now + (int) (60*60*24*15))|date_format:"%Y-%m-%d"}",
       {if $product.images|count > 0}
         "image": {strip}[
           {foreach from=$product.images item=p_img name="p_img_list"}


### PR DESCRIPTION
## Summary

- use the original product cover URL in `Product.image` instead of the 250 x 250 `home_default` thumbnail
- omit `Offer.priceValidUntil` when the catalog has no actual price-expiry date

## Why

`priceValidUntil` means the date after which the displayed price is no longer available. Generating an arbitrary date 15 days in the future publishes data that is not backed by catalog state and changes on every render. Omitting it is accurate when no validity date exists.

The full product cover is also a better structured-data image than the small listing thumbnail and is already exposed by the product presenter.

Reference: https://developers.google.com/search/docs/appearance/structured-data/product-snippet#offer-properties

## Test

- reviewed the rendered JSON-LD template paths for products with and without a cover
- verified the trailing commas remain valid with `priceValidUntil` removed