### PR TITLE
Show the stock label in product listings

### DIFF
--- a/src/scss/prestashop/components/product/_product-miniature.scss
+++ b/src/scss/prestashop/components/product/_product-miniature.scss
@@ -98,6 +98,18 @@ $product-miniature-container-query-width: 13.5rem;
     }
   }
 
+  &__availability-status {
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+    font-size: 0.875rem;
+    line-height: 1.2;
+  }
+
+  &__availability-icon {
+    font-size: 1rem;
+  }
+
   &__prices {
     display: flex;
     flex-wrap: wrap;

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -13,7 +13,10 @@
     <div class="{$componentName}__inner">
       {block name='product_miniature_top'}
         <div class="{$componentName}__top">
-          {include file='catalog/_partials/product-flags.tpl'}
+          {** The stock label below says the same thing, in the same words, so only one of them shows *}
+          {include file='catalog/_partials/product-flags.tpl'
+            hideOutOfStockFlag=!empty($product.availability_message)
+          }
 
           {include file='catalog/_partials/miniatures/product-image.tpl'}
 
@@ -68,6 +71,13 @@
                 {/block}
               </div>
             {/if}
+
+            {block name='product_availability'}
+              {include file='catalog/_partials/product-availability-status.tpl'
+                product=$product
+                componentName=$componentName
+              }
+            {/block}
 
             {block name='product_reviews'}
               {hook h='displayProductListReviews' product=$product}

--- a/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/templates/catalog/_partials/product-add-to-cart.tpl
@@ -12,36 +12,11 @@
           hidden
         {/if}
       >
-        {if !empty($product.availability_message)}
-          {** First, we prepare the icons and colors we want to use *}
-          {if $product.availability == 'in_stock'}
-            {assign 'availability_icon' 'E5CA'}
-            {assign 'availability_class' 'text-success'}
-          {elseif $product.availability == 'available'}
-            {assign 'availability_icon' 'E002'}
-            {assign 'availability_class' 'text-warning'}
-          {elseif $product.availability == 'last_remaining_items'}
-            {assign 'availability_icon' 'E002'}
-            {assign 'availability_class' 'text-warning'}
-          {else}
-            {assign 'availability_icon' 'E14B'}
-            {assign 'availability_class' 'text-danger'}
-          {/if}
-
-          {** And render the availability message with icon *}
-          <div class="product__availability-status {$availability_class}" aria-live="off" data-ps-ref="product-availability">
-            <i class="product__availability-icon material-icons rtl-no-flip" aria-hidden="true">&#x{$availability_icon};</i>
-
-            <div class="product__availability-messages">
-              <span class="visually-hidden">{l s='Product availability:' d='Shop.Theme.Global'}</span>
-              <span>{$product.availability_message}</span>
-
-              {if !empty($product.availability_submessage)}
-                <small class="d-block">{$product.availability_submessage}</small>
-              {/if}
-            </div>
-          </div>
-        {/if}
+        {include file='catalog/_partials/product-availability-status.tpl'
+          product=$product
+          componentName='product'
+          dataPsRef='product-availability'
+        }
 
         {block name='product_delivery_times'}
           {if !empty($product.delivery_information)}

--- a/templates/catalog/_partials/product-availability-status.tpl
+++ b/templates/catalog/_partials/product-availability-status.tpl
@@ -1,0 +1,37 @@
+{**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ *
+ * Stock label of a product, with the icon and the colour of its availability state.
+ * The caller passes its own BEM block as $componentName, and optionally a $dataPsRef.
+ *}
+{if !empty($product.availability_message)}
+  {** First, we prepare the icons and colors we want to use *}
+  {if $product.availability == 'in_stock'}
+    {assign 'availability_icon' 'E5CA'}
+    {assign 'availability_class' 'text-success'}
+  {elseif $product.availability == 'available'}
+    {assign 'availability_icon' 'E002'}
+    {assign 'availability_class' 'text-warning'}
+  {elseif $product.availability == 'last_remaining_items'}
+    {assign 'availability_icon' 'E002'}
+    {assign 'availability_class' 'text-warning'}
+  {else}
+    {assign 'availability_icon' 'E14B'}
+    {assign 'availability_class' 'text-danger'}
+  {/if}
+
+  {** And render the availability message with icon *}
+  <div class="{$componentName}__availability-status {$availability_class}" aria-live="off"{if !empty($dataPsRef)} data-ps-ref="{$dataPsRef}"{/if}>
+    <i class="{$componentName}__availability-icon material-icons rtl-no-flip" aria-hidden="true">&#x{$availability_icon};</i>
+
+    <div class="{$componentName}__availability-messages">
+      <span class="visually-hidden">{l s='Product availability:' d='Shop.Theme.Global'}</span>
+      <span>{$product.availability_message}</span>
+
+      {if !empty($product.availability_submessage)}
+        <small class="d-block">{$product.availability_submessage}</small>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/templates/catalog/_partials/product-flags.tpl
+++ b/templates/catalog/_partials/product-flags.tpl
@@ -2,10 +2,21 @@
  * For the full copyright and license information, please view the
  * LICENSE.md file that was distributed with this source code.
  *}
