### PR TITLE
Defer the zoom gallery's large image candidates until the modal opens

### DIFF
--- a/src/js/product-images-modal.test.ts
+++ b/src/js/product-images-modal.test.ts
@@ -1,0 +1,97 @@
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+import initProductImagesModal from '@js/product-images-modal';
+import selectorsMap from '@constants/selectors-map';
+
+const SRCSET = '/320.jpg 320w, /720.jpg 720w, /1440.jpg 1440w';
+const SIZES = '(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw';
+
+function renderModal(): {modal: HTMLElement; img: HTMLImageElement; source: HTMLSourceElement} {
+  document.body.innerHTML = `
+    <div data-ps-ref="product-images-modal">
+      <picture>
+        <source data-srcset="${SRCSET}" data-sizes="${SIZES}" type="image/webp">
+        <img src="/720.jpg" data-srcset="${SRCSET}" data-sizes="${SIZES}" alt="">
+      </picture>
+    </div>`;
+
+  return {
+    modal: document.querySelector<HTMLElement>(selectorsMap.product.productImagesModal) as HTMLElement,
+    img: document.querySelector('img') as HTMLImageElement,
+    source: document.querySelector('source') as HTMLSourceElement,
+  };
+}
+
+describe('product images modal', () => {
+  beforeEach(() => {
+    window.Theme = {selectors: selectorsMap} as Theme.ThemeType;
+  });
+
+  test('leaves the large candidates deferred until the modal is opened', () => {
+    const {img, source} = renderModal();
+
+    initProductImagesModal();
+
+    expect(img.hasAttribute('srcset')).toBe(false);
+    expect(source.hasAttribute('srcset')).toBe(false);
+    expect(img.getAttribute('src')).toBe('/720.jpg');
+  });
+
+  test('promotes srcset and sizes on both the img and the source when the modal opens', () => {
+    const {modal, img, source} = renderModal();
+
+    initProductImagesModal();
+    modal.dispatchEvent(new Event('show.bs.modal'));
+
+    expect(img.getAttribute('srcset')).toBe(SRCSET);
+    expect(img.getAttribute('sizes')).toBe(SIZES);
+    expect(source.getAttribute('srcset')).toBe(SRCSET);
+    expect(source.getAttribute('sizes')).toBe(SIZES);
+    expect(img.dataset.srcset).toBeUndefined();
+    expect(img.dataset.sizes).toBeUndefined();
+  });
+
+  test('sets sizes before srcset so the browser never resolves against the default 100vw', () => {
+    const {modal, img} = renderModal();
+    const order: string[] = [];
+    const setAttribute = img.setAttribute.bind(img);
+
+    jest.spyOn(img, 'setAttribute').mockImplementation((name: string, value: string) => {
+      order.push(name);
+      setAttribute(name, value);
+    });
+
+    initProductImagesModal();
+    modal.dispatchEvent(new Event('show.bs.modal'));
+
+    expect(order).toEqual(['sizes', 'srcset']);
+  });
+
+  test('a candidate without deferred sizes gets srcset only, not a stray sizes attribute', () => {
+    document.body.innerHTML = `
+      <div data-ps-ref="product-images-modal">
+        <img src="/720.jpg" data-srcset="${SRCSET}" alt="">
+      </div>`;
+    const modal = document.querySelector<HTMLElement>(selectorsMap.product.productImagesModal) as HTMLElement;
+    const img = document.querySelector('img') as HTMLImageElement;
+
+    initProductImagesModal();
+    modal.dispatchEvent(new Event('show.bs.modal'));
+
+    expect(img.getAttribute('srcset')).toBe(SRCSET);
+    expect(img.hasAttribute('sizes')).toBe(false);
+  });
+
+  test('is idempotent, so reopening the modal does not overwrite the resolved candidates', () => {
+    const {modal, img} = renderModal();
+
+    initProductImagesModal();
+    modal.dispatchEvent(new Event('show.bs.modal'));
+    img.setAttribute('srcset', '/changed.jpg 1x');
+    modal.dispatchEvent(new Event('show.bs.modal'));
+
+    expect(img.getAttribute('srcset')).toBe('/changed.jpg 1x');
+  });
+});

