### PR TITLE
Type the window.prestashop global

### DIFF
--- a/src/js/components/useProgressRing.test.ts
+++ b/src/js/components/useProgressRing.test.ts
@@ -14,7 +14,7 @@ describe('useProgressRing', () => {
   describe('with valid template', () => {
     beforeAll(() => {
       resetHTMLBodyContent(ProgressRingMockData.Template);
-      window.prestashop = {};
+      window.prestashop = {} as PrestaShop.Global;
       initEmitter();
     });
 
@@ -61,7 +61,7 @@ describe('useProgressRing', () => {
 
   describe('without valid template', () => {
     beforeAll(() => {
-      window.prestashop = {};
+      window.prestashop = {} as PrestaShop.Global;
       initEmitter();
     });
 

--- a/src/js/components/useQuantityInput.test.ts
+++ b/src/js/components/useQuantityInput.test.ts
@@ -14,7 +14,7 @@ describe('useQuantityInput', () => {
   describe('with update URL', () => {
     beforeAll(() => {
       resetHTMLBodyContent(Quantify.ProductLineTemplate);
-      window.prestashop = {};
+      window.prestashop = {} as PrestaShop.Global;
       window.Theme = {
         ...window.Theme,
         events: EVENTS,
@@ -155,7 +155,7 @@ describe('useQuantityInput', () => {
   describe('without update URL', () => {
     beforeAll(() => {
       resetHTMLBodyContent(Quantify.ProductTemplate);
-      window.prestashop = {};
+      window.prestashop = {} as PrestaShop.Global;
       initEmitter();
       useQuantityInput(selectorsMap.qtyInput.modal, Quantify.delay);
     });

--- a/src/js/modules/blockcart.ts
+++ b/src/js/modules/blockcart.ts
@@ -124,8 +124,10 @@ export default function initBlockCart() {
   });
 
   // Legacy support for function call
-  prestashop.blockcart = prestashop.blockcart || {};
-  prestashop.blockcart.showModal = function showAddToCartModal(addToCartModal: string) {
-    openModalFromHtml(addToCartModal);
+  prestashop.blockcart = {
+    ...prestashop.blockcart,
+    showModal: function showAddToCartModal(addToCartModal: string) {
+      openModalFromHtml(addToCartModal);
+    },
   };
 }

--- a/src/js/quickview.ts
+++ b/src/js/quickview.ts
@@ -14,7 +14,7 @@ export default function initQuickview() {
   let lastQuickviewOpener: HTMLElement | null = null;
 
   async function fetchQuickview(data: Record<string, unknown>): Promise<QuickviewResponse> {
-    const url = prestashop.urls.pages.product as string;
+    const url = prestashop.urls.pages.product;
     const params = new URLSearchParams();
 
     Object.entries(data).forEach(([key, value]) => {

--- a/src/js/responsive-toggler.test.ts
+++ b/src/js/responsive-toggler.test.ts
@@ -18,7 +18,7 @@ beforeAll(() => {
 
   window.prestashop = {
     responsive: {},
-  };
+  } as PrestaShop.Global;
 
   window.Theme = {
     ...window.Theme,

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -21,7 +21,7 @@ declare namespace Theme {
 }
 
 interface Window extends Theme.Window {
-  prestashop: any;
+  prestashop: PrestaShop.Global;
   $: JQueryStatic;
   jQuery: JQueryStatic;
 }

--- a/types/prestashop.d.ts
+++ b/types/prestashop.d.ts
@@ -1,0 +1,71 @@
+/**
+ * For the full copyright and license information, please view the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare namespace PrestaShop {
+  /**
+   * The emitter API. `src/js/prestashop.ts` copies `EventEmitter.prototype` onto the global,
+   * so these are available from the moment `initEmitter()` has run.
+   *
+   * The payload is whatever the emitting side passes, so each listener names the shape it
+   * expects and the type parameter is inferred from it. Core emits a second argument on at
+   * least one event - `prestashop.emit('updatedProduct', data, form)` - hence the rest.
+   */
+  interface Emitter {
+    on<T = unknown>(event: string, listener: (payload: T, ...rest: unknown[]) => void): PrestaShop.Global;
+    once<T = unknown>(event: string, listener: (payload: T, ...rest: unknown[]) => void): PrestaShop.Global;
+    off<T = unknown>(event: string, listener: (payload: T, ...rest: unknown[]) => void): PrestaShop.Global;
+    emit(event: string, ...payload: unknown[]): boolean;
+  }
+
+  /**
+   * Viewport state. Owned by the theme, written by `src/js/responsive-toggler.ts`.
+   */
+  type Responsive = {
+    current_width: number;
+    min_width: number;
+    mobile: boolean;
+  };
+
+  /**
+   * A subset of `FrontController::getTemplateVarUrls()`. `pages` maps a page name to its URL.
+   */
+  type Urls = {
+    base_url: string;
+    current_url: string;
+    pages: Record<string, string>;
+  };
+
+  /**
+   * What `prestashop.checkPasswordScore()` resolves to, narrowed to the fields the theme reads.
+   * The core implementation returns a zxcvbn result.
+   */
+  type PasswordScore = {
+    score: number;
+    feedback: {
+      warning: string;
+      suggestions: string[];
+    };
+  };
+
+  /**
+   * Added by `src/js/modules/blockcart.ts`, so it is only present once that module has loaded.
+   */
+  type BlockCart = {
+    showModal: (addToCartModal: string) => void;
+  };
+
+  /**
+   * The `window.prestashop` object, as far as this theme relies on it.
+   *
+   * It is deliberately not an open map: core publishes more than this, and a contributor who
+   * needs another member declares it here with its type rather than reaching through `any`.
+   */
+  interface Global extends Emitter {
+    responsive: Responsive;
+    urls: Urls;
+    checkPasswordScore(password: string): Promise<PasswordScore>;
+    blockcart?: BlockCart;
+  }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | `window.prestashop` was declared `any`, so every access through it was unchecked: a member that does not exist compiled, and `urls.pages.product` had to be cast to `string` at the call site to be usable. `types/prestashop.d.ts` now declares the surface the theme relies on - the emitter, `responsive`, `urls`, `checkPasswordScore` and the optional `blockcart` - and `types/global.d.ts` points `window.prestashop` at it. This was the last `any` in the theme's TypeScript: `src/js` has none left outside test fixtures.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/hummingbird#618
| Sponsor company   |
| How to test?      | `npx tsc --noEmit --skipLibCheck -p tsconfig.json` is clean on the branch. Add `prestashop.thisMemberDoesNotExist` anywhere under `src/js` and it now fails with `TS2339`; on `develop` the same line compiles. `npm test` (39 tests) and `npm run lint` both pass.

## What the type says, and what it deliberately does not

The declaration covers what the theme actually consumes, each member sourced rather than guessed:

- **Emitter** - `src/js/prestashop.ts` copies `EventEmitter.prototype` onto the global, so `on`,
  `once`, `off` and `emit` are declared. The payload is a type parameter inferred from the listener,
  because the emitting sides genuinely differ: `{event: Event}`, `{context: 'main' | 'quickview'}`,
  `HTMLElement`, `Record<string, unknown>`, a bare `string`. A fixed payload type rejected nine call
  sites; a generic accepts all of them without widening anything to `any`. `emit` takes a rest
  parameter and the listener a trailing rest, because core does emit a second argument on at least
  one event - `themes/_core/js/product.js` calls
  `prestashop.emit('updatedProduct', data, $form.serializeArray())`.
- **`responsive`** - theme-owned, written by `src/js/responsive-toggler.ts`.
- **`urls`** - `base_url`, `current_url` and `pages`, a page-name-to-URL map. Names come from
  `FrontController::getTemplateVarUrls()`, and the three were then read off `window.prestashop.urls`
  on a running 9.2 shop rather than trusted from the source: both are strings and every value in
  `pages` is a string.
- **`checkPasswordScore`** - core's `themes/_core/js/common.js` returns a zxcvbn result; the type
  carries `score` and `feedback`, which are the fields `usePasswordPolicy.ts` reads. The theme has no
  zxcvbn dependency, so importing the upstream type would mean adding one.
- **`blockcart`** - optional, added by `src/js/modules/blockcart.ts`.

It is deliberately **not** an open map. Core publishes more than this, and leaving an index signature
would put the `any` back under another name. A contributor who needs `cart` or `customer` declares it
here with its type - which is the coordination this issue asked for.

## Two call sites had to change, both because the type is honest

`src/js/modules/blockcart.ts` built its entry in two steps, `prestashop.blockcart = prestashop.blockcart || {}`
followed by assigning `showModal`. With `blockcart` correctly optional, the intermediate `{}` is not a
`BlockCart`. It is now one assignment that spreads whatever was already there, so an entry another
module had added survives exactly as before.

`src/js/quickview.ts` no longer casts `prestashop.urls.pages.product as string`. That cast existed
only because the global was `any`; the type now says `string`.

`responsive-toggler.ts` needed nothing - `responsive` is non-optional, so TypeScript narrows
`prestashop.responsive || {}` on its own.

The three test files build partial globals on purpose and now say so with a single assertion each.

## Verification

- Re-verified after the retarget, on `2.x`: `tsc --noEmit --skipLibCheck` exit 0, `npx jest` 7 suites
  and 39 tests passing, `npx eslint` exit 0. The same `tsc` run on the base is also 0, so this is not
  clearing a pre-existing backlog.
- Mutation, both directions, re-run on `2.x`: with `prestashop.thisMemberDoesNotExist` and
  `prestashop.urls.pages.product.toFixed(2)` added to `src/js/quickview.ts`, the branch fails with
  `TS2339` ("Property 'thisMemberDoesNotExist' does not exist on type 'Global'") and `TS2551`;
  reverting `types/global.d.ts` to `prestashop: any` and leaving that same code in place compiles
  clean, exit 0. The probe has to sit inside `initQuickview()`, after
  `const {prestashop, Theme: {events}} = window;` - at module scope both sides fail with `TS2304`
  instead and the control proves nothing.
- `npx jest`: 7 suites, 39 tests, all pass.
- `npx eslint -c .eslintrc.js --ext .js,.ts ./src/js`: exit 0, no output.
- Arity control: a two-argument `emit` with a two-parameter listener compiles, so the rest parameters
  are not decorative.

`CONTEXT.md` in this repository states the rule this implements: "NEVER use the `any` type. Ensure
strict typing for all variables, function returns, DOM elements, and parsed JSON payloads."