-{if !empty($product.flags)}
+{**
+ * $hideOutOfStockFlag lets a caller that already renders the stock label drop the flag saying the same
+ * thing. Filtering first so an empty list renders no list at all.
+ *}
+{assign 'visibleFlags' []}
+{foreach from=$product.flags|default:[] item=flag}
+  {if !($hideOutOfStockFlag|default:false) || $flag.type != 'out_of_stock'}
+    {append 'visibleFlags' $flag}
+  {/if}
+{/foreach}
+
+{if !empty($visibleFlags)}
   {block name='product_flags'}
     <ul class="product-flags js-product-flags">
-      {foreach from=$product.flags item=flag}
+      {foreach from=$visibleFlags item=flag}
         <li class="badge {$flag.type}">{$flag.label nofilter}</li>
       {/foreach}
     </ul>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The product listing shows no stock information, so a customer has to open every product to learn whether it can be shipped now. The miniature now renders the same stock label the product page does.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23659
| Sponsor company   | --
| How to test?      | See below.

### Why

The listing has carried the data all along. `ProductListingPresenter` extends `ProductPresenter`, and
`availability`, `availability_message`, `availability_submessage` and `show_availability` are all in
`ProductLazyArray::getProductAttributeWhitelist()`, so they reach the miniature. Measured on a 9.2 shop
by rendering a probe inside the miniature on a category page:

```
show_availability=[1] availability=[in_stock] quantity=[300]
```

Only the template never read them.

### What it does

The mapping from an availability state to its icon and colour was inline in
`product-add-to-cart.tpl`. It moves to `catalog/_partials/product-availability-status.tpl`, which both
the product page and the miniature include, so the two surfaces cannot drift apart. The partial takes
the caller's BEM block through `$componentName`, the convention the theme already uses for shared
partials, so `componentName='product'` reproduces the product page's existing classes exactly and the
miniature gets `product-miniature__availability-*` for free.

States follow the specs on the issue: in stock green, out of stock with backorders allowed orange, out
of stock with backorders denied red. Nothing new is decided here - those three colours are what the
product page has been rendering.

### One indicator, not two

A listing already carried an out-of-stock signal: the flag over the thumbnail, gated by
`PS_SHOW_LABEL_OOS_LISTING_PAGES`, which is **1 on a default install**. It renders the same words as the
new label, so a tile with every combination out of stock showed "Out-of-Stock" twice - measured before
this was addressed:

```
<li class="badge out_of_stock">Out-of-Stock</li>
<div class="product-miniature__availability-status text-danger">... Out-of-Stock
```

`product-flags.tpl` now takes `hideOutOfStockFlag`, and the miniature sets it exactly when it renders a
label of its own. Consequences, each measured:

- default install, all combinations out of stock: one indicator, the label. The discount badge on the
  same tile is untouched, so the filter is selective rather than a blanket suppression.
- the merchant has emptied "Label of out-of-stock products when backorders are denied": no label is
  rendered, and the flag comes back. The setting still does something.
- the product page cover, which includes the same partial without the flag, is unchanged.

This is the listing half of https://github.com/PrestaShop/PrestaShop/issues/24759, which is
`PM (approved)` and asks for the flag and its BO toggle to be removed outright; that issue was waiting on
this one. The toggle and the product-page flag stay here.

### How to test

Requires stock management enabled (Shop parameters > Product settings).

1. Shop parameters > Product settings, fill "Label of in-stock products", e.g. `In stock`.
2. Open any category page. Each tile now shows a green check and that label under the price.
3. Set a product's quantity to 0 with "Deny orders" - its tile turns red with the out-of-stock label.
4. Switch that product to "Allow orders" and fill "Label of out-of-stock products with allowed
   backorders" - the tile turns orange.
5. Clear "Label of in-stock products" again: in-stock tiles show nothing, exactly as the product page
   does in the same state.

6. Set every combination of a product to 0 with "Deny orders": the tile shows the red label and no
   out-of-stock badge. Empty the out-of-stock label in Shop parameters > Product settings and the badge
   comes back.

### Measured on a running 9.2 shop

Product page markup is **byte-identical** before and after the extraction (diff of the rendered
`product__availability-status` block: no output). Listing, same request:

```
in stock              <div class="product-miniature__availability-status text-success" ...>&#xE5CA;  In stock
out of stock, allowed <div class="product-miniature__availability-status text-warning" ...>&#xE002;  Available for backorder
out of stock, denied  <div class="product-miniature__availability-status text-danger"  ...>&#xE14B;  Out-of-Stock
```

With the label left empty the listing renders nothing, and so does the product page - checked both in
the same state rather than assumed.

**Not verified:** the compiled CSS. `assets/` is generated and gitignored, so the SCSS added for
`product-miniature__availability-status` was not built; the classes and their order are what was
measured, not their rendering.
