### PR TITLE
Show the other-versions hint in product listings

### DIFF
--- a/src/scss/prestashop/components/product/_product-miniature.scss
+++ b/src/scss/prestashop/components/product/_product-miniature.scss
@@ -114,6 +114,12 @@ $product-miniature-container-query-width: 13.5rem;
     text-decoration: line-through;
   }
 
+  &__availability-submessage {
+    margin-bottom: 0;
+    font-size: 0.875rem;
+    color: var(--bs-secondary-color);
+  }
+
   &__form {
     display: flex;
     row-gap: 0.5rem;

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -72,6 +72,12 @@
             {block name='product_reviews'}
               {hook h='displayProductListReviews' product=$product}
             {/block}
+
+            {block name='product_availability_submessage'}
+              {if !empty($product.availability_submessage)}
+                <p class="{$componentName}__availability-submessage">{$product.availability_submessage}</p>
+              {/if}
+            {/block}
           </div>
 
           {block name='product_actions'}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | `availability_submessage` - the hint shown when the chosen version cannot be ordered but another one can - is already computed for listings (`ProductListingLazyArray` extends `ProductLazyArray`, whose constructor fills it), but only the product page rendered it. A shopper browsing a category could not tell that a product whose default version is out of stock is available in another one. The miniature now renders it, in its own `product_availability_submessage` block so a child theme can override it.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Refs https://github.com/PrestaShop/PrestaShop/issues/24929
| Sponsor company   |
| How to test?      | Take a product with combinations, set its default combination out of stock with backorders denied, and leave another combination in stock. In a category listing its miniature shows the hint under the reviews block. A product with nothing to hint renders no empty paragraph.

The wording of the hint changes in core, in PrestaShop/PrestaShop#42944 ("Other product variations available", approved on
the issue). This change renders whatever the core provides and does not depend on it; the classic-theme
half is PrestaShop/classic-theme#242.

Measured on a 9.2 shop, product 1 (8 combinations), default combination out of stock, backorders denied,
another combination with stock, category listing:

```
patched miniature   1 submessage   /  37 miniatures
stock miniature     0 submessages  /  37 miniatures
product page        shows the hint in both  (pre-existing, untouched)
```

For a product with combinations the `id_product_attribute = 0` row of `stock_available` holds the sum over
combinations, and `Product::getProductsProperties()` reads that row into `quantity_all_versions`, which is
the guard on the hint - so the fixture must leave that row positive.
