### PR TITLE
Render the order product line hook on every order product line

### DIFF
--- a/templates/customer/_partials/order-detail-no-return.tpl
+++ b/templates/customer/_partials/order-detail-no-return.tpl
@@ -116,6 +116,7 @@
                     </span>
                   {/foreach}
                 {/if}
+                {hook h='displayOrderDetailProductLine' id_order=$product.id_order id_order_detail=$product.id_order_detail id_product=$product.id_product}
               </span>
             </span>
           </span>

--- a/templates/customer/_partials/order-detail-product-line-no-return.tpl
+++ b/templates/customer/_partials/order-detail-product-line-no-return.tpl
@@ -118,6 +118,7 @@
               </span>
             {/foreach}
           {/if}
+          {hook h='displayOrderDetailProductLine' id_order=$product.id_order id_order_detail=$product.id_order_detail id_product=$product.id_product}
         </span>
       </span>
     </span>

--- a/templates/customer/_partials/order-detail-product-line-return.tpl
+++ b/templates/customer/_partials/order-detail-product-line-return.tpl
@@ -125,6 +125,7 @@
               </div>
             {/foreach}
           {/if}
+          {hook h='displayOrderDetailProductLine' id_order=$product.id_order id_order_detail=$product.id_order_detail id_product=$product.id_product}
         </span>
       </span>
     </span>

--- a/templates/customer/_partials/order-detail-return.tpl
+++ b/templates/customer/_partials/order-detail-return.tpl
@@ -128,6 +128,7 @@
                       </div>
                     {/foreach}
                   {/if}
+                  {hook h='displayOrderDetailProductLine' id_order=$product.id_order id_order_detail=$product.id_order_detail id_product=$product.id_product}
                 </span>
               </span>
             </span>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 2.x
| Description?      | Call the new `displayOrderDetailProductLine` hook on every product line of the order detail page, so a module can show information next to one product of an order.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23245
| Related PRs       | PrestaShop/PrestaShop#TBD declares the hook. PrestaShop/classic-theme#TBD does the same for the other shipped theme.
| Sponsor company   | --

### Why

The order detail page has one hook, `displayOrderDetail`, and it is executed once for the whole page
with the order as its only parameter. Nothing receives a single product line, so a module cannot show
information next to one product.

### What it does

One `{hook h='displayOrderDetailProductLine' ...}` at the end of `order-product__content`, where the
reference, the virtual product note and the carrier note already are. It passes identifiers only -
`$product.id_order`, `$product.id_order_detail`, `$product.id_product` - all three of which the
presented product row already carries (`Order::getProductsDetail()` selects `od.*`), so the partials
stay self contained and nothing new has to be threaded through the includes.

**Four call sites, because the theme renders a product line from four places.** The two line
partials, `order-detail-product-line-no-return.tpl` and `order-detail-product-line-return.tpl`, are
used only by the two multishipment templates; `order-detail-no-return.tpl` and
`order-detail-return.tpl` hold the row inline instead. Adding the call to the partials alone would
have given a hook that fires only on a multishipment order.

Each line still renders from exactly one of those four sites, so a listener fires **once** per order
line here. On classic it fires twice, because that theme renders every line in both a `hidden-sm-down`
and a `hidden-md-up` block. A listener therefore has to be idempotent and must not emit fixed `id` or
`name` attributes - stated on the classic branch as well, and worth carrying into the devdocs entry.

### How to test

Register a module on `displayOrderDetailProductLine` that returns some markup from
`hookDisplayOrderDetailProductLine($params)`, then open an order under Your account > Order history >
Details. The markup appears under the product name of every line and `$params` carries the three
identifiers of that line. It should appear whether or not the order is returnable and whether or not
it has shipments.

### Measured on a running 9.2 shop

A probe module returning `<!--PROBE-FO id_order=... id_order_detail=... id_product=...-->` was
installed and registered on the hook, this theme's four templates were deployed with a per-site
marker, and the order detail page was fetched over HTTP as a logged in customer owning a two product
order:

```
site                  fired   probe output
inline-no-return       2      id_order=1 id_order_detail=1 id_product=1 / ...=2 ...=2
inline-return          2      same
partial-no-return      2      same
partial-return         2      same
```

`inline-no-return` is the one the real selection reaches on that order
(`$order.details.is_returnable` false, no shipments). The other three were forced by temporarily
including them from `order-detail.tpl`, which proves each template compiles and emits the hook with
the right identifiers, but not that the selection reaches them - that needs a returnable order and a
shipment fixture.

Everything was put back afterwards: the five deployed templates restored and checked by md5, the
probe module uninstalled and deleted with its hook rows, the probe customer and its
`ps_customer_group` / `ps_customer_session` / `ps_guest` / `ps_cart` / `ps_psgdpr_log` rows deleted,
`ps_orders.id_customer` for the test order set back, and `PS_ORDER_RETURN` set back to 0.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- **Rebase note.** My own open #1103 edits all four of these files, and tblivet's #1096 edits
  `order-detail-return.tpl`. Both were hunk-checked: #1103 touches the licence header and the two
  `<picture>` blocks (hunks ending around lines 71 to 100), #1096 touches line 3, and the four lines
  added here are at 116, 118, 125 and 128. Nothing overlaps, so either order merges.
- **Two findings for a separate PR, deliberately not fixed here.** The inline row in
  `order-detail-no-return.tpl` is a copy of `order-detail-product-line-no-return.tpl`: 121 duplicated
  lines, and the copy has drifted - the partial renders the "Virtual product(s): No delivery service"
  note and the inline row does not, so that note appears on a multishipment order's detail page and
  not on a single shipment one. Replacing the inline rows with an `{include}` of the partials would
  remove the duplication, fix the drift, and reduce this hook to two call sites - but it is a 121 line
  structural change to files that #1103 and #1096 are both editing, so it does not belong in the same
  PR as a one line hook call.
