### PR TITLE
Mark the reassurance icons as decorative

### DIFF
--- a/modules/blockreassurance/views/templates/hook/displayBlock.tpl
+++ b/modules/blockreassurance/views/templates/hook/displayBlock.tpl
@@ -14,9 +14,9 @@
 
           <span class="reassurance__image">
             {if $block['custom_icon']}
-              <img {if $block['is_svg']}class="svg img-fluid invisible" {/if}src="{$block['custom_icon']}">
+              <img {if $block['is_svg']}class="svg img-fluid invisible" {/if}src="{$block['custom_icon']}" alt="">
             {elseif $block['icon']}
-              <img class="svg img-fluid invisible" src="{$block['icon']}">
+              <img class="svg img-fluid invisible" src="{$block['icon']}" alt="">
             {/if}
           </span>
 

--- a/modules/blockreassurance/views/templates/hook/displayBlockProduct.tpl
+++ b/modules/blockreassurance/views/templates/hook/displayBlockProduct.tpl
@@ -13,9 +13,9 @@
 
         <span class="reassurance__image">
           {if $block['custom_icon']}
-            <img {if $block['is_svg']}class="svg img-fluid invisible" {/if}src="{$block['custom_icon']}">
+            <img {if $block['is_svg']}class="svg img-fluid invisible" {/if}src="{$block['custom_icon']}" alt="">
           {elseif $block['icon']}
-            <img class="svg img-fluid invisible" src="{$block['icon']}">
+            <img class="svg img-fluid invisible" src="{$block['icon']}" alt="">
           {/if}
         </span>
 

--- a/modules/blockreassurance/views/templates/hook/displayBlockWhite.tpl
+++ b/modules/blockreassurance/views/templates/hook/displayBlockWhite.tpl
@@ -14,9 +14,9 @@
 
           <span class="reassurance__image">
             {if $block['custom_icon']}
-              <img {if $block['is_svg']}class="svg img-fluid invisible" {/if}src="{$block['custom_icon']}">
+              <img {if $block['is_svg']}class="svg img-fluid invisible" {/if}src="{$block['custom_icon']}" alt="">
             {elseif $block['icon']}
-              <img class="svg img-fluid invisible" src="{$block['icon']}">
+              <img class="svg img-fluid invisible" src="{$block['icon']}" alt="">
             {/if}
           </span>
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The theme overrides the three blockreassurance hook templates, and its copies carry no `alt` on the six `img` tags either, so the default PrestaShop 9 front office renders the reassurance icons with no alt attribute. Each icon sits next to the block title and description, so it is redundant to adjacent text and gets `alt=""`, the same call as https://github.com/PrestaShop/hummingbird/pull/1060 for the payment option logo.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/30619
| Sponsor company   | None
| How to test?      | Open a product page on a shop using this theme with the blockreassurance module enabled and read the rendered markup: the three `img` tags inside `.reassurance__image` now carry `alt=""`. Verified on a 9.2 shop: before, `<img class="svg img-fluid invisible" src="...security.svg">`; after, the same tag with `alt=""`. The rendered pixels are unchanged.

### Related

Companion PR on the module itself, for shops using a theme that does not override these templates: https://github.com/PrestaShop/blockreassurance/pull/818
