### PR TITLE
Respect the country tax label setting on the product page

### DIFF
--- a/templates/catalog/_partials/product-prices.tpl
+++ b/templates/catalog/_partials/product-prices.tpl
@@ -57,10 +57,12 @@
 
         <div class="product__tax-infos">
           <span class="product__tax-label">
-            {if !$configuration.taxes_enabled}
-              {l s='No tax' d='Shop.Theme.Catalog'}
-            {elseif $configuration.display_taxes_label}
-              {$product.labels.tax_long}
+            {if $configuration.display_taxes_label}
+              {if $configuration.taxes_enabled}
+                {$product.labels.tax_long}
+              {else}
+                {l s='No tax' d='Shop.Theme.Catalog'}
+              {/if}
             {/if}
             
             {hook h='displayProductPriceBlock' product=$product type="price"}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?    | The product page prints "No tax" whenever taxes are disabled without consulting the country's "Display tax label" setting, which the very next branch of the same template already honours. `$configuration.display_taxes_label` is `$this->context->country->display_tax_label` (`FrontController::getDisplayTaxesLabel()`), so a merchant who turns that checkbox off still gets a tax statement on every product page. Both branches are now gated on the setting.
| Type?           | bug fix
| BC breaks?      | no
| Deprecations?   | no
| Fixed ticket?   | Fixes https://github.com/PrestaShop/PrestaShop/issues/21484
| Sponsor company |
| How to test?    | Set a country's "Display tax label" to No (International > Locations > Countries), then disable taxes (International > Taxes > Enable taxes: No) and open a product page. Before: "No tax" is displayed. After: nothing is displayed. With the label set to Yes the behaviour is unchanged in both tax states.

### Before

```smarty
{if !$configuration.taxes_enabled}
  {l s='No tax' d='Shop.Theme.Catalog'}
{elseif $configuration.display_taxes_label}
  {$product.labels.tax_long}
{/if}
```

### After

```smarty
{if $configuration.display_taxes_label}
  {if $configuration.taxes_enabled}
    {$product.labels.tax_long}
  {else}
    {l s='No tax' d='Shop.Theme.Catalog'}
  {/if}
{/if}
```

### Empty block

With the label off and no ecotax, `product__tax-infos` rendered empty and still took the flex gap. It is now
rendered only when it has a label, an ecotax line or price hook output: the two `displayProductPriceBlock` hooks
are captured first and the gate tests the capture with `|trim`. In debug mode the `<!-- begin/end -->` comments
around an empty hook count as output, so a dev shop can still show the empty block; a production shop cannot.

### Why this shape

https://github.com/PrestaShop/PrestaShop/pull/25882 fixed the same defect for the cart summary and the
order confirmation table by gating on `display_taxes_label` together with `taxes_enabled`, and was merged
in October 2021. The product page was not part of it, which is why the issue is still open with this exact
template quoted in the thread. Using the same gate keeps the three places consistent rather than inventing
a rule for this one.

### Scope

Only the product page template changes. The cart summary and the order confirmation table already respect
the setting since https://github.com/PrestaShop/PrestaShop/pull/25882, and so does `DeliveryOptionsFinder`.

Companion to the same change in `classic-theme`: the two themes carry the same template and the same defect.