--- a/src/js/product-images-modal.ts
+++ b/src/js/product-images-modal.ts
@@ -1,0 +1,48 @@
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+/**
+ * Promotes the zoom gallery's deferred image candidates the first time the modal is opened.
+ *
+ * WHY: the modal is rendered on every product page but starts hidden, and a browser fetches an
+ * image inside a `display: none` container whatever its `loading` attribute says - `loading="lazy"`
+ * does not defer it, because the element has no box to intersect the viewport with. The large
+ * candidates therefore ship in `data-srcset` / `data-sizes` and the markup keeps a `src` the page
+ * has already loaded, so a visitor who never zooms pays nothing and one who does still sees an
+ * image immediately while the larger one arrives.
+ */
+const initProductImagesModal = () => {
+  const {Theme: {selectors}} = window;
+  const modal = document.querySelector<HTMLElement>(selectors.product.productImagesModal);
+
+  if (!modal) {
+    return;
+  }
+
+  const promoteDeferredCandidates = () => {
+    modal.querySelectorAll<HTMLElement>('[data-srcset]').forEach((element) => {
+      const {srcset, sizes} = element.dataset;
+
+      // WHY: `sizes` has to be in place before `srcset`, because the browser resolves the candidate
+      // list as soon as `srcset` appears - assigning it first would let it choose against the
+      // default `100vw` and fetch a wider file than the modal will ever display.
+      if (sizes) {
+        element.setAttribute('sizes', sizes);
+        delete element.dataset.sizes;
+      }
+
+      if (srcset) {
+        element.setAttribute('srcset', srcset);
+        delete element.dataset.srcset;
+      }
+    });
+  };
+
+  // WHY: no `once` option - promotion is already idempotent because each attribute is deleted as it
+  // is promoted, so a reopened modal finds nothing left to do. One mechanism, and it is tested.
+  modal.addEventListener('show.bs.modal', promoteDeferredCandidates);
+};
+
+export default initProductImagesModal;

--- a/src/js/theme.ts
+++ b/src/js/theme.ts
@@ -7,6 +7,7 @@ import EVENTS from '@constants/events-map';
 import initEmitter from '@js/prestashop';
 import initResponsiveToggler from '@js/responsive-toggler';
 import initQuickview from '@js/quickview';
+import initProductImagesModal from '@js/product-images-modal';
 import initCart from '@js/pages/cart';
 import initCheckout from '@js/pages/checkout';
 import initCustomer from '@js/pages/customer';
@@ -43,6 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   initProductBehavior();
   initQuickview();
+  initProductImagesModal();
   initCheckout();
   initCustomer();
   initResponsiveToggler();

--- a/templates/catalog/_partials/product-images-modal.tpl
+++ b/templates/catalog/_partials/product-images-modal.tpl
@@ -21,33 +21,33 @@
                 <picture>
                   {if isset($image.bySize.default_md.sources.avif)}
                     <source 
-                      srcset="
+                      data-srcset="
                         {$image.bySize.default_md.sources.avif} 320w,
                         {$image.bySize.product_main.sources.avif} 720w,
                         {$image.bySize.product_main_2x.sources.avif} 1440w"
-                      sizes="(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw" 
+                      data-sizes="(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw" 
                       type="image/avif"
                     >
                   {/if}
 
                   {if isset($image.bySize.default_md.sources.webp)}
                     <source 
-                      srcset="
+                      data-srcset="
                         {$image.bySize.default_md.sources.webp} 320w,
                         {$image.bySize.product_main.sources.webp} 720w,
                         {$image.bySize.product_main_2x.sources.webp} 1440w"
-                      sizes="(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw" 
+                      data-sizes="(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw" 
                       type="image/webp"
                     >
                   {/if}
 
                   <img
                     class="img-fluid"
-                    srcset="
+                    data-srcset="
                       {$image.bySize.default_md.url} 320w,
                       {$image.bySize.product_main.url} 720w,
                       {$image.bySize.product_main_2x.url} 1440w"
