### PR TITLE
Emit only the srcset candidates whose image type exists

### DIFF
--- a/templates/catalog/_partials/miniatures/product-image.tpl
+++ b/templates/catalog/_partials/miniatures/product-image.tpl
@@ -3,27 +3,25 @@
  * LICENSE.md file that was distributed with this source code.
  *}
 {block name='product_miniature_image'}
+  {assign var='miniatureSizes' value=['default_sm' => '216w', 'default_md' => '261w', 'default_lg' => '336w']}
   <div class="{$componentName}__image-container thumbnail-container">
     <a href="{$product.url}" class="{$componentName}__image-link outline outline--rounded">
       {if $product.cover}
+        {capture name='miniatureSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$miniatureSizes srcsetVariant='avif'}{/capture}
+        {capture name='miniatureSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$miniatureSizes srcsetVariant='webp'}{/capture}
+        {capture name='miniatureSrcset'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$miniatureSizes}{/capture}
         <picture>
-          {if isset($product.cover.bySize.default_md.sources.avif)}
+          {if $smarty.capture.miniatureSrcsetAvif|trim}
             <source
-              srcset="
-                {$product.cover.bySize.default_sm.sources.avif} 216w,
-                {$product.cover.bySize.default_md.sources.avif} 261w,
-                {$product.cover.bySize.default_lg.sources.avif} 336w"
+              srcset="{$smarty.capture.miniatureSrcsetAvif|trim nofilter}"
               sizes="(min-width: 992px) 25vw, (min-width: 360px) 50vw, 100vw"
               type="image/avif"
             >
           {/if}
 
-          {if isset($product.cover.bySize.default_md.sources.webp)}
+          {if $smarty.capture.miniatureSrcsetWebp|trim}
             <source
-              srcset="
-                {$product.cover.bySize.default_sm.sources.webp} 216w,
-                {$product.cover.bySize.default_md.sources.webp} 261w,
-                {$product.cover.bySize.default_lg.sources.webp} 336w"
+              srcset="{$smarty.capture.miniatureSrcsetWebp|trim nofilter}"
               sizes="(min-width: 992px) 25vw, (min-width: 360px) 50vw, 100vw"
               type="image/webp"
             >
@@ -31,11 +29,10 @@
 
           <img
             class="{$componentName}__image"
-            srcset="
-              {$product.cover.bySize.default_sm.url} 216w,
-              {$product.cover.bySize.default_md.url} 261w,
-              {$product.cover.bySize.default_lg.url} 336w"
-            sizes="(min-width: 992px) 25vw, (min-width: 360px) 50vw, 100vw"
+            {if $smarty.capture.miniatureSrcset|trim}
+              srcset="{$smarty.capture.miniatureSrcset|trim nofilter}"
+              sizes="(min-width: 992px) 25vw, (min-width: 360px) 50vw, 100vw"
+            {/if}
             src="{$product.cover.bySize.default_md.url}"
             width="{$product.cover.bySize.default_md.width}"
             height="{$product.cover.bySize.default_md.height}"
@@ -46,24 +43,21 @@
           >
         </picture>
       {else}
+        {capture name='miniatureEmptySrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$miniatureSizes srcsetVariant='avif'}{/capture}
+        {capture name='miniatureEmptySrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$miniatureSizes srcsetVariant='webp'}{/capture}
+        {capture name='miniatureEmptySrcset'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$miniatureSizes}{/capture}
         <picture>
-          {if isset($urls.no_picture_image.bySize.default_md.sources.avif)}
+          {if $smarty.capture.miniatureEmptySrcsetAvif|trim}
             <source
-              srcset="
-                {$urls.no_picture_image.bySize.default_sm.sources.avif} 216w,
-                {$urls.no_picture_image.bySize.default_md.sources.avif} 261w,
-                {$urls.no_picture_image.bySize.default_lg.sources.avif} 336w"
+              srcset="{$smarty.capture.miniatureEmptySrcsetAvif|trim nofilter}"
               sizes="(min-width: 992px) 25vw, (min-width: 360px) 50vw, 100vw"
               type="image/avif"
             >
           {/if}
 
-          {if isset($urls.no_picture_image.bySize.default_md.sources.webp)}
+          {if $smarty.capture.miniatureEmptySrcsetWebp|trim}
             <source
-              srcset="
-                {$urls.no_picture_image.bySize.default_sm.sources.webp} 216w,
-                {$urls.no_picture_image.bySize.default_md.sources.webp} 261w,
-                {$urls.no_picture_image.bySize.default_lg.sources.webp} 336w"
+              srcset="{$smarty.capture.miniatureEmptySrcsetWebp|trim nofilter}"
               sizes="(min-width: 992px) 25vw, (min-width: 360px) 50vw, 100vw"
               type="image/webp"
             >
@@ -71,11 +65,10 @@
 
           <img
             class="{$componentName}__image"
-            srcset="
-              {$urls.no_picture_image.bySize.default_sm.url} 216w,
-              {$urls.no_picture_image.bySize.default_md.url} 261w,
-              {$urls.no_picture_image.bySize.default_lg.url} 336w"
-            sizes="(min-width: 992px) 25vw, (min-width: 360px) 50vw, 100vw"
+            {if $smarty.capture.miniatureEmptySrcset|trim}
+              srcset="{$smarty.capture.miniatureEmptySrcset|trim nofilter}"
+              sizes="(min-width: 992px) 25vw, (min-width: 360px) 50vw, 100vw"
+            {/if}
             width="{$urls.no_picture_image.bySize.default_md.width}"
             height="{$urls.no_picture_image.bySize.default_md.height}"
             src="{$urls.no_picture_image.bySize.default_md.url}"

--- a/templates/catalog/_partials/miniatures/product-pack.tpl
+++ b/templates/catalog/_partials/miniatures/product-pack.tpl
@@ -2,6 +2,8 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
+{assign var='emptyImageSizes' value=['default_xs' => '', 'default_md' => '2x']}
+{assign var='imageSizes' value=['default_xs' => '', 'default_md' => '2x']}
 {block name='pack_miniature_item'}
   <article class="product-pack__item">
     <a href="{$product.url}"
@@ -11,29 +13,28 @@
       <span class="product-pack__image-wrapper">
         {if !empty($product.default_image)}
           <picture>
-            {if isset($product.default_image.bySize.default_xs.sources.avif)}
-              <source 
-                srcset="
-                  {$product.default_image.bySize.default_xs.sources.avif},
-                  {$product.default_image.bySize.default_md.sources.avif} 2x"
+            {capture name='imageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes srcsetVariant='avif'}{/capture}
+            {if $smarty.capture.imageSrcsetAvif|trim}
+              <source
+                srcset="{$smarty.capture.imageSrcsetAvif|trim nofilter}"
                 type="image/avif"
               >
             {/if}
 
-            {if isset($product.default_image.bySize.default_xs.sources.webp)}
-              <source 
-                srcset="
-                  {$product.default_image.bySize.default_xs.sources.webp},
-                  {$product.default_image.bySize.default_md.sources.webp} 2x"
+            {capture name='imageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes srcsetVariant='webp'}{/capture}
+            {if $smarty.capture.imageSrcsetWebp|trim}
+              <source
+                srcset="{$smarty.capture.imageSrcsetWebp|trim nofilter}"
                 type="image/webp"
               >
             {/if}
 
             <img
               class="product-pack__image img-fluid"
-              srcset="
-                {$product.default_image.bySize.default_xs.url},
-                {$product.default_image.bySize.default_md.url} 2x"
+              {capture name='imageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes}{/capture}
+              {if $smarty.capture.imageSrcset|trim}
+                srcset="{$smarty.capture.imageSrcset|trim nofilter}"
+              {/if}
               src="{$product.default_image.bySize.default_xs.url}"
               loading="lazy"
               width="{$product.default_image.bySize.default_xs.width}"
@@ -44,29 +45,28 @@
           </picture>
         {else}
           <picture>
-            {if isset($urls.no_picture_image.bySize.default_xs.sources.avif)}
-              <source 
-                srcset="
-                  {$urls.no_picture_image.bySize.default_xs.sources.avif},
-                  {$urls.no_picture_image.bySize.default_md.sources.avif} 2x"
+            {capture name='emptyImageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='avif'}{/capture}
+            {if $smarty.capture.emptyImageSrcsetAvif|trim}
+              <source
+                srcset="{$smarty.capture.emptyImageSrcsetAvif|trim nofilter}"
                 type="image/avif"
               >
             {/if}
 
-            {if isset($urls.no_picture_image.bySize.default_xs.sources.webp)}
-              <source 
-                srcset="
-                  {$urls.no_picture_image.bySize.default_xs.sources.webp},
-                  {$urls.no_picture_image.bySize.default_md.sources.webp} 2x"
+            {capture name='emptyImageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='webp'}{/capture}
+            {if $smarty.capture.emptyImageSrcsetWebp|trim}
+              <source
+                srcset="{$smarty.capture.emptyImageSrcsetWebp|trim nofilter}"
                 type="image/webp"
               >
             {/if}
 
             <img
               class="product-pack__image img-fluid"
-              srcset="
-                {$urls.no_picture_image.bySize.default_xs.url},
-                {$urls.no_picture_image.bySize.default_md.url} 2x"
+              {capture name='emptyImageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes}{/capture}
+              {if $smarty.capture.emptyImageSrcset|trim}
+                srcset="{$smarty.capture.emptyImageSrcset|trim nofilter}"
+              {/if}
               src="{$urls.no_picture_image.bySize.default_xs.url}"
               width="{$urls.no_picture_image.bySize.default_xs.width}"
               height="{$urls.no_picture_image.bySize.default_xs.height}"

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -2,6 +2,7 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
+{assign var='imageSizes' value=['default_xs' => '', 'default_xl' => '2x']}
 
 <div class="product__images js-images-container">
   {if $product.images|@count > 0}
@@ -13,24 +14,24 @@
 
       <div class="carousel-inner">
         {block name='product_cover'}
+          {assign var='coverSizes' value=['default_xl' => '400w', 'product_main' => '720w']}
           {foreach from=$product.images item=image key=key name=productImages}
             <div class="carousel-item{if $image.id_image == $product.default_image.id_image} active{/if}">
               <picture>
-                {if isset($image.bySize.default_xl.sources.avif)}
-                  <source 
-                    srcset="
-                      {$image.bySize.default_xl.sources.avif} 400w,
-                      {$image.bySize.product_main.sources.avif} 720w"
+                {capture name='coverSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$image sizes=$coverSizes srcsetVariant='avif'}{/capture}
+                {capture name='coverSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$image sizes=$coverSizes srcsetVariant='webp'}{/capture}
+                {capture name='coverSrcset'}{include file='catalog/_partials/srcset.tpl' image=$image sizes=$coverSizes}{/capture}
+                {if $smarty.capture.coverSrcsetAvif|trim}
+                  <source
+                    srcset="{$smarty.capture.coverSrcsetAvif|trim nofilter}"
                     sizes="(min-width: 992px) 50vw, 100vw"
                     type="image/avif"
                   >
                 {/if}
 
-                {if isset($image.bySize.default_xl.sources.webp)}
-                  <source 
-                    srcset="
-                      {$image.bySize.default_xl.sources.webp} 400w,
-                      {$image.bySize.product_main.sources.webp} 720w"
+                {if $smarty.capture.coverSrcsetWebp|trim}
+                  <source
+                    srcset="{$smarty.capture.coverSrcsetWebp|trim nofilter}"
                     sizes="(min-width: 992px) 50vw, 100vw"
                     type="image/webp"
                   >
@@ -38,10 +39,10 @@
 
                 <img
                   class="img-fluid w-100"
-                  srcset="
-                    {$image.bySize.default_xl.url} 400w,
-                    {$image.bySize.product_main.url} 720w"
-                  sizes="(min-width: 992px) 50vw, 100vw"
+                  {if $smarty.capture.coverSrcset|trim}
+                    srcset="{$smarty.capture.coverSrcset|trim nofilter}"
+                    sizes="(min-width: 992px) 50vw, 100vw"
+                  {/if}
                   src="{$image.bySize.product_main.url}" 
                   width="{$image.bySize.product_main.width}"
                   height="{$image.bySize.product_main.height}"
@@ -96,29 +97,28 @@
                 aria-label="{l s='Slide to product image %number%' d='Shop.Theme.Catalog' sprintf=['%number%' => $key + 1]}"
               >
                 <picture>
-                  {if isset($image.bySize.default_xs.sources.avif)}
-                    <source 
-                      srcset="
-                        {$image.bySize.default_xs.sources.avif},
-                        {$image.bySize.default_xl.sources.avif} 2x"
+                  {capture name='imageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$image sizes=$imageSizes srcsetVariant='avif'}{/capture}
+                  {if $smarty.capture.imageSrcsetAvif|trim}
+                    <source
+                      srcset="{$smarty.capture.imageSrcsetAvif|trim nofilter}"
                       type="image/avif"
                     >
                   {/if}
 
-                  {if isset($image.bySize.default_xs.sources.webp)}
-                    <source 
-                      srcset="
-                        {$image.bySize.default_xs.sources.webp},
-                        {$image.bySize.default_xl.sources.webp} 2x"
+                  {capture name='imageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$image sizes=$imageSizes srcsetVariant='webp'}{/capture}
+                  {if $smarty.capture.imageSrcsetWebp|trim}
+                    <source
+                      srcset="{$smarty.capture.imageSrcsetWebp|trim nofilter}"
                       type="image/webp"
                     >
                   {/if}
 
                   <img
                     class="product__thumbnail-image outline outline--rounded img-fluid js-thumb{if $image.id_image == $product.default_image.id_image} js-thumb-selected{/if}"
-                    srcset="
-                      {$image.bySize.default_xs.url},
-                      {$image.bySize.default_xl.url} 2x"
+                    {capture name='imageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$image sizes=$imageSizes}{/capture}
+                    {if $smarty.capture.imageSrcset|trim}
+                      srcset="{$smarty.capture.imageSrcset|trim nofilter}"
+                    {/if}
                     width="{$image.bySize.default_xs.width}"
                     height="{$image.bySize.default_xs.height}"
                     loading="lazy"
@@ -139,21 +139,21 @@
       {include file='catalog/_partials/product-flags.tpl'}
 
       <picture>
-        {if isset($urls.no_picture_image.bySize.default_xl.sources.avif)}
-          <source 
-            srcset="
-              {$urls.no_picture_image.bySize.default_xl.sources.avif} 400w,
-              {$urls.no_picture_image.bySize.product_main.sources.avif} 720w"
+        {assign var='coverEmptySizes' value=['default_xl' => '400w', 'product_main' => '720w']}
+        {capture name='coverEmptySrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$coverEmptySizes srcsetVariant='avif'}{/capture}
+        {capture name='coverEmptySrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$coverEmptySizes srcsetVariant='webp'}{/capture}
+        {capture name='coverEmptySrcset'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$coverEmptySizes}{/capture}
+        {if $smarty.capture.coverEmptySrcsetAvif|trim}
+          <source
+            srcset="{$smarty.capture.coverEmptySrcsetAvif|trim nofilter}"
             sizes="(min-width: 992px) 50vw, 100vw"
             type="image/avif"
           >
         {/if}
 
-        {if isset($urls.no_picture_image.bySize.default_xl.sources.webp)}
-          <source 
-            srcset="
-              {$urls.no_picture_image.bySize.default_xl.sources.webp} 400w,
-              {$urls.no_picture_image.bySize.product_main.sources.webp} 720w"
+        {if $smarty.capture.coverEmptySrcsetWebp|trim}
+          <source
+            srcset="{$smarty.capture.coverEmptySrcsetWebp|trim nofilter}"
             sizes="(min-width: 992px) 50vw, 100vw"
             type="image/webp"
           >
@@ -161,10 +161,10 @@
 
         <img
           class="img-fluid"
-          srcset="
-            {$urls.no_picture_image.bySize.default_xl.url} 400w,
-            {$urls.no_picture_image.bySize.product_main.url} 720w"
-          sizes="(min-width: 992px) 50vw, 100vw"
+          {if $smarty.capture.coverEmptySrcset|trim}
+            srcset="{$smarty.capture.coverEmptySrcset|trim nofilter}"
+            sizes="(min-width: 992px) 50vw, 100vw"
+          {/if}
           width="{$urls.no_picture_image.bySize.product_main.width}"
           height="{$urls.no_picture_image.bySize.product_main.height}"
           src="{$urls.no_picture_image.bySize.default_xl.url}" 

--- a/templates/catalog/_partials/product-images-modal.tpl
+++ b/templates/catalog/_partials/product-images-modal.tpl
@@ -16,38 +16,35 @@
           data-ps-ref="product-images-modal-carousel"
         >
           <div class="carousel-inner">
+            {assign var='modalSizes' value=['default_md' => '320w', 'product_main' => '720w', 'product_main_2x' => '1440w']}
             {foreach from=$product.images item=image key=key name=productImages}
               <div class="carousel-item{if $image.id_image == $product.default_image.id_image} active{/if}">
                 <picture>
-                  {if isset($image.bySize.default_md.sources.avif)}
-                    <source 
-                      srcset="
-                        {$image.bySize.default_md.sources.avif} 320w,
-                        {$image.bySize.product_main.sources.avif} 720w,
-                        {$image.bySize.product_main_2x.sources.avif} 1440w"
-                      sizes="(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw" 
+                  {capture name='modalSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$image sizes=$modalSizes srcsetVariant='avif'}{/capture}
+                  {capture name='modalSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$image sizes=$modalSizes srcsetVariant='webp'}{/capture}
+                  {capture name='modalSrcset'}{include file='catalog/_partials/srcset.tpl' image=$image sizes=$modalSizes}{/capture}
+                  {if $smarty.capture.modalSrcsetAvif|trim}
+                    <source
+                      srcset="{$smarty.capture.modalSrcsetAvif|trim nofilter}"
+                      sizes="(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw"
                       type="image/avif"
                     >
                   {/if}
 
-                  {if isset($image.bySize.default_md.sources.webp)}
-                    <source 
-                      srcset="
-                        {$image.bySize.default_md.sources.webp} 320w,
-                        {$image.bySize.product_main.sources.webp} 720w,
-                        {$image.bySize.product_main_2x.sources.webp} 1440w"
-                      sizes="(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw" 
+                  {if $smarty.capture.modalSrcsetWebp|trim}
+                    <source
+                      srcset="{$smarty.capture.modalSrcsetWebp|trim nofilter}"
+                      sizes="(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw"
                       type="image/webp"
                     >
                   {/if}
 
                   <img
                     class="img-fluid"
-                    srcset="
-                      {$image.bySize.default_md.url} 320w,
-                      {$image.bySize.product_main.url} 720w,
-                      {$image.bySize.product_main_2x.url} 1440w"
-                    sizes="(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw" 
+                    {if $smarty.capture.modalSrcset|trim}
+                      srcset="{$smarty.capture.modalSrcset|trim nofilter}"
+                      sizes="(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw"
+                    {/if}
                     src="{$image.bySize.product_main.url}" 
                     width="{$image.bySize.product_main_2x.width}"
                     height="{$image.bySize.product_main_2x.height}"

--- a/templates/catalog/_partials/srcset.tpl
+++ b/templates/catalog/_partials/srcset.tpl
@@ -1,0 +1,48 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *}
+{**
+ * Builds a srcset value out of the image sizes that actually exist.
+ *
+ * An image type declared in theme.yml only reaches `bySize` once the shop has a row for it in
+ * ps_image_type. A shop that was upgraded rather than freshly installed can be missing one the theme
+ * asks for, because a theme's image types are applied when the theme is installed and not again
+ * afterwards. Naming the type unconditionally then emitted a candidate with a descriptor and no URL,
+ * such as " 216w" or " 2x", which is not a valid srcset candidate and which the browser resolves as a
+ * relative URL - hence requests for /216w. It also raised "Undefined array key" warnings on every
+ * image.
+ *
+ * Every lookup here goes through isset() rather than a |default modifier, because the modifier runs
+ * after PHP has already evaluated the missing offset and warned.
+ *
+ * The front office runs with $smarty->escape_html = true, so each URL printed below is already
+ * escaped. Callers therefore capture this output and print it with nofilter - escaping it a second
+ * time would turn an & in a URL into &amp;amp;.
+ *
+ * @param array  $image         image array holding a bySize map, e.g. $product.cover
+ * @param array  $sizes         image type name => descriptor, in order. The descriptor is emitted
+ *                              verbatim after the URL, so use '216w' for a width candidate, '2x' for
+ *                              a density one, or '' for the default candidate that carries none.
+ * @param string $srcsetVariant 'url' (default), 'avif' or 'webp'
+ *}
+{assign var='srcsetSeparator' value=''}
+{strip}
+{foreach $sizes as $srcsetType => $srcsetDescriptor}
+  {assign var='srcsetUrl' value=''}
+  {if ($srcsetVariant|default:'url') === 'avif'}
+    {if isset($image.bySize.$srcsetType.sources.avif)}
+      {assign var='srcsetUrl' value=$image.bySize.$srcsetType.sources.avif}
+    {/if}
+  {elseif ($srcsetVariant|default:'url') === 'webp'}
+    {if isset($image.bySize.$srcsetType.sources.webp)}
+      {assign var='srcsetUrl' value=$image.bySize.$srcsetType.sources.webp}
+    {/if}
+  {else}
+    {if isset($image.bySize.$srcsetType.url)}
+      {assign var='srcsetUrl' value=$image.bySize.$srcsetType.url}
+    {/if}
+  {/if}
+  {if $srcsetUrl}{$srcsetSeparator}{$srcsetUrl}{if $srcsetDescriptor} {$srcsetDescriptor}{/if}{assign var='srcsetSeparator' value=', '}{/if}
+{/foreach}
+{/strip}

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -2,6 +2,8 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
+{assign var='emptyImageSizes' value=['default_xs' => '', 'default_md' => '2x']}
+{assign var='imageSizes' value=['default_xs' => '', 'default_md' => '2x']}
 
 <div class="product-line">
   <div class="product-line__image">
@@ -9,29 +11,28 @@
       data-id_customization="{$product.id_customization|intval}">
       {if $product.default_image}
         <picture>
-          {if isset($product.default_image.bySize.default_xs.sources.avif)}
-            <source 
-              srcset="
-                {$product.default_image.bySize.default_xs.sources.avif},
-                {$product.default_image.bySize.default_md.sources.avif} 2x"
+          {capture name='imageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes srcsetVariant='avif'}{/capture}
+          {if $smarty.capture.imageSrcsetAvif|trim}
+            <source
+              srcset="{$smarty.capture.imageSrcsetAvif|trim nofilter}"
               type="image/avif"
             >
           {/if}
 
-          {if isset($product.default_image.bySize.default_xs.sources.webp)}
-            <source 
-              srcset="
-                {$product.default_image.bySize.default_xs.sources.webp},
-                {$product.default_image.bySize.default_md.sources.webp} 2x"
+          {capture name='imageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes srcsetVariant='webp'}{/capture}
+          {if $smarty.capture.imageSrcsetWebp|trim}
+            <source
+              srcset="{$smarty.capture.imageSrcsetWebp|trim nofilter}"
               type="image/webp"
             >
           {/if}
 
           <img
             class="product-line__img img-fluid"
-            srcset="
-              {$product.default_image.bySize.default_xs.url},
-              {$product.default_image.bySize.default_md.url} 2x"
+            {capture name='imageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes}{/capture}
+            {if $smarty.capture.imageSrcset|trim}
+              srcset="{$smarty.capture.imageSrcset|trim nofilter}"
+            {/if}
             width="{$product.default_image.bySize.default_xs.width}"
             height="{$product.default_image.bySize.default_xs.height}"
             loading="lazy"
@@ -41,29 +42,28 @@
         </picture>
       {else}
         <picture>
-          {if isset($urls.no_picture_image.bySize.default_xs.sources.avif)}
-            <source 
-              srcset="
-                {$urls.no_picture_image.bySize.default_xs.sources.avif},
-                {$urls.no_picture_image.bySize.default_md.sources.avif} 2x"
+          {capture name='emptyImageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='avif'}{/capture}
+          {if $smarty.capture.emptyImageSrcsetAvif|trim}
+            <source
+              srcset="{$smarty.capture.emptyImageSrcsetAvif|trim nofilter}"
               type="image/avif"
             >
           {/if}
 
-          {if isset($urls.no_picture_image.bySize.default_xs.sources.webp)}
-            <source 
-              srcset="
-                {$urls.no_picture_image.bySize.default_xs.sources.webp},
-                {$urls.no_picture_image.bySize.default_md.sources.webp} 2x"
+          {capture name='emptyImageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='webp'}{/capture}
+          {if $smarty.capture.emptyImageSrcsetWebp|trim}
+            <source
+              srcset="{$smarty.capture.emptyImageSrcsetWebp|trim nofilter}"
               type="image/webp"
             >
           {/if}
 
           <img
             class="product-line__img img-fluid"
-            srcset="
-              {$urls.no_picture_image.bySize.default_xs.url},
-              {$urls.no_picture_image.bySize.default_md.url} 2x"
+            {capture name='emptyImageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes}{/capture}
+            {if $smarty.capture.emptyImageSrcset|trim}
+              srcset="{$smarty.capture.emptyImageSrcset|trim nofilter}"
+            {/if}
             width="{$urls.no_picture_image.bySize.default_xs.width}"
             height="{$urls.no_picture_image.bySize.default_xs.height}"
             loading="lazy"

--- a/templates/checkout/_partials/cart-summary-product-line.tpl
+++ b/templates/checkout/_partials/cart-summary-product-line.tpl
@@ -2,6 +2,8 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
+{assign var='emptyImageSizes' value=['default_xs' => '', 'default_sm' => '2x']}
+{assign var='imageSizes' value=['default_xs' => '', 'default_sm' => '2x']}
 {$componentName = 'cart-summary-product'}
 
 {block name='cart_summary_product_line'}
@@ -10,29 +12,28 @@
       <a href="{$product.url}" title="{$product.name}">
         {if $product.default_image}
           <picture>
-            {if isset($product.default_image.bySize.default_xs.sources.avif)}
-              <source 
-                srcset="
-                  {$product.default_image.bySize.default_xs.sources.avif},
-                  {$product.default_image.bySize.default_sm.sources.avif} 2x"
+            {capture name='imageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes srcsetVariant='avif'}{/capture}
+            {if $smarty.capture.imageSrcsetAvif|trim}
+              <source
+                srcset="{$smarty.capture.imageSrcsetAvif|trim nofilter}"
                 type="image/avif"
               >
             {/if}
 
-            {if isset($product.default_image.bySize.default_xs.sources.webp)}
-              <source 
-                srcset="
-                  {$product.default_image.bySize.default_xs.sources.webp},
-                  {$product.default_image.bySize.default_sm.sources.webp} 2x"
+            {capture name='imageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes srcsetVariant='webp'}{/capture}
+            {if $smarty.capture.imageSrcsetWebp|trim}
+              <source
+                srcset="{$smarty.capture.imageSrcsetWebp|trim nofilter}"
                 type="image/webp"
               >
             {/if}
 
             <img
               class="{$componentName}__img img-fluid"
-              srcset="
-                {$product.default_image.bySize.default_xs.url},
-                {$product.default_image.bySize.default_sm.url} 2x"
+              {capture name='imageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes}{/capture}
+              {if $smarty.capture.imageSrcset|trim}
+                srcset="{$smarty.capture.imageSrcset|trim nofilter}"
+              {/if}
               width="{$product.default_image.bySize.default_xs.width}"
               height="{$product.default_image.bySize.default_xs.height}"
               loading="lazy"
@@ -42,29 +43,28 @@
           </picture>
         {else}
           <picture>
-            {if isset($urls.no_picture_image.bySize.default_xs.sources.avif)}
-              <source 
-                srcset="
-                  {$urls.no_picture_image.bySize.default_xs.sources.avif},
-                  {$urls.no_picture_image.bySize.default_sm.sources.avif} 2x"
+            {capture name='emptyImageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='avif'}{/capture}
+            {if $smarty.capture.emptyImageSrcsetAvif|trim}
+              <source
+                srcset="{$smarty.capture.emptyImageSrcsetAvif|trim nofilter}"
                 type="image/avif"
               >
             {/if}
 
-            {if isset($urls.no_picture_image.bySize.default_xs.sources.webp)}
-              <source 
-                srcset="
-                  {$urls.no_picture_image.bySize.default_xs.sources.webp},
-                  {$urls.no_picture_image.bySize.default_sm.sources.webp} 2x"
+            {capture name='emptyImageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='webp'}{/capture}
+            {if $smarty.capture.emptyImageSrcsetWebp|trim}
+              <source
+                srcset="{$smarty.capture.emptyImageSrcsetWebp|trim nofilter}"
                 type="image/webp"
               >
             {/if}
 
             <img
               class="{$componentName}__img img-fluid"
-              srcset="
-                {$urls.no_picture_image.bySize.default_xs.url},
-                {$urls.no_picture_image.bySize.default_sm.url} 2x"
+              {capture name='emptyImageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes}{/capture}
+              {if $smarty.capture.emptyImageSrcset|trim}
+                srcset="{$smarty.capture.emptyImageSrcset|trim nofilter}"
+              {/if}
               width="{$urls.no_picture_image.bySize.default_xs.width}"
               height="{$urls.no_picture_image.bySize.default_xs.height}"
               loading="lazy"

--- a/templates/checkout/_partials/order-confirmation-table-multishipment.tpl
+++ b/templates/checkout/_partials/order-confirmation-table-multishipment.tpl
@@ -2,6 +2,8 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
+{assign var='emptyImageSizes' value=['default_xs' => '', 'default_md' => '2x']}
+{assign var='imageSizes' value=['default_xs' => '', 'default_md' => '2x']}
 {$componentName = 'order-confirmation'}
 
 <div class="{$componentName}__table {block name='order-confirmation-classes'}{/block}">
@@ -25,29 +27,28 @@
           <div class="{$componentName}__product-image">
             {if !empty($product.default_image)}
               <picture>
-                {if isset($product.default_image.bySize.default_xs.sources.avif)}
-                  <source 
-                    srcset="
-                      {$product.default_image.bySize.default_xs.sources.avif},
-                      {$product.default_image.bySize.default_md.sources.avif} 2x"
+                {capture name='imageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes srcsetVariant='avif'}{/capture}
+                {if $smarty.capture.imageSrcsetAvif|trim}
+                  <source
+                    srcset="{$smarty.capture.imageSrcsetAvif|trim nofilter}"
                     type="image/avif"
                   >
                 {/if}
   
-                {if isset($product.default_image.bySize.default_xs.sources.webp)}
-                  <source 
-                    srcset="
-                      {$product.default_image.bySize.default_xs.sources.webp},
-                      {$product.default_image.bySize.default_md.sources.webp} 2x"
+                {capture name='imageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes srcsetVariant='webp'}{/capture}
+                {if $smarty.capture.imageSrcsetWebp|trim}
+                  <source
+                    srcset="{$smarty.capture.imageSrcsetWebp|trim nofilter}"
                     type="image/webp"
                   >
                 {/if}
   
                 <img
                   class="{$componentName}__product-img img-fluid"
-                  srcset="
-                    {$product.default_image.bySize.default_xs.url},
-                    {$product.default_image.bySize.default_md.url} 2x"
+                  {capture name='imageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes}{/capture}
+                  {if $smarty.capture.imageSrcset|trim}
+                    srcset="{$smarty.capture.imageSrcset|trim nofilter}"
+                  {/if}
                   src="{$product.default_image.bySize.default_xs.url}"
                   loading="lazy"
                   width="{$product.default_image.bySize.default_xs.width}"
@@ -58,29 +59,28 @@
               </picture>
             {else}
               <picture>
-                {if isset($urls.no_picture_image.bySize.default_xs.sources.avif)}
-                  <source 
-                    srcset="
-                      {$urls.no_picture_image.bySize.default_xs.sources.avif},
-                      {$urls.no_picture_image.bySize.default_md.sources.avif} 2x"
+                {capture name='emptyImageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='avif'}{/capture}
+                {if $smarty.capture.emptyImageSrcsetAvif|trim}
+                  <source
+                    srcset="{$smarty.capture.emptyImageSrcsetAvif|trim nofilter}"
                     type="image/avif"
                   >
                 {/if}
   
-                {if isset($urls.no_picture_image.bySize.default_xs.sources.webp)}
-                  <source 
-                    srcset="
-                      {$urls.no_picture_image.bySize.default_xs.sources.webp},
-                      {$urls.no_picture_image.bySize.default_md.sources.webp} 2x"
+                {capture name='emptyImageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='webp'}{/capture}
+                {if $smarty.capture.emptyImageSrcsetWebp|trim}
+                  <source
+                    srcset="{$smarty.capture.emptyImageSrcsetWebp|trim nofilter}"
                     type="image/webp"
                   >
                 {/if}
   
                 <img
                   class="{$componentName}__product-img img-fluid"
-                  srcset="
-                    {$urls.no_picture_image.bySize.default_xs.url},
-                    {$urls.no_picture_image.bySize.default_md.url} 2x"
+                  {capture name='emptyImageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes}{/capture}
+                  {if $smarty.capture.emptyImageSrcset|trim}
+                    srcset="{$smarty.capture.emptyImageSrcset|trim nofilter}"
+                  {/if}
                   width="{$urls.no_picture_image.bySize.default_xs.width}"
                   height="{$urls.no_picture_image.bySize.default_xs.height}"
                   loading="lazy"
@@ -160,29 +160,28 @@
           <div class="{$componentName}__product-image">
             {if !empty($product.default_image)}
               <picture>
-                {if isset($product.default_image.bySize.default_xs.sources.avif)}
-                  <source 
-                    srcset="
-                      {$product.default_image.bySize.default_xs.sources.avif},
-                      {$product.default_image.bySize.default_md.sources.avif} 2x"
+                {capture name='imageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes srcsetVariant='avif'}{/capture}
+                {if $smarty.capture.imageSrcsetAvif|trim}
+                  <source
+                    srcset="{$smarty.capture.imageSrcsetAvif|trim nofilter}"
                     type="image/avif"
                   >
                 {/if}
 
-                {if isset($product.default_image.bySize.default_xs.sources.webp)}
-                  <source 
-                    srcset="
-                      {$product.default_image.bySize.default_xs.sources.webp},
-                      {$product.default_image.bySize.default_md.sources.webp} 2x"
+                {capture name='imageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes srcsetVariant='webp'}{/capture}
+                {if $smarty.capture.imageSrcsetWebp|trim}
+                  <source
+                    srcset="{$smarty.capture.imageSrcsetWebp|trim nofilter}"
                     type="image/webp"
                   >
                 {/if}
 
                 <img
                   class="{$componentName}__product-img img-fluid"
-                  srcset="
-                    {$product.default_image.bySize.default_xs.url},
-                    {$product.default_image.bySize.default_md.url} 2x"
+                  {capture name='imageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes}{/capture}
+                  {if $smarty.capture.imageSrcset|trim}
+                    srcset="{$smarty.capture.imageSrcset|trim nofilter}"
+                  {/if}
                   src="{$product.default_image.bySize.default_xs.url}"
                   loading="lazy"
                   width="{$product.default_image.bySize.default_xs.width}"
@@ -193,29 +192,28 @@
               </picture>
             {else}
               <picture>
-                {if isset($urls.no_picture_image.bySize.default_xs.sources.avif)}
-                  <source 
-                    srcset="
-                      {$urls.no_picture_image.bySize.default_xs.sources.avif},
-                      {$urls.no_picture_image.bySize.default_md.sources.avif} 2x"
+                {capture name='emptyImageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='avif'}{/capture}
+                {if $smarty.capture.emptyImageSrcsetAvif|trim}
+                  <source
+                    srcset="{$smarty.capture.emptyImageSrcsetAvif|trim nofilter}"
                     type="image/avif"
                   >
                 {/if}
 
-                {if isset($urls.no_picture_image.bySize.default_xs.sources.webp)}
-                  <source 
-                    srcset="
-                      {$urls.no_picture_image.bySize.default_xs.sources.webp},
-                      {$urls.no_picture_image.bySize.default_md.sources.webp} 2x"
+                {capture name='emptyImageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='webp'}{/capture}
+                {if $smarty.capture.emptyImageSrcsetWebp|trim}
+                  <source
+                    srcset="{$smarty.capture.emptyImageSrcsetWebp|trim nofilter}"
                     type="image/webp"
                   >
                 {/if}
 
                 <img
                   class="{$componentName}__product-img img-fluid"
-                  srcset="
-                    {$urls.no_picture_image.bySize.default_xs.url},
-                    {$urls.no_picture_image.bySize.default_md.url} 2x"
+                  {capture name='emptyImageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes}{/capture}
+                  {if $smarty.capture.emptyImageSrcset|trim}
+                    srcset="{$smarty.capture.emptyImageSrcset|trim nofilter}"
+                  {/if}
                   width="{$urls.no_picture_image.bySize.default_xs.width}"
                   height="{$urls.no_picture_image.bySize.default_xs.height}"
                   loading="lazy"

--- a/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/templates/checkout/_partials/order-confirmation-table.tpl
@@ -2,6 +2,8 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
+{assign var='emptyImageSizes' value=['default_xs' => '', 'default_md' => '2x']}
+{assign var='imageSizes' value=['default_xs' => '', 'default_md' => '2x']}
 {$componentName = 'order-confirmation'}
 
 <div class="{$componentName}__table {block name='order-confirmation-classes'}{/block}">
@@ -11,29 +13,28 @@
         <div class="{$componentName}__product-image">
           {if !empty($product.default_image)}
             <picture>
-              {if isset($product.default_image.bySize.default_xs.sources.avif)}
-                <source 
-                  srcset="
-                    {$product.default_image.bySize.default_xs.sources.avif},
-                    {$product.default_image.bySize.default_md.sources.avif} 2x"
+              {capture name='imageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes srcsetVariant='avif'}{/capture}
+              {if $smarty.capture.imageSrcsetAvif|trim}
+                <source
+                  srcset="{$smarty.capture.imageSrcsetAvif|trim nofilter}"
                   type="image/avif"
                 >
               {/if}
 
-              {if isset($product.default_image.bySize.default_xs.sources.webp)}
-                <source 
-                  srcset="
-                    {$product.default_image.bySize.default_xs.sources.webp},
-                    {$product.default_image.bySize.default_md.sources.webp} 2x"
+              {capture name='imageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes srcsetVariant='webp'}{/capture}
+              {if $smarty.capture.imageSrcsetWebp|trim}
+                <source
+                  srcset="{$smarty.capture.imageSrcsetWebp|trim nofilter}"
                   type="image/webp"
                 >
               {/if}
 
               <img
                 class="{$componentName}__product-img img-fluid"
-                srcset="
-                  {$product.default_image.bySize.default_xs.url},
-                  {$product.default_image.bySize.default_md.url} 2x"
+                {capture name='imageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$product.default_image sizes=$imageSizes}{/capture}
+                {if $smarty.capture.imageSrcset|trim}
+                  srcset="{$smarty.capture.imageSrcset|trim nofilter}"
+                {/if}
                 src="{$product.default_image.bySize.default_xs.url}"
                 loading="lazy"
                 width="{$product.default_image.bySize.default_xs.width}"
@@ -44,29 +45,28 @@
             </picture>
           {else}
             <picture>
-              {if isset($urls.no_picture_image.bySize.default_xs.sources.avif)}
-                <source 
-                  srcset="
-                    {$urls.no_picture_image.bySize.default_xs.sources.avif},
-                    {$urls.no_picture_image.bySize.default_md.sources.avif} 2x"
+              {capture name='emptyImageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='avif'}{/capture}
+              {if $smarty.capture.emptyImageSrcsetAvif|trim}
+                <source
+                  srcset="{$smarty.capture.emptyImageSrcsetAvif|trim nofilter}"
                   type="image/avif"
                 >
               {/if}
 
-              {if isset($urls.no_picture_image.bySize.default_xs.sources.webp)}
-                <source 
-                  srcset="
-                    {$urls.no_picture_image.bySize.default_xs.sources.webp},
-                    {$urls.no_picture_image.bySize.default_md.sources.webp} 2x"
+              {capture name='emptyImageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='webp'}{/capture}
+              {if $smarty.capture.emptyImageSrcsetWebp|trim}
+                <source
+                  srcset="{$smarty.capture.emptyImageSrcsetWebp|trim nofilter}"
                   type="image/webp"
                 >
               {/if}
 
               <img
                 class="{$componentName}__product-img img-fluid"
-                srcset="
-                  {$urls.no_picture_image.bySize.default_xs.url},
-                  {$urls.no_picture_image.bySize.default_md.url} 2x"
+                {capture name='emptyImageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes}{/capture}
+                {if $smarty.capture.emptyImageSrcset|trim}
+                  srcset="{$smarty.capture.emptyImageSrcset|trim nofilter}"
+                {/if}
                 src="{$urls.no_picture_image.bySize.default_xs.url}"
                 loading="lazy"
                 width="{$urls.no_picture_image.bySize.default_xs.width}"

--- a/templates/customer/_partials/order-detail-no-return.tpl
+++ b/templates/customer/_partials/order-detail-no-return.tpl
@@ -2,6 +2,9 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
+{assign var='imageSizes' value=['default_xs' => '', 'default_md' => '2x']}
+{assign var='emptyImageSizes' value=['default_xs' => '', 'default_md' => '2x']}
+{assign var='imageSizes' value=['default_xs' => '', 'default_md' => '2x']}
 {block name='order_products_table'}
   <div class="grid-table grid-table--collapse mb-0" role="table" aria-label="{l s='Products details' d='Shop.Theme.Customeraccount'}">
     <div class="grid-table__inner grid-table__inner--4" role="rowgroup">
@@ -20,29 +23,28 @@
                 <a href="{$link->getProductLink($product.id_product)}">
                   {if $product.cover}
                     <picture>
-                      {if isset($product.cover.bySize.default_xs.sources.avif)}
+                      {capture name='imageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$imageSizes srcsetVariant='avif'}{/capture}
+                      {if $smarty.capture.imageSrcsetAvif|trim}
                         <source
-                          srcset="
-                            {$product.cover.bySize.default_xs.sources.avif},
-                            {$product.cover.bySize.default_md.sources.avif} 2x",
+                          srcset="{$smarty.capture.imageSrcsetAvif|trim nofilter}"
                           type="image/avif"
                         >
                       {/if}
 
-                      {if isset($product.cover.bySize.default_xs.sources.webp)}
+                      {capture name='imageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$imageSizes srcsetVariant='webp'}{/capture}
+                      {if $smarty.capture.imageSrcsetWebp|trim}
                         <source
-                          srcset="
-                            {$product.cover.bySize.default_xs.sources.webp},
-                            {$product.cover.bySize.default_md.sources.webp} 2x"
+                          srcset="{$smarty.capture.imageSrcsetWebp|trim nofilter}"
                           type="image/webp"
                         >
                       {/if}
 
                       <img
                         class="order-product__img img-fluid"
-                        srcset="
-                          {$product.cover.bySize.default_xs.url},
-                          {$product.cover.bySize.default_md.url} 2x"
+                        {capture name='imageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$imageSizes}{/capture}
+                        {if $smarty.capture.imageSrcset|trim}
+                          srcset="{$smarty.capture.imageSrcset|trim nofilter}"
+                        {/if}
                         width="{$product.cover.bySize.default_xs.width}"
                         height="{$product.cover.bySize.default_xs.height}"
                         loading="lazy"
@@ -52,29 +54,28 @@
                     </picture>
                   {else}
                     <picture>
-                      {if isset($urls.no_picture_image.bySize.default_xs.sources.avif)}
+                      {capture name='emptyImageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='avif'}{/capture}
+                      {if $smarty.capture.emptyImageSrcsetAvif|trim}
                         <source
-                          srcset="
-                            {$urls.no_picture_image.bySize.default_xs.sources.avif},
-                            {$urls.no_picture_image.bySize.default_md.sources.avif} 2x"
+                          srcset="{$smarty.capture.emptyImageSrcsetAvif|trim nofilter}"
                           type="image/avif"
                         >
                       {/if}
 
-                      {if isset($urls.no_picture_image.bySize.default_xs.sources.webp)}
+                      {capture name='emptyImageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='webp'}{/capture}
+                      {if $smarty.capture.emptyImageSrcsetWebp|trim}
                         <source
-                          srcset="
-                            {$urls.no_picture_image.bySize.default_xs.sources.webp},
-                            {$urls.no_picture_image.bySize.default_md.sources.webp} 2x"
+                          srcset="{$smarty.capture.emptyImageSrcsetWebp|trim nofilter}"
                           type="image/webp"
                         >
                       {/if}
 
                       <img
                         class="order-product__img img-fluid"
-                        srcset="
-                          {$urls.no_picture_image.bySize.default_xs.url},
-                          {$urls.no_picture_image.bySize.default_md.url} 2x"
+                        {capture name='emptyImageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes}{/capture}
+                        {if $smarty.capture.emptyImageSrcset|trim}
+                          srcset="{$smarty.capture.emptyImageSrcset|trim nofilter}"
+                        {/if}
                         width="{$urls.no_picture_image.bySize.default_xs.width}"
                         height="{$urls.no_picture_image.bySize.default_xs.height}"
                         loading="lazy"

--- a/templates/customer/_partials/order-detail-product-line-no-return.tpl
+++ b/templates/customer/_partials/order-detail-product-line-no-return.tpl
@@ -2,6 +2,9 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
+{assign var='imageSizes' value=['default_xs' => '', 'default_md' => '2x']}
+{assign var='emptyImageSizes' value=['default_xs' => '', 'default_md' => '2x']}
+{assign var='imageSizes' value=['default_xs' => '', 'default_md' => '2x']}
 {block name='order_products_table_line_no_return'}
   <div class="grid-table__row {if isset($is_last_product) && $is_last_product}rounded-bottom-0{/if}" role="row">
     <span class="grid-table__cell order-product" role="cell" data-ps-label="{l s='Product' d='Shop.Theme.Catalog'}">
@@ -10,29 +13,28 @@
           <a href="{$link->getProductLink($product.id_product)}">
             {if isset($product.cover) && $product.cover}
               <picture>
-                {if isset($product.cover.bySize.default_xs.sources.avif)}
+                {capture name='imageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$imageSizes srcsetVariant='avif'}{/capture}
+                {if $smarty.capture.imageSrcsetAvif|trim}
                   <source
-                    srcset="
-                      {$product.cover.bySize.default_xs.sources.avif},
-                      {$product.cover.bySize.default_md.sources.avif} 2x",
+                    srcset="{$smarty.capture.imageSrcsetAvif|trim nofilter}"
                     type="image/avif"
                   >
                 {/if}
 
-                {if isset($product.cover.bySize.default_xs.sources.webp)}
+                {capture name='imageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$imageSizes srcsetVariant='webp'}{/capture}
+                {if $smarty.capture.imageSrcsetWebp|trim}
                   <source
-                    srcset="
-                      {$product.cover.bySize.default_xs.sources.webp},
-                      {$product.cover.bySize.default_md.sources.webp} 2x"
+                    srcset="{$smarty.capture.imageSrcsetWebp|trim nofilter}"
                     type="image/webp"
                   >
                 {/if}
 
                 <img
                   class="order-product__img img-fluid"
-                  srcset="
-                    {$product.cover.bySize.default_xs.url},
-                    {$product.cover.bySize.default_md.url} 2x"
+                  {capture name='imageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$imageSizes}{/capture}
+                  {if $smarty.capture.imageSrcset|trim}
+                    srcset="{$smarty.capture.imageSrcset|trim nofilter}"
+                  {/if}
                   width="{$product.cover.bySize.default_xs.width}"
                   height="{$product.cover.bySize.default_xs.height}"
                   loading="lazy"
@@ -42,29 +44,28 @@
               </picture>
             {else}
               <picture>
-                {if isset($urls.no_picture_image.bySize.default_xs.sources.avif)}
+                {capture name='emptyImageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='avif'}{/capture}
+                {if $smarty.capture.emptyImageSrcsetAvif|trim}
                   <source
-                    srcset="
-                      {$urls.no_picture_image.bySize.default_xs.sources.avif},
-                      {$urls.no_picture_image.bySize.default_md.sources.avif} 2x"
+                    srcset="{$smarty.capture.emptyImageSrcsetAvif|trim nofilter}"
                     type="image/avif"
                   >
                 {/if}
 
-                {if isset($urls.no_picture_image.bySize.default_xs.sources.webp)}
+                {capture name='emptyImageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='webp'}{/capture}
+                {if $smarty.capture.emptyImageSrcsetWebp|trim}
                   <source
-                    srcset="
-                      {$urls.no_picture_image.bySize.default_xs.sources.webp},
-                      {$urls.no_picture_image.bySize.default_md.sources.webp} 2x"
+                    srcset="{$smarty.capture.emptyImageSrcsetWebp|trim nofilter}"
                     type="image/webp"
                   >
                 {/if}
 
                 <img
                   class="order-product__img img-fluid"
-                  srcset="
-                    {$urls.no_picture_image.bySize.default_xs.url},
-                    {$urls.no_picture_image.bySize.default_md.url} 2x"
+                  {capture name='emptyImageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes}{/capture}
+                  {if $smarty.capture.emptyImageSrcset|trim}
+                    srcset="{$smarty.capture.emptyImageSrcset|trim nofilter}"
+                  {/if}
                   width="{$urls.no_picture_image.bySize.default_xs.width}"
                   height="{$urls.no_picture_image.bySize.default_xs.height}"
                   loading="lazy"

--- a/templates/customer/_partials/order-detail-product-line-return.tpl
+++ b/templates/customer/_partials/order-detail-product-line-return.tpl
@@ -2,6 +2,9 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
+{assign var='imageSizes' value=['default_xs' => '', 'default_md' => '2x']}
+{assign var='emptyImageSizes' value=['default_xs' => '', 'default_md' => '2x']}
+{assign var='imageSizes' value=['default_xs' => '', 'default_md' => '2x']}
 {block name='order_products_table_line_return'}
   <div class="grid-table__row {if isset($is_last_product) && $is_last_product}rounded-bottom-0{/if}" role="row">
     <span class="grid-table__cell" role="cell" data-ps-label="{l s='Select' d='Shop.Theme.Catalog'}">
@@ -23,29 +26,28 @@
           <a href="{$link->getProductLink($product.id_product)}">
             {if $product.cover}
               <picture>
-                {if isset($product.cover.bySize.default_xs.sources.avif)}
+                {capture name='imageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$imageSizes srcsetVariant='avif'}{/capture}
+                {if $smarty.capture.imageSrcsetAvif|trim}
                   <source
-                    srcset="
-                      {$product.cover.bySize.default_xs.sources.avif},
-                      {$product.cover.bySize.default_md.sources.avif} 2x",
+                    srcset="{$smarty.capture.imageSrcsetAvif|trim nofilter}"
                     type="image/avif"
                   >
                 {/if}
 
-                {if isset($product.cover.bySize.default_xs.sources.webp)}
+                {capture name='imageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$imageSizes srcsetVariant='webp'}{/capture}
+                {if $smarty.capture.imageSrcsetWebp|trim}
                   <source
-                    srcset="
-                      {$product.cover.bySize.default_xs.sources.webp},
-                      {$product.cover.bySize.default_md.sources.webp} 2x"
+                    srcset="{$smarty.capture.imageSrcsetWebp|trim nofilter}"
                     type="image/webp"
                   >
                 {/if}
 
                 <img
                   class="order-product__img img-fluid"
-                  srcset="
-                    {$product.cover.bySize.default_xs.url},
-                    {$product.cover.bySize.default_md.url} 2x"
+                  {capture name='imageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$imageSizes}{/capture}
+                  {if $smarty.capture.imageSrcset|trim}
+                    srcset="{$smarty.capture.imageSrcset|trim nofilter}"
+                  {/if}
                   width="{$product.cover.bySize.default_xs.width}"
                   height="{$product.cover.bySize.default_xs.height}"
                   loading="lazy"
@@ -55,29 +57,28 @@
               </picture>
             {else}
               <picture>
-                {if isset($urls.no_picture_image.bySize.default_xs.sources.avif)}
+                {capture name='emptyImageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='avif'}{/capture}
+                {if $smarty.capture.emptyImageSrcsetAvif|trim}
                   <source
-                    srcset="
-                      {$urls.no_picture_image.bySize.default_xs.sources.avif},
-                      {$urls.no_picture_image.bySize.default_md.sources.avif} 2x"
+                    srcset="{$smarty.capture.emptyImageSrcsetAvif|trim nofilter}"
                     type="image/avif"
                   >
                 {/if}
 
-                {if isset($urls.no_picture_image.bySize.default_xs.sources.webp)}
+                {capture name='emptyImageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='webp'}{/capture}
+                {if $smarty.capture.emptyImageSrcsetWebp|trim}
                   <source
-                    srcset="
-                      {$urls.no_picture_image.bySize.default_xs.sources.webp},
-                      {$urls.no_picture_image.bySize.default_md.sources.webp} 2x"
+                    srcset="{$smarty.capture.emptyImageSrcsetWebp|trim nofilter}"
                     type="image/webp"
                   >
                 {/if}
 
                 <img
                   class="order-product__img img-fluid"
-                  srcset="
-                    {$urls.no_picture_image.bySize.default_xs.url},
-                    {$urls.no_picture_image.bySize.default_md.url} 2x"
+                  {capture name='emptyImageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes}{/capture}
+                  {if $smarty.capture.emptyImageSrcset|trim}
+                    srcset="{$smarty.capture.emptyImageSrcset|trim nofilter}"
+                  {/if}
                   width="{$urls.no_picture_image.bySize.default_xs.width}"
                   height="{$urls.no_picture_image.bySize.default_xs.height}"
                   loading="lazy"

--- a/templates/customer/_partials/order-detail-return.tpl
+++ b/templates/customer/_partials/order-detail-return.tpl
@@ -2,6 +2,9 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
+{assign var='imageSizes' value=['default_xs' => '', 'default_md' => '2x']}
+{assign var='emptyImageSizes' value=['default_xs' => '', 'default_md' => '2x']}
+{assign var='imageSizes' value=['default_xs' => '', 'default_md' => '2x']}
 {block name='order_products_table'}
   <form id="order-return-form" class="js-order-return-form" action="{$urls.pages.order_follow}" method="post" data-ps-action="form-validation">
     <div class="grid-table grid-table--collapse mb-0" role="table" data-ps-ref="order-return-products-table" aria-label="{l s='Products details' d='Shop.Theme.Catalog'}">
@@ -38,29 +41,28 @@
                   <a href="{$link->getProductLink($product.id_product)}">
                     {if $product.cover}
                       <picture>
-                        {if isset($product.cover.bySize.default_xs.sources.avif)}
+                        {capture name='imageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$imageSizes srcsetVariant='avif'}{/capture}
+                        {if $smarty.capture.imageSrcsetAvif|trim}
                           <source
-                            srcset="
-                              {$product.cover.bySize.default_xs.sources.avif},
-                              {$product.cover.bySize.default_md.sources.avif} 2x",
+                            srcset="{$smarty.capture.imageSrcsetAvif|trim nofilter}"
                             type="image/avif"
                           >
                         {/if}
 
-                        {if isset($product.cover.bySize.default_xs.sources.webp)}
+                        {capture name='imageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$imageSizes srcsetVariant='webp'}{/capture}
+                        {if $smarty.capture.imageSrcsetWebp|trim}
                           <source
-                            srcset="
-                              {$product.cover.bySize.default_xs.sources.webp},
-                              {$product.cover.bySize.default_md.sources.webp} 2x"
+                            srcset="{$smarty.capture.imageSrcsetWebp|trim nofilter}"
                             type="image/webp"
                           >
                         {/if}
 
                         <img
                           class="order-product__img img-fluid"
-                          srcset="
-                            {$product.cover.bySize.default_xs.url},
-                            {$product.cover.bySize.default_md.url} 2x"
+                          {capture name='imageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$product.cover sizes=$imageSizes}{/capture}
+                          {if $smarty.capture.imageSrcset|trim}
+                            srcset="{$smarty.capture.imageSrcset|trim nofilter}"
+                          {/if}
                           width="{$product.cover.bySize.default_xs.width}"
                           height="{$product.cover.bySize.default_xs.height}"
                           loading="lazy"
@@ -70,29 +72,28 @@
                       </picture>
                     {else}
                       <picture>
-                        {if isset($urls.no_picture_image.bySize.default_xs.sources.avif)}
+                        {capture name='emptyImageSrcsetAvif'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='avif'}{/capture}
+                        {if $smarty.capture.emptyImageSrcsetAvif|trim}
                           <source
-                            srcset="
-                              {$urls.no_picture_image.bySize.default_xs.sources.avif},
-                              {$urls.no_picture_image.bySize.default_md.sources.avif} 2x"
+                            srcset="{$smarty.capture.emptyImageSrcsetAvif|trim nofilter}"
                             type="image/avif"
                           >
                         {/if}
 
-                        {if isset($urls.no_picture_image.bySize.default_xs.sources.webp)}
+                        {capture name='emptyImageSrcsetWebp'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes srcsetVariant='webp'}{/capture}
+                        {if $smarty.capture.emptyImageSrcsetWebp|trim}
                           <source
-                            srcset="
-                              {$urls.no_picture_image.bySize.default_xs.sources.webp},
-                              {$urls.no_picture_image.bySize.default_md.sources.webp} 2x"
+                            srcset="{$smarty.capture.emptyImageSrcsetWebp|trim nofilter}"
                             type="image/webp"
                           >
                         {/if}
 
                         <img
                           class="order-product__img img-fluid"
-                          srcset="
-                            {$urls.no_picture_image.bySize.default_xs.url},
-                            {$urls.no_picture_image.bySize.default_md.url} 2x"
+                          {capture name='emptyImageSrcset'}{include file='catalog/_partials/srcset.tpl' image=$urls.no_picture_image sizes=$emptyImageSizes}{/capture}
+                          {if $smarty.capture.emptyImageSrcset|trim}
+                            srcset="{$smarty.capture.emptyImageSrcset|trim nofilter}"
+                          {/if}
                           width="{$urls.no_picture_image.bySize.default_xs.width}"
                           height="{$urls.no_picture_image.bySize.default_xs.height}"
                           loading="lazy"


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Every srcset in the theme named its image types unconditionally, so a shop missing one emitted a candidate with a descriptor and no URL - `" 216w"` or `" 2x"`. That is not a valid srcset candidate, the browser resolves the bare descriptor as a relative URL and requests `/216w`, and the product listing loses its images. It also raised an `Undefined array key` warning per candidate - **22 on a single category page** in the reported configuration. Each srcset is now built from the sizes that actually exist, through a shared `catalog/_partials/srcset.tpl`, and the attribute is dropped when none is. Fixes PrestaShop/PrestaShop#41511.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#41511
| Sponsor company   |
| How to test?      | On a shop whose image types do not include everything `config/theme.yml` declares - an upgrade from 9.0.x reproduces it, or rename `default_sm` and `default_lg` in `ps_image_type` - open any page with product miniatures. Before: `srcset=" 216w, .../default_md/....jpg 261w, 336w"`, a 404 on `/216w`, no images in the listing, and `Undefined array key` warnings in debug mode. After: `srcset=".../default_md/....jpg 261w"` - a valid single candidate, images render, no warnings. Restore the image types and the full three-candidate srcset comes back unchanged.

### Why the shop can be missing a type the theme names

An image type declared in `theme.yml` only reaches `bySize` once the shop has a row for it in
`ps_image_type`. A theme's image types are applied when the theme is installed, not again on every
upgrade, so a shop upgraded from 9.0.x keeps the types it had. In the reported case the shop carried
`default_xs, default_s, default_m, default_md, default_xl` while Hummingbird 2.0 asks for `default_sm`,
`default_md` and `default_lg` - `default_md` was the only one of the three present, which is exactly why
the reporter saw listings break while product pages were fine: those use `default_xl` and `product_main`,
which the shop did have.

**The data half of this is not a theme fix.** Making an upgrade re-apply the enabled theme's declared
image types belongs in the core `ThemeManager` or in the update process, per the theme's own boundary
rule in `CONTEXT.md`. This PR is the presentation half: the theme should not emit invalid markup when the
shop does not match what `theme.yml` declares.

### The whole class, not just the reported page

The reported symptom was the product miniature, but every srcset in the theme had the same shape. Two
descriptor forms are in use and both were affected:

- width descriptors (`216w`) in the catalog templates;
- density descriptors (`2x`) in the cart, order-confirmation, order-detail and pack lines.

The partial takes the descriptor verbatim, so one implementation covers both. After the change no
template names an image type inside a srcset - verified by grep across `templates/`.

Two details worth calling out:

- lookups go through `isset()` rather than a `|default` modifier, because the modifier only runs after
  PHP has already evaluated the missing offset and warned;
- the front office runs with `$smarty->escape_html = true`, so the partial's output is already escaped
  and callers print the capture with `nofilter`. Escaping again would turn an `&` in a URL into
  `&amp;amp;`.

### Also fixed, found while doing this

The avif `<source>` in the four order-detail templates closed its srcset with `2x",` - a stray comma that
landed in the attribute list as `<source srcset="..." , type="image/avif">`. Removed.

### Deliberately out of scope

`width`, `height` and `src` attributes still name a fixed image type, so on a shop missing that type they
still emit a warning and an empty value. That is a different defect - missing intrinsic dimensions rather
than an invalid srcset candidate - and the right fix there is to fall back to an available size, not to
omit the attribute, since omitting `width`/`height` reintroduces layout shift. It is left untouched rather
than half-fixed; the srcset class in this PR is complete.

### Verification

- **Reproduced first**, by renaming `default_sm`/`default_lg` in `ps_image_type` on a 9.2 shop:
  `srcset=" 216w, .../default_md/....jpg 261w, 336w"` and **22** `Undefined array key` warnings on one
  category page. Restoring the types restored the correct output, so the trigger is confirmed.
- **After:** with those types missing, `srcset=".../default_md/....jpg 261w"`, 0 malformed candidates,
  0 warnings. With all types present, the three-candidate srcset is byte-identical in content to before.
- Also exercised with `default_xs` missing, which is the density-form equivalent: the cart line degrades
  to a single `... 2x` candidate, still valid, 0 malformed.
- Pages actually rendered: home (miniatures), a product page (cover + thumbnail strip + modal) and the
  cart (detailed product line, density form). All 13 changed templates additionally pass a Smarty
  compile check (`compileTemplateSource()`), since the order-confirmation and order-detail templates were
  not reachable by rendering in this environment.

### Notes for publishing

- The reporter's theme is Themevolty, a third-party theme based on Hummingbird, so their own copy of
  these templates needs the same change; the fix here only covers the bundled theme.
- Mention the core/upgrade half explicitly so it is not assumed this closes the whole problem: a shop
  still ends up without the responsive variants until its image types match `theme.yml`.