-                    sizes="(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw" 
+                    data-sizes="(min-width: 1200px) 1440px, (min-width: 768px) 720px, 100vw" 
                     src="{$image.bySize.product_main.url}" 
                     width="{$image.bySize.product_main_2x.width}"
                     height="{$image.bySize.product_main_2x.height}"


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The zoom gallery modal is rendered on every product page but starts hidden, and a browser fetches an image inside a `display: none` container whatever its `loading` attribute says. So every product page view downloaded the modal's largest candidate - measured at 68,984 bytes of `product_main_2x` on a 1400px viewport - for markup most visitors never open. The large candidates now ship in `data-srcset` / `data-sizes`, the markup keeps the `src` the carousel has already fetched, and a small module promotes them the first time the modal opens.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| Sponsor company   |
| How to test?      | Open a product page at a viewport of 1200px or wider with an empty cache and watch the network panel: no `product_main_2x` request is made, and the hidden modal's `<img>` has `data-srcset` rather than `srcset`. Click the zoom control: the request is made then, the `<img>` gains `srcset` and `sizes`, and it renders at the full 1440px. With JavaScript disabled the modal still shows the `product_main` image, so it degrades rather than breaking. `npx jest src/js/product-images-modal.test.ts` covers the promotion.

## Why `loading="lazy"` is not the fix

The obvious change is to drop the `eager` on the modal's first image. It does not work, and this was
measured rather than assumed: with `loading="lazy"` on every modal image the browser still fetched
`product_main_2x` and reported `complete: true`, `naturalWidth: 1440`. Chrome does not defer a lazy
image that has no layout box, and everything inside a `display: none` modal has none, so there is
nothing for the viewport intersection to be computed against.

That rules out a markup-only fix that keeps the zoom quality. The remaining options were to serve a
smaller image in the modal - which defeats the feature - or to defer the candidate list and restore
it when the modal opens, which is what this does.

## What the markup keeps

`src` stays on `product_main`, the candidate the visible carousel has already downloaded at
>= 992px, so the deferred modal costs nothing at page load and still has something to show the moment
it opens. Only `srcset` and `sizes` move to `data-*`, on the `<img>` and on both `<source>` elements.
A `<source>` without `srcset` is skipped by the picture algorithm, so the fallback is exactly the
`src`. `width` and `height` still come from `product_main_2x`; both types are square, so the aspect
ratio is unchanged and there is no layout shift when the larger file replaces the smaller one.

This is never worse than the current behaviour at any viewport. On a wide screen it replaces a 1440px
download with a cache hit. On a narrow one the modal was already resolving to `product_main`, which is
what `src` now serves. With JavaScript unavailable the modal keeps working at 720px.

## Ordering, and why the module sets `sizes` first

`sizes` is assigned before `srcset` on each element. The browser resolves the candidate list as soon
as `srcset` appears, so assigning it first would let it choose against the default `100vw` and fetch
a wider file than the modal will ever display. There is a test that pins the order specifically.

There is no `{once: true}` on the listener. Promotion deletes each `data-` attribute as it consumes
it, so a reopened modal finds nothing left to do; `once` was removed after a mutation showed that
dropping it changed no test outcome - it was redundant with the delete, and untested redundancy is
worse than no redundancy.

## Verification

Measured on a 9.2 shop running hummingbird 2.1.0, viewport 1400x900, at `upstream/2.x`
(`7c7e1450`) plus this change. The deployed template was confirmed byte-identical to `upstream/2.x`
before the baseline was taken.

- Baseline, product page, hidden modal: the modal `<img>` reported `insideModal: true`,
  `modalDisplay: "none"`, `loading: "eager"`, `complete: true`, `naturalWidth: 1440`, and
  `product_main_2x` accounted for 68,984 decoded bytes.
- Control on the same page with `loading="lazy"` on every modal image: still fetched, still
  `naturalWidth: 1440`. Confirmed the attribute reached the DOM before concluding anything.
- With this change, page load: `srcset` absent, `data-srcset` present, rendered `naturalWidth: 720`,
  `product_main_2x` bytes **0**.
- Same page after `show.bs.modal`: `srcset` and `sizes` present and correct, both `data-` attributes
  cleared, `currentSrc` upgraded to `product_main_2x`, `naturalWidth: 1440`.
- `npx jest`: 8 suites, 44 tests, all passing. Five of them are new.
- Mutation, one per mechanism, each failing only its own test: swapping the `sizes`/`srcset` order
  fails the ordering test; promoting immediately instead of on the event fails the deferral test;
  making the `sizes` assignment unconditional fails the missing-`data-sizes` test; removing the
  dataset deletes fails the promotion and idempotence tests.
- `npx tsc --noEmit --skipLibCheck` exit 0, `npx eslint ./src/js` exit 0.
